### PR TITLE
fix(portal): reset localStorage + sessionStorage on /auth/login

### DIFF
--- a/apps/portal/app/auth/callback/route.ts
+++ b/apps/portal/app/auth/callback/route.ts
@@ -15,6 +15,16 @@ export async function GET(request: Request) {
   if (code) {
     const supabase = await createClient()
     const { error } = await supabase.auth.exchangeCodeForSession(code)
+    if (error) {
+      // Visible in Vercel runtime logs — critical for diagnosing why a user
+      // is in a retry loop. Keep the whole object so status / name / status
+      // code survive.
+      console.error("[auth/callback] exchangeCodeForSession failed", {
+        name: error.name,
+        message: error.message,
+        status: error.status,
+      })
+    }
     if (!error) {
       const forwardedHost = request.headers.get("x-forwarded-host")
       const isLocalEnv = process.env.NODE_ENV === "development"

--- a/apps/portal/app/auth/login/page.tsx
+++ b/apps/portal/app/auth/login/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation"
 
+import { AuthStateReset } from "@/components/auth-state-reset"
 import { PortalShell } from "@/components/portal-shell"
 import { SignInButton } from "@/components/sign-in-button"
 import { getCurrentUser } from "@/lib/user"
@@ -16,6 +17,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
 
   return (
     <PortalShell appName="Sign in">
+      <AuthStateReset />
       <div className="flex min-h-[60vh] flex-col justify-center gap-6">
         <div className="flex flex-col gap-1">
           <h1 className="text-lg font-medium">Sign in to portal</h1>

--- a/apps/portal/components/auth-state-reset.tsx
+++ b/apps/portal/components/auth-state-reset.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import { useEffect } from "react"
+
+// Nukes every local Supabase auth artefact. Mounted on /auth/login so any
+// user arriving to sign in gets a clean slate — no ghost cookie, no stale
+// localStorage session, no orphan sessionStorage flag.
+//
+// Why each piece matters:
+// - localStorage: @supabase/ssr browser client stores session JSON here and
+//   auto-refreshes on page mount. A stale entry here spawns a refresh loop
+//   (visible as grant_type=refresh_token + over_request_rate_limit in
+//   Supabase auth logs) that poisons the user's IP rate limit and can make
+//   a subsequent exchangeCodeForSession fail with 429.
+// - sessionStorage: less critical but @supabase/ssr occasionally puts PKCE
+//   scratch state there. Clear for completeness.
+// - document.cookie: our server-side clear handles this too, but JS can
+//   only see & clear non-HttpOnly entries on the current domain. The old
+//   portal set cookies with domain=.winlab.tw, so we blast that scope too
+//   (writing a cookie with matching Domain and Max-Age=0 removes it).
+export function AuthStateReset() {
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    const nukeStorage = (storage: Storage) => {
+      for (let i = storage.length - 1; i >= 0; i--) {
+        const key = storage.key(i)
+        if (key?.startsWith("sb-")) storage.removeItem(key)
+      }
+    }
+
+    try {
+      nukeStorage(localStorage)
+      nukeStorage(sessionStorage)
+    } catch {
+      // Safari private mode etc — nothing to do, carry on.
+    }
+
+    const domains: (string | undefined)[] = [
+      undefined, // host-only current deployment
+      ".winlab.tw", // old portal's explicit scope
+      "portal.winlab.tw",
+    ]
+    for (const entry of document.cookie.split("; ")) {
+      const name = entry.split("=")[0]
+      if (!name?.startsWith("sb-")) continue
+      for (const domain of domains) {
+        const domainPart = domain ? `; domain=${domain}` : ""
+        document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/${domainPart}`
+      }
+    }
+  }, [])
+
+  return null
+}


### PR DESCRIPTION
## Why PRs #15 and #16 didn't end the loop

Both earlier fixes cleared cookies server-side only. Supabase's auth logs for the project told the real story:

\`\`\`
time range:  2026-04-23 22:12:22 → 22:12:31   (9 seconds)
paths:       /token   × 100
grant_types: refresh_token   × 100
errors:      over_request_rate_limit × 48, refresh_token_not_found × 4
referers:    http://localhost:3000   × 100
authorization_code events: 0
\`\`\`

**~10 requests per second** hammering \`/token\` with \`grant_type=refresh_token\`. That's \`@supabase/ssr\`'s browser client auto-refreshing a stale session **on every page mount**. Source: \`localStorage\` — not cookies. Our server-side cookie clear never saw this, because cookies and localStorage are orthogonal.

The loop burns through the user's IP rate limit. When they finally click "Sign in with Keycloak" for real, the final \`/token\` call (with \`grant_type=authorization_code\`) that \`exchangeCodeForSession\` makes also gets 429'd. Our callback treats it as a failure, redirects to \`/auth/login?stale=1\`, the login page mounts, browser client auto-refreshes again, loop resumes. No amount of cookie-clearing could escape this — the localStorage re-spawns a session every time.

## Fix

New client component \`<AuthStateReset />\` mounted on \`/auth/login\`. On mount:

1. Walks \`localStorage\` + \`sessionStorage\` and removes every key starting with \`sb-\` — kills the source of the background refresh loop.
2. Walks \`document.cookie\` and clears every \`sb-*\` entry on three scopes (host-only, \`.winlab.tw\`, \`portal.winlab.tw\`) — same pattern PR #16 applied server-side, but now covers anything \`cookies().set()\` might have missed.

Server-side clear in \`/auth/callback\` stays as belt-and-suspenders.

Also added \`console.error\` on \`exchangeCodeForSession\` failure so next time the user is in a broken state, Vercel runtime logs will show the actual Supabase error string instead of a silent 307.

## Test plan

- [x] \`bun run typecheck --filter=portal\`
- [x] \`bun run build --filter=portal\`
- [ ] Post-deploy, the affected device: open \`portal.winlab.tw/auth/login\` → DevTools → Application tab → Storage → localStorage should have no \`sb-*\` keys after the page loads. Click Sign in → OAuth round-trip → \`/\` as authenticated user.

## If the user still sees the loop after this

The \`referer: http://localhost:3000\` in logs strongly suggests there's a separate open browser tab or running dev server on \`localhost:3000\` (probably the old portal) that's doing its own refresh loop against the same Supabase project. That loop shares the user's IP with their production login attempt and can rate-limit them. If this fix doesn't fully clear the problem, closing that tab / stopping that dev server is the last mile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)