### PR TITLE
fix(portal): self-heal stale Supabase local state in AuthProvider

### DIFF
--- a/apps/portal/components/auth-provider.tsx
+++ b/apps/portal/components/auth-provider.tsx
@@ -27,6 +27,36 @@ export function AuthProvider({
     }
   }
 
+  // Self-heal for stale localStorage. If the server authoritatively says
+  // we're not signed in but there's still an `sb-*` shard in localStorage,
+  // the local state is dead weight — most likely a refresh_token the old
+  // portal left here that's been revoked/rotated since. Leaving it would
+  // kick off @supabase/ssr's auto-refresh timer, which hammers /token
+  // trying to revive a corpse and eventually hits rate-limit 429s.
+  //
+  // signOut({ scope: "local" }) clears storage and stops the timer
+  // without a network call — no rate-limit burn, no cross-device blast.
+  useEffect(() => {
+    if (initialUser) return
+    let hasStaleState = false
+    try {
+      hasStaleState = Object.keys(localStorage).some((k) => k.startsWith("sb-"))
+    } catch {
+      return // SSR or private mode — nothing to do
+    }
+    if (!hasStaleState) return
+
+    supabase.auth.signOut({ scope: "local" }).catch(() => {
+      try {
+        Object.keys(localStorage)
+          .filter((k) => k.startsWith("sb-"))
+          .forEach((k) => localStorage.removeItem(k))
+      } catch {
+        /* give up silently */
+      }
+    })
+  }, [initialUser, supabase])
+
   useEffect(() => {
     let mounted = true
 


### PR DESCRIPTION
## Why this last piece

Three fixes already shipped for the migration from old portal:
- \`/auth/callback\` server-side cookie clear on failed exchange (PR #16)
- \`<AuthStateReset />\` on \`/auth/login\` mount clears localStorage + sessionStorage + cookies (PR #17)

Those handle the \"user lands on /auth/login\" path. But \`<AuthProvider />\` lives in the **root layout** — it mounts on **every** page. If a user arrives on \`/bento\` or \`/\` with a valid-looking cookie but a dead localStorage shard (e.g. refresh_token revoked by Supabase, or cookie and localStorage out of sync for any reason), \`@supabase/ssr\`'s browser client kicks off an auto-refresh timer against the dead shard. That's the \`/token\` hammer we caught at ~10 req/s in Supabase auth logs yesterday.

## The self-heal

\`\`\`ts
useEffect(() => {
  if (initialUser) return
  const hasStaleState = Object.keys(localStorage).some((k) =>
    k.startsWith(\"sb-\")
  )
  if (!hasStaleState) return
  supabase.auth.signOut({ scope: \"local\" }).catch(/* manual fallback */)
}, [initialUser, supabase])
\`\`\`

Trigger condition: server says anon **and** localStorage has \`sb-*\` → flush.

\`scope: \"local\"\` does NOT hit Supabase's network (no rate-limit burn, no revoking other-device sessions) — it just clears storage and stops the timer. The follow-up \`SIGNED_OUT\` event it emits is caught by the existing \`onAuthStateChange\` listener, which updates \`user\` to \`null\` cleanly.

## Safety analysis

| Scenario | \`initialUser\` | localStorage \`sb-*\` | Trigger? | Result |
|---|---|---|---|---|
| Normal signed-in user | User | yes | No | untouched ✅ |
| Just signed out | null | empty (signOut already cleared it) | No | untouched ✅ |
| Access-token expired, middleware refreshes | User (fresh cookie) | yes | No | untouched ✅ |
| **Stale localStorage, anon cookie** (the bug) | null | yes | **Yes** | flushed ✅ |

No false-positive path: \`initialUser = null\` requires \`getClaims()\` to find no valid JWT, which is a local decode with no transient network failure. If claims are valid, server sets \`initialUser\` and this useEffect short-circuits before touching anything.

## Test plan

- [x] \`bun run typecheck --filter=portal\`
- [x] \`bun run build --filter=portal\`
- [x] \`bun run lint --filter=portal\` — no new warnings
- [ ] Post-deploy: device with stale localStorage that hasn't hit \`/auth/login\` (e.g. go straight to \`/\`) — AuthProvider flushes localStorage on mount, middleware redirects to \`/auth/login\`, normal sign-in works. No \`/token\` hammer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)