### PR TITLE
feat: add leave app for monday meeting sign-ups

### DIFF
--- a/apps/portal/app/leave/_components/confirm-dialog.tsx
+++ b/apps/portal/app/leave/_components/confirm-dialog.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import type { ReactNode } from "react"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@workspace/ui/components/alert-dialog"
+
+interface ConfirmDialogProps {
+  trigger: ReactNode
+  title: string
+  description: string
+  confirmText?: string
+  cancelText?: string
+  variant?: "default" | "destructive"
+  onConfirm: () => void
+}
+
+export function ConfirmDialog({
+  trigger,
+  title,
+  description,
+  confirmText = "確認",
+  cancelText = "取消",
+  variant = "default",
+  onConfirm,
+}: ConfirmDialogProps) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{cancelText}</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            className={
+              variant === "destructive"
+                ? "text-destructive-foreground bg-destructive hover:bg-destructive/90"
+                : ""
+            }
+          >
+            {confirmText}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/apps/portal/app/leave/_components/create-leave-dialog.tsx
+++ b/apps/portal/app/leave/_components/create-leave-dialog.tsx
@@ -1,0 +1,123 @@
+"use client"
+
+import { useState } from "react"
+import { toast } from "sonner"
+
+import { Button } from "@workspace/ui/components/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@workspace/ui/components/dialog"
+import { Label } from "@workspace/ui/components/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@workspace/ui/components/select"
+import { Textarea } from "@workspace/ui/components/textarea"
+
+import { useCreateLeave } from "@/hooks/leave/use-leaves"
+import { useAuth } from "@/hooks/use-auth"
+import { formatLeaveDate, getNextMondays, toIsoDate } from "@/lib/leave/date"
+
+const MONDAY_OPTIONS = 8
+
+export function CreateLeaveDialog() {
+  const [open, setOpen] = useState(false)
+  const mondays = getNextMondays(MONDAY_OPTIONS)
+  const [date, setDate] = useState(toIsoDate(mondays[0]!))
+  const [reason, setReason] = useState("")
+  const { user } = useAuth()
+  const createLeave = useCreateLeave()
+
+  if (!user) return null
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!date || !reason.trim()) return
+
+    try {
+      await createLeave.mutateAsync({
+        user_id: user.id,
+        date,
+        reason: reason.trim(),
+      })
+      toast.success("已送出請假")
+      setOpen(false)
+      setDate(toIsoDate(getNextMondays(1)[0]!))
+      setReason("")
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error("送出失敗")
+      toast.error(err.message)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm">新增請假</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>新增請假</DialogTitle>
+          <DialogDescription>選一個週一，寫下原因</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="date">日期</Label>
+              <Select value={date} onValueChange={setDate}>
+                <SelectTrigger id="date" className="w-full">
+                  <SelectValue placeholder="選擇週一" />
+                </SelectTrigger>
+                <SelectContent>
+                  {mondays.map((m) => {
+                    const iso = toIsoDate(m)
+                    return (
+                      <SelectItem key={iso} value={iso}>
+                        {formatLeaveDate(iso)}
+                      </SelectItem>
+                    )
+                  })}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="reason">原因</Label>
+              <Textarea
+                id="reason"
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                placeholder="例：家中有事、看醫生、其他會議衝堂"
+                rows={3}
+                required
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+            >
+              取消
+            </Button>
+            <Button
+              type="submit"
+              disabled={createLeave.isPending || !date || !reason.trim()}
+            >
+              {createLeave.isPending ? "送出中..." : "送出"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/portal/app/leave/_components/leave-card.tsx
+++ b/apps/portal/app/leave/_components/leave-card.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { Trash2 } from "lucide-react"
+import { toast } from "sonner"
+
+import { Badge } from "@workspace/ui/components/badge"
+import { Button } from "@workspace/ui/components/button"
+
+import { useDeleteLeave } from "@/hooks/leave/use-leaves"
+import { useAuth } from "@/hooks/use-auth"
+import { formatLeaveDate } from "@/lib/leave/date"
+import type { LeaveWithUser } from "@/lib/leave/types"
+
+import { ConfirmDialog } from "./confirm-dialog"
+
+export function LeaveCard({ leave }: { leave: LeaveWithUser }) {
+  const { user } = useAuth()
+  const deleteLeave = useDeleteLeave()
+  const isMine = user?.id === leave.user_id
+  const displayName = leave.user?.name ?? "未知成員"
+
+  const handleDelete = async () => {
+    try {
+      await deleteLeave.mutateAsync(leave.id)
+      toast.success("已撤回請假")
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error("撤回失敗")
+      toast.error(err.message)
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-3 rounded-xl border border-border bg-card p-4">
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <span className="truncate text-sm font-medium">{displayName}</span>
+        <p className="truncate text-sm text-muted-foreground">{leave.reason}</p>
+      </div>
+      <Badge variant="outline" className="shrink-0 text-xs">
+        {formatLeaveDate(leave.date)}
+      </Badge>
+      {isMine && (
+        <ConfirmDialog
+          trigger={
+            <Button
+              size="icon"
+              variant="ghost"
+              className="size-8 shrink-0 text-muted-foreground"
+              aria-label="撤回請假"
+            >
+              <Trash2 className="size-4" />
+            </Button>
+          }
+          title="撤回這筆請假？"
+          description={`${formatLeaveDate(leave.date)} — ${leave.reason}`}
+          confirmText="撤回"
+          variant="destructive"
+          onConfirm={handleDelete}
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/portal/app/leave/_components/leave-list.tsx
+++ b/apps/portal/app/leave/_components/leave-list.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import { Skeleton } from "@workspace/ui/components/skeleton"
+
+import { useLeaves } from "@/hooks/leave/use-leaves"
+
+import { CreateLeaveDialog } from "./create-leave-dialog"
+import { LeaveCard } from "./leave-card"
+
+export function LeaveList() {
+  const { data: leaves, isLoading } = useLeaves()
+
+  const today = new Date().toISOString().split("T")[0]!
+  const upcoming = (leaves ?? []).filter((l) => l.date >= today)
+  const past = (leaves ?? []).filter((l) => l.date < today)
+
+  if (isLoading && !leaves) {
+    return (
+      <div className="flex flex-col gap-10">
+        <Skeleton className="h-6 w-32 rounded-md" />
+        <div className="flex flex-col gap-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-[72px] w-full rounded-xl" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-10">
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-1">
+          <h1 className="font-medium">Leave</h1>
+          <p className="text-sm text-muted-foreground">
+            週一組會請假登記。大家都看得到。
+          </p>
+        </div>
+        <CreateLeaveDialog />
+      </div>
+
+      {upcoming.length > 0 && (
+        <section className="flex flex-col gap-4">
+          <h2 className="text-sm font-medium">即將</h2>
+          <div className="flex flex-col gap-3">
+            {upcoming.map((leave) => (
+              <LeaveCard key={leave.id} leave={leave} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {past.length > 0 && (
+        <section className="flex flex-col gap-4">
+          <h2 className="text-sm font-medium">歷史</h2>
+          <div className="flex flex-col gap-3">
+            {past.map((leave) => (
+              <LeaveCard key={leave.id} leave={leave} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {(leaves ?? []).length === 0 && (
+        <div className="py-12 text-center text-sm text-muted-foreground">
+          還沒有請假紀錄
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/portal/app/leave/_components/query-provider.tsx
+++ b/apps/portal/app/leave/_components/query-provider.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { useState, type ReactNode } from "react"
+
+export function QueryProvider({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 1000 * 60,
+            refetchOnWindowFocus: false,
+          },
+        },
+      })
+  )
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}

--- a/apps/portal/app/leave/layout.tsx
+++ b/apps/portal/app/leave/layout.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+
+import { Toaster } from "@workspace/ui/components/sonner"
+
+import { PortalShell } from "@/components/portal-shell"
+
+import { QueryProvider } from "./_components/query-provider"
+
+export const metadata: Metadata = {
+  title: "Leave | Portal",
+  description: "NYCU WinLab leave tracker.",
+}
+
+export default function LeaveLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <QueryProvider>
+      <PortalShell
+        appName="Leave"
+        appHref="/leave"
+        bottomLeft={
+          <Link href="/" className="transition-colors hover:text-foreground">
+            Portal
+          </Link>
+        }
+      >
+        {children}
+      </PortalShell>
+      <Toaster />
+    </QueryProvider>
+  )
+}

--- a/apps/portal/app/leave/page.tsx
+++ b/apps/portal/app/leave/page.tsx
@@ -1,0 +1,5 @@
+import { LeaveList } from "./_components/leave-list"
+
+export default function LeaveHome() {
+  return <LeaveList />
+}

--- a/apps/portal/app/page.tsx
+++ b/apps/portal/app/page.tsx
@@ -9,6 +9,7 @@ import { getCurrentUser } from "@/lib/user"
 
 const apps = [
   { href: "/bento", label: "Bento", note: "便當訂購" },
+  { href: "/leave", label: "Leave", note: "請假登記" },
   { href: "/profile", label: "Profile", note: "Your account" },
 ]
 

--- a/apps/portal/hooks/leave/query-keys.ts
+++ b/apps/portal/hooks/leave/query-keys.ts
@@ -1,0 +1,6 @@
+export const queryKeys = {
+  leaves: {
+    all: ["leave", "leaves"] as const,
+    list: () => [...queryKeys.leaves.all, "list"] as const,
+  },
+}

--- a/apps/portal/hooks/leave/use-leaves.ts
+++ b/apps/portal/hooks/leave/use-leaves.ts
@@ -1,0 +1,100 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import type { Leave, LeaveWithUser } from "@/lib/leave/types"
+import { createClient } from "@/lib/supabase/client"
+
+import { queryKeys } from "./query-keys"
+
+export function useLeaves() {
+  const supabase = createClient()
+
+  return useQuery({
+    queryKey: queryKeys.leaves.list(),
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("leaves")
+        .select("*")
+        .order("date", { ascending: false })
+        .order("created_at", { ascending: false })
+
+      if (error) throw error
+
+      const leaves = (data ?? []) as Leave[]
+      if (leaves.length === 0) return [] as LeaveWithUser[]
+
+      const userIds = [...new Set(leaves.map((l) => l.user_id))]
+      const { data: profiles } = await supabase
+        .from("user_profiles")
+        .select("id, name")
+        .in("id", userIds)
+
+      const profileMap = new Map(
+        (profiles ?? []).map((p: { id: string; name: string | null }) => [
+          p.id,
+          p,
+        ])
+      )
+
+      return leaves.map((leave) => ({
+        ...leave,
+        user: profileMap.has(leave.user_id)
+          ? { name: profileMap.get(leave.user_id)!.name ?? null }
+          : null,
+      })) as LeaveWithUser[]
+    },
+  })
+}
+
+export function useCreateLeave() {
+  const supabase = createClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (params: {
+      user_id: string
+      date: string
+      reason: string
+    }) => {
+      const { data, error } = await supabase
+        .from("leaves")
+        .insert({
+          user_id: params.user_id,
+          date: params.date,
+          reason: params.reason,
+        })
+        .select()
+        .single()
+
+      if (error) {
+        if (error.code === "23505") {
+          throw new Error("這一天已經請過假了")
+        }
+        if (error.code === "23514") {
+          throw new Error("請假日期只能選週一")
+        }
+        throw error
+      }
+      return data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.leaves.all })
+    },
+  })
+}
+
+export function useDeleteLeave() {
+  const supabase = createClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (leaveId: string) => {
+      const { error } = await supabase.from("leaves").delete().eq("id", leaveId)
+      if (error) throw error
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.leaves.all })
+    },
+  })
+}

--- a/apps/portal/lib/leave/date.ts
+++ b/apps/portal/lib/leave/date.ts
@@ -1,0 +1,28 @@
+import { format } from "date-fns"
+
+export function parseLocalDate(isoDate: string): Date {
+  const [y, m, d] = isoDate.split("-").map(Number)
+  return new Date(y!, m! - 1, d!)
+}
+
+export function formatLeaveDate(isoDate: string): string {
+  return format(parseLocalDate(isoDate), "yyyy/MM/dd")
+}
+
+export function toIsoDate(date: Date): string {
+  return format(date, "yyyy-MM-dd")
+}
+
+export function getNextMondays(count: number, from: Date = new Date()): Date[] {
+  const base = new Date(from.getFullYear(), from.getMonth(), from.getDate())
+  const dow = base.getDay()
+  const offset = dow === 0 ? 1 : dow === 1 ? 0 : 8 - dow
+  const firstMonday = new Date(base)
+  firstMonday.setDate(base.getDate() + offset)
+
+  return Array.from({ length: count }, (_, i) => {
+    const d = new Date(firstMonday)
+    d.setDate(firstMonday.getDate() + i * 7)
+    return d
+  })
+}

--- a/apps/portal/lib/leave/types.ts
+++ b/apps/portal/lib/leave/types.ts
@@ -1,0 +1,14 @@
+export interface Leave {
+  id: string
+  user_id: string
+  date: string
+  reason: string
+  created_at: string
+  updated_at: string
+}
+
+export interface LeaveWithUser extends Leave {
+  user: {
+    name: string | null
+  } | null
+}

--- a/packages/ui/src/components/textarea.tsx
+++ b/packages/ui/src/components/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@workspace/ui/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "field-sizing-content min-h-16 w-full min-w-0 rounded-2xl border border-transparent bg-input/50 px-3 py-2 text-base transition-[color,box-shadow,background-color] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }


### PR DESCRIPTION
## Summary

新增 `/leave` app — 給 WinLab 週一 meeting 請假登記用，公開表格，全 lab 看得到誰週一不在。

## Why

Portal 第二個業務 app，照 bento reference implementation 複製結構。既有 Supabase `public.leaves` table（12 筆歷史資料）已經在服役，這個 PR 只是把 UI 搬進 portal 讓登記流程和其他業務統一入口。

## What changed

**新增 Leave app（11 檔）**

- `app/leave/layout.tsx` — QueryProvider + PortalShell (appHref=`/leave`, BL→Portal) + Toaster
- `app/leave/page.tsx` — 渲染 `<LeaveList />`
- `app/leave/_components/` — leave-list / leave-card / create-leave-dialog / confirm-dialog / query-provider
- `hooks/leave/` — `useLeaves()` 讀全 lab、`useCreateLeave()` / `useDeleteLeave()`，錯誤碼 23505 / 23514 轉成可讀訊息
- `lib/leave/` — types（對齊實際 schema 含 `updated_at`）+ date helpers（`getNextMondays`, `toIsoDate`, `formatLeaveDate`）

**業務邏輯對齊 DB**

- DB `CHECK (EXTRACT(dow FROM date) = 1)` → UI 表單用 `<Select>` 列未來 8 個週一，根本擋掉非週一
- DB `UNIQUE (user_id, date)` → 23505 duplicate 轉成「這一天已經請過假了」
- DB RLS SELECT `true` → UI 是公開列表，每筆顯示請假人名（join `user_profiles.name`），撤回 icon 僅限自己那筆

**共用元件**

- `packages/ui/src/components/textarea.tsx` — 對齊 Input 的樣式 token（`rounded-2xl / bg-input/50`）

**Portal 首頁**

- `app/page.tsx` apps 陣列加 `{ href: "/leave", label: "Leave", note: "請假登記" }`

## Test plan

- [x] `bun run typecheck` — pass
- [x] `bun run lint` — 0 errors（2 warnings 是 bento 既存）
- [x] `bun run build` — 交給 CI
- [x] Dev server 手動點過：新增（選週一 / 寫原因 / 送出）+ 撤回（只能撤自己的）+ 重複日期錯誤訊息
- [x] DB / env 同步 — 既有 table，無 migration 需求

## Screenshots

TBD（reviewer 本地跑過再補）

## Breaking changes

無。新 route、新元件、新 hooks，對既有業務零影響。