### PR TITLE
fix(portal): clear ghost cookies from old portal, retry instead of dead-end

### DIFF
--- a/apps/portal/app/auth/callback/route.ts
+++ b/apps/portal/app/auth/callback/route.ts
@@ -1,5 +1,7 @@
+import { cookies } from "next/headers"
 import { NextResponse } from "next/server"
 
+import { clearStaleSupabaseCookies } from "@/lib/auth/clear-stale-cookies"
 import { createClient } from "@/lib/supabase/server"
 
 export async function GET(request: Request) {
@@ -26,5 +28,15 @@ export async function GET(request: Request) {
     }
   }
 
-  return NextResponse.redirect(`${origin}/auth/auth-code-error`)
+  // Exchange failed (or no code). Most common cause: stale cross-subdomain
+  // Supabase cookies left behind by the previous portal at .winlab.tw. Clear
+  // them and send the user back to /auth/login so one extra click gets them
+  // through instead of a dead-end error page. First-failure users never see
+  // /auth/auth-code-error again.
+  const cookieStore = await cookies()
+  await clearStaleSupabaseCookies(cookieStore)
+
+  const retry = new URL("/auth/login", origin)
+  retry.searchParams.set("stale", "1")
+  return NextResponse.redirect(retry.toString())
 }

--- a/apps/portal/app/auth/login/page.tsx
+++ b/apps/portal/app/auth/login/page.tsx
@@ -4,9 +4,15 @@ import { PortalShell } from "@/components/portal-shell"
 import { SignInButton } from "@/components/sign-in-button"
 import { getCurrentUser } from "@/lib/user"
 
-export default async function LoginPage() {
+type LoginPageProps = {
+  searchParams: Promise<{ stale?: string }>
+}
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
   const user = await getCurrentUser()
   if (user) redirect("/")
+
+  const { stale } = await searchParams
 
   return (
     <PortalShell appName="Sign in">
@@ -16,6 +22,12 @@ export default async function LoginPage() {
           <p className="text-sm text-muted-foreground">
             Continue with your WinLab SSO account.
           </p>
+          {stale === "1" ? (
+            <p className="mt-2 text-xs text-muted-foreground">
+              Cleared a leftover session from the previous portal. Try signing
+              in again.
+            </p>
+          ) : null}
         </div>
         <SignInButton />
       </div>

--- a/apps/portal/lib/auth/clear-stale-cookies.ts
+++ b/apps/portal/lib/auth/clear-stale-cookies.ts
@@ -1,0 +1,45 @@
+import type { cookies } from "next/headers"
+
+// The previous portal (old.portal.winlab.tw) set Supabase auth cookies with
+// `domain: ".winlab.tw"` so they leaked across subdomains. This portal uses
+// default host-only scope (portal.winlab.tw). When a user who logged in on
+// the old portal hits this one, the browser sends BOTH the cross-subdomain
+// ghost cookie AND any fresh host-only cookie under the same name —
+// @supabase/ssr picks one value, fails to parse against the current PKCE
+// state, and the callback falls through to /auth/auth-code-error.
+//
+// Nuking only the host-only version leaves the .winlab.tw ghost intact and
+// the loop repeats. We have to Set-Cookie with the matching domain for the
+// browser to drop it. We don't know every domain the old portal scoped to,
+// so blast every plausible one — extra clears are harmless.
+const DOMAINS_TO_CLEAR = [
+  undefined, // host-only (current deployment)
+  ".winlab.tw", // old portal's explicit scope
+  "portal.winlab.tw",
+]
+
+export async function clearStaleSupabaseCookies(
+  cookieStore: Awaited<ReturnType<typeof cookies>>
+) {
+  const staleNames = cookieStore
+    .getAll()
+    .map((c) => c.name)
+    // Session / auth-token cookies interfere with exchangeCodeForSession.
+    // The code-verifier cookie is the one we JUST set for the PKCE round-trip
+    // we're currently completing — don't touch it.
+    .filter(
+      (name) => name.startsWith("sb-") && !name.endsWith("-code-verifier")
+    )
+
+  for (const name of staleNames) {
+    for (const domain of DOMAINS_TO_CLEAR) {
+      cookieStore.set(name, "", {
+        maxAge: 0,
+        path: "/",
+        ...(domain ? { domain } : {}),
+      })
+    }
+  }
+
+  return staleNames.length
+}


### PR DESCRIPTION
## The bug

Users who signed in on the previous portal (\`old.portal/portal.winlab.tw\`) land on \`/auth/auth-code-error\` when they try to sign in here, with no way to recover without manually clearing cookies or opening incognito.

## Root cause

The old portal's Supabase browser client was configured with \`cookieOptions: { domain: ".winlab.tw" }\` — its auth cookies leaked to every subdomain. This portal uses @supabase/ssr defaults (host-only scope). Both cookies end up in the browser with the SAME name:

```
Cookie: sb-yissfqcdmzsxwfnzrflz-auth-token.0=<GHOST>   (Domain=.winlab.tw)
        sb-yissfqcdmzsxwfnzrflz-auth-token.0=<FRESH>   (Domain=portal.winlab.tw, if set)
```

Both get sent together. @supabase/ssr picks one, fails to reconcile it with the current PKCE state, \`exchangeCodeForSession\` returns an error, callback redirects to the error page.

Evidence from the old repo: \`old.portal/portal.winlab.tw/lib/supabase/client.ts\` explicitly sets \`domain: ".winlab.tw"\` on winlab.tw hosts. They even had a \`clearSupabaseCookies\` helper in \`lib/clear-cookies.ts\` that hard-coded the same cookie names — which is exactly what this fix generalizes server-side.

## Fix

- New helper \`apps/portal/lib/auth/clear-stale-cookies.ts\` — enumerates current \`sb-*\` cookies (skips \`-code-verifier\` which we just set for this round-trip) and clears each one on host-only + \`.winlab.tw\` + \`portal.winlab.tw\` via multiple \`Set-Cookie: ...; Max-Age=0; Domain=...\` headers.
- \`/auth/callback\` on error now calls the helper and redirects to \`/auth/login?stale=1\` instead of \`/auth/auth-code-error\`. One retry and they're in.
- \`/auth/login\` shows a muted note when \`?stale=1\` so the user understands why they're seeing the screen again: *"Cleared a leftover session from the previous portal. Try signing in again."*

The \`/auth/auth-code-error\` page stays as a deep-link safety net — no user should reach it from the normal flow anymore.

## Test plan

- [x] \`bun run typecheck --filter=portal\`
- [x] \`bun run build --filter=portal\`
- [x] \`bun run lint --filter=portal\` — 0 warnings on changed files
- [ ] Post-deploy manual: in a browser that has the ghost cookie (simulate by \`document.cookie = "sb-yissfqcdmzsxwfnzrflz-auth-token.0=garbage; Domain=.winlab.tw"\` in devtools on any \`.winlab.tw\` subdomain), visit \`portal.winlab.tw/auth/login\`, sign in with Keycloak, verify: callback clears, redirects to \`/auth/login?stale=1\`, second click succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)