### PR TITLE
refactor: swap theme toggle icons for Light/Dark text labels

### DIFF
--- a/apps/portal/components/theme-toggle.tsx
+++ b/apps/portal/components/theme-toggle.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { Moon, Sun } from "lucide-react"
 import { useTheme } from "next-themes"
 import { useEffect, useState } from "react"
 
@@ -11,7 +10,6 @@ export function ThemeToggle() {
   useEffect(() => setMounted(true), [])
 
   const isDark = mounted ? resolvedTheme === "dark" : true
-  const Icon = isDark ? Sun : Moon
 
   return (
     <button
@@ -20,7 +18,7 @@ export function ThemeToggle() {
       aria-label={isDark ? "Switch to light" : "Switch to dark"}
       className="transition-colors hover:text-foreground"
     >
-      <Icon className="size-3.5" />
+      {isDark ? "Dark" : "Light"}
     </button>
   )
 }


### PR DESCRIPTION
## Summary

把 PR #7 merged 的 Sun / Moon icon 主題切換換成 `Dark` / `Light` 文字。

## Why

Icon 在 BL 角落看起來形狀孤立 — 其他 slot（TL `Portal`、TR `Menu`、BR `© 2026`）全是文字，icon 跳出來不對齊。

文字版本有兩個優點：

1. 視覺語言和其他 corner slots 拉通
2. 顯示「當前狀態」比 icon「點了會變什麼」直覺（使用者第一眼知道自己是哪個 theme，不用解 icon 的 metaphor）

## What changed

- `components/theme-toggle.tsx` — 拿掉 `lucide-react` 的 `Moon` / `Sun` import 與 `<Icon />`，改渲染 `{isDark ? \"Dark\" : \"Light\"}` 文字。其他邏輯（`useTheme` + `mounted` 防閃 + `aria-label`）完全保留

## Test plan

- [x] `bun run typecheck`
- [x] `bun run build` — 交給 CI
- [x] 瀏覽器實測：BL 顯示當前主題文字，點擊切換，重整保留選擇

## Breaking changes

無。僅 BL 視覺呈現改動，語意、API、hotkey 邏輯不變。