### PR TITLE
fix(ui): dialog scrolls; feat(mcp): bento update/delete restaurant

### DIFF
--- a/apps/mcp/lib/mcp/tools/bento.ts
+++ b/apps/mcp/lib/mcp/tools/bento.ts
@@ -274,4 +274,60 @@ export function registerBentoTools(
       return ok({ removed: menu_item_id })
     }
   )
+
+  server.tool(
+    "bento_update_restaurant",
+    "Patch a restaurant (bento_menus) row. Use for fixing a typo in name / phone / google_map_link, or changing the additional options list. Pass only the fields you want to change.",
+    {
+      restaurant_id: z.string().uuid(),
+      name: z.string().min(1).optional(),
+      phone: z.string().min(1).optional().describe("Digits only, no dashes."),
+      google_map_link: z
+        .string()
+        .url()
+        .nullable()
+        .optional()
+        .describe("Pass null to clear."),
+      additional: z
+        .array(z.string())
+        .nullable()
+        .optional()
+        .describe(
+          "Order-time options for every item. Pass null or [] to clear."
+        ),
+    },
+    async ({ restaurant_id, name, phone, google_map_link, additional }) => {
+      const patch: Record<string, unknown> = {}
+      if (name !== undefined) patch.name = name
+      if (phone !== undefined) patch.phone = phone
+      if (google_map_link !== undefined) patch.google_map_link = google_map_link
+      if (additional !== undefined)
+        patch.additional =
+          additional && additional.length > 0 ? additional : null
+      if (Object.keys(patch).length === 0) return err("No fields to update")
+
+      const { data, error } = await supabase
+        .from("bento_menus")
+        .update(patch)
+        .eq("id", restaurant_id)
+        .select()
+        .single()
+      if (error) return err(error.message)
+      return ok(data)
+    }
+  )
+
+  server.tool(
+    "bento_delete_restaurant",
+    "Delete a restaurant (bento_menus row). WARNING: this cascades to menu items and historical orders depending on FK rules — verify with bento_get_order / bento_list_restaurants first. Intended for cleaning up mis-created restaurants, not for retiring ones with real order history.",
+    { restaurant_id: z.string().uuid() },
+    async ({ restaurant_id }) => {
+      const { error } = await supabase
+        .from("bento_menus")
+        .delete()
+        .eq("id", restaurant_id)
+      if (error) return err(error.message)
+      return ok({ removed: restaurant_id })
+    }
+  )
 }

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -61,7 +61,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 rounded-4xl bg-popover p-6 text-sm text-popover-foreground shadow-xl ring-1 ring-foreground/5 duration-100 outline-none sm:max-w-md dark:ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-50 grid max-h-[calc(100vh-4rem)] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 overflow-y-auto rounded-4xl bg-popover p-6 text-sm text-popover-foreground shadow-xl ring-1 ring-foreground/5 duration-100 outline-none sm:max-w-md dark:ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}


### PR DESCRIPTION
Two fixes shipped from using the previous MCP bento menu management PR in anger:

## 1. `fix(ui)`: shared Dialog scrolls when content overflows

Surfaced at \`/bento/menus\` — editing a restaurant with a long menu (~40 items) grew the dialog past the viewport, and the Save button sat below the fold with no way to reach it.

Shared \`DialogContent\` had no max-height and no overflow rule. Cap at \`calc(100vh-4rem)\` + \`overflow-y-auto\`. Short dialogs behave identically; tall dialogs get a scrollbar instead of truncating.

One shared-component edit — covers every dialog across the app (bento create + edit, approve dialogs, future features).

## 2. \`feat(mcp)\`: bento_update_restaurant + bento_delete_restaurant

Menu management MCP (PR #13) shipped without a recovery path for restaurant-level typos. First real use hit it: phone parsed as \`0357521230\` instead of \`035752123\` and there was no MCP tool to fix it.

- \`bento_update_restaurant\` — PATCH: send only fields you want to change, \`null\` clears nullables
- \`bento_delete_restaurant\` — explicit warning in the description that it cascades to items / history; for cleanup, not retirement

Intended agent flow after merge: I ping, I find the bad phone, I call \`bento_update_restaurant({ restaurant_id, phone: '035752123' })\`, done.

## Test plan

- [x] \`bun run typecheck --filter=mcp\`
- [x] \`bun run typecheck --filter=portal\`
- [x] \`bun run build --filter=portal\`
- [x] \`bun run lint --filter=mcp\`
- [ ] Post-merge: open 榮師傅麵食館 edit dialog in portal — Save button reachable
- [ ] Post-merge + Vercel deploy: Claude Code reconnects, new tools appear, fix phone typo

🤖 Generated with [Claude Code](https://claude.com/claude-code)