### PR TITLE
fix(portal): nuke every sb-* cookie on callback failure, code-verifier too

### DIFF
--- a/apps/portal/app/auth/callback/route.ts
+++ b/apps/portal/app/auth/callback/route.ts
@@ -1,7 +1,7 @@
 import { cookies } from "next/headers"
 import { NextResponse } from "next/server"
 
-import { clearStaleSupabaseCookies } from "@/lib/auth/clear-stale-cookies"
+import { clearStaleSupabaseCookiesOnResponse } from "@/lib/auth/clear-stale-cookies"
 import { createClient } from "@/lib/supabase/server"
 
 export async function GET(request: Request) {
@@ -28,15 +28,17 @@ export async function GET(request: Request) {
     }
   }
 
-  // Exchange failed (or no code). Most common cause: stale cross-subdomain
-  // Supabase cookies left behind by the previous portal at .winlab.tw. Clear
-  // them and send the user back to /auth/login so one extra click gets them
-  // through instead of a dead-end error page. First-failure users never see
-  // /auth/auth-code-error again.
-  const cookieStore = await cookies()
-  await clearStaleSupabaseCookies(cookieStore)
-
+  // Failure path: most likely cause is a ghost `sb-*` cookie left over from
+  // the previous portal at `.winlab.tw` scope poisoning @supabase/ssr's PKCE
+  // state. Clear every sb-* cookie (including code-verifier — the current
+  // round-trip has already failed, its verifier is worthless) on every
+  // plausible domain and send the user back to login.
   const retry = new URL("/auth/login", origin)
   retry.searchParams.set("stale", "1")
-  return NextResponse.redirect(retry.toString())
+  const response = NextResponse.redirect(retry.toString())
+
+  const cookieStore = await cookies()
+  clearStaleSupabaseCookiesOnResponse(response, cookieStore)
+
+  return response
 }

--- a/apps/portal/lib/auth/clear-stale-cookies.ts
+++ b/apps/portal/lib/auth/clear-stale-cookies.ts
@@ -1,39 +1,39 @@
-import type { cookies } from "next/headers"
+import type { NextResponse } from "next/server"
+import type { cookies as nextCookies } from "next/headers"
 
-// The previous portal (old.portal.winlab.tw) set Supabase auth cookies with
-// `domain: ".winlab.tw"` so they leaked across subdomains. This portal uses
-// default host-only scope (portal.winlab.tw). When a user who logged in on
-// the old portal hits this one, the browser sends BOTH the cross-subdomain
-// ghost cookie AND any fresh host-only cookie under the same name —
-// @supabase/ssr picks one value, fails to parse against the current PKCE
-// state, and the callback falls through to /auth/auth-code-error.
+// The previous portal scoped Supabase auth cookies to `.winlab.tw`, so users
+// who logged in there carry cross-subdomain ghost cookies on this portal
+// (host-only). Both values collide in the browser's Cookie header under the
+// same name; @supabase/ssr picks one, the PKCE verifier / session reconciles
+// wrong, exchangeCodeForSession fails.
 //
-// Nuking only the host-only version leaves the .winlab.tw ghost intact and
-// the loop repeats. We have to Set-Cookie with the matching domain for the
-// browser to drop it. We don't know every domain the old portal scoped to,
-// so blast every plausible one — extra clears are harmless.
+// First attempt at a fix (PR #15) preserved `-code-verifier` cookies on the
+// theory that we'd need the current round-trip's verifier. In practice the
+// GHOST verifier at `.winlab.tw` was the exact thing poisoning the exchange —
+// preserving verifiers meant the ghost survived and the loop continued.
+//
+// New policy: on failure, nuke EVERY `sb-*` cookie on every plausible domain
+// scope. The current attempt's verifier dies with the ghost, but that's
+// fine — the current attempt has already failed. The next click starts
+// fresh and succeeds.
 const DOMAINS_TO_CLEAR = [
   undefined, // host-only (current deployment)
   ".winlab.tw", // old portal's explicit scope
   "portal.winlab.tw",
 ]
 
-export async function clearStaleSupabaseCookies(
-  cookieStore: Awaited<ReturnType<typeof cookies>>
+export function clearStaleSupabaseCookiesOnResponse(
+  response: NextResponse,
+  cookieStore: Awaited<ReturnType<typeof nextCookies>>
 ) {
   const staleNames = cookieStore
     .getAll()
     .map((c) => c.name)
-    // Session / auth-token cookies interfere with exchangeCodeForSession.
-    // The code-verifier cookie is the one we JUST set for the PKCE round-trip
-    // we're currently completing — don't touch it.
-    .filter(
-      (name) => name.startsWith("sb-") && !name.endsWith("-code-verifier")
-    )
+    .filter((name) => name.startsWith("sb-"))
 
   for (const name of staleNames) {
     for (const domain of DOMAINS_TO_CLEAR) {
-      cookieStore.set(name, "", {
+      response.cookies.set(name, "", {
         maxAge: 0,
         path: "/",
         ...(domain ? { domain } : {}),


### PR DESCRIPTION
## Evidence

After PR #15 shipped, a user with a pre-existing \`.winlab.tw\`-scoped session reported getting stuck in a \`/auth/login?stale=1\` loop — every click produced the same screen. Supabase auth logs for the project confirmed the exact failure mode:

\`\`\`
paths:        [('/token', 100)]
grant_types:  [('refresh_token', 100)]
error_codes:  [('over_request_rate_limit', 48), ('refresh_token_not_found', 3)]
/authorize or authorization_code events:  0
\`\`\`

Zero \`/authorize\` events means \`exchangeCodeForSession\` was failing **inside @supabase/ssr before ever making a network call**. That narrows the culprit to local PKCE state — cookies.

## Two bugs in PR #15

### 1. The clear preserved \`-code-verifier\` cookies

PR #15's helper filtered out any cookie ending in \`-code-verifier\`, on the theory that the current PKCE round-trip needed its verifier preserved. In practice the **ghost verifier at \`.winlab.tw\`** was the exact cookie poisoning the exchange. The browser sends both the ghost and the fresh host-only verifier under the same name; @supabase/ssr picks one, gets a verifier that doesn't match the code it's trying to exchange, fails. Preserving verifiers meant the ghost survived every retry.

Fix: **clear every \`sb-*\` cookie unconditionally**, including code-verifier. The current attempt has already failed (we're in the error path), its verifier is worthless, so there's nothing to preserve. The next click's \`signInWithOAuth\` writes a fresh verifier with no ghost left to collide with.

### 2. Set-Cookie headers were on the wrong object

PR #15 used \`cookieStore.set(name, "", { maxAge: 0 })\` from \`next/headers\`. Whether those mutations attach to a \`NextResponse.redirect()\` return value is undocumented — in this case, they apparently didn't reach the browser consistently.

Fix: build the \`NextResponse.redirect()\` first, then call \`response.cookies.set(...)\` directly on it. Unambiguous: the \`Set-Cookie\` headers ship with the redirect.

## Test plan

- [x] \`bun run typecheck --filter=portal\`
- [x] \`bun run build --filter=portal\`
- [ ] Post-deploy: the reporter (who's currently stuck in the \`?stale=1\` loop) signs in. First click clears every sb-* cookie cross-domain. Second click lands at \`/\` as an authenticated user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)