### PR TITLE
feat(approve): rebrand emails to WinLab + align with portal design

### DIFF
--- a/apps/portal/emails/approve/document-completed.tsx
+++ b/apps/portal/emails/approve/document-completed.tsx
@@ -2,10 +2,12 @@ import {
   Body,
   Button,
   Container,
+  Font,
   Head,
   Heading,
   Hr,
   Html,
+  Link,
   Preview,
   Section,
   Text,
@@ -17,22 +19,40 @@ export type DocumentCompletedProps = {
   viewUrl: string
 }
 
+const FONT_STACK =
+  '"Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace'
+
 export function DocumentCompleted({
   documentTitle,
   signerNames,
   viewUrl,
 }: DocumentCompletedProps) {
   return (
-    <Html>
-      <Head />
+    <Html lang="zh-Hant">
+      <Head>
+        <Font
+          fontFamily="Geist Mono"
+          fallbackFontFamily="monospace"
+          webFont={{
+            url: "https://fonts.gstatic.com/s/geistmono/v3/or3sQ6P-YJ3kg-7SKRMNME-yy4Dt-S1r.woff2",
+            format: "woff2",
+          }}
+          fontWeight={400}
+          fontStyle="normal"
+        />
+      </Head>
       <Preview>{`大家都簽好了：${documentTitle}`}</Preview>
       <Body style={body}>
         <Container style={container}>
+          <Text style={brand}>WinLab Approve</Text>
+          <Hr style={hr} />
           <Heading style={h1}>簽核完成</Heading>
           <Text style={p}>你的文件所有簽核人都簽好了：</Text>
-          <Text style={title}>{documentTitle}</Text>
+          <Section style={docCard}>
+            <Text style={docTitle}>{documentTitle}</Text>
+          </Section>
           <Text style={p}>
-            已簽核：<strong>{signerNames.join("、")}</strong>
+            已簽核：<strong style={strong}>{signerNames.join("、")}</strong>
           </Text>
           <Section style={buttonWrap}>
             <Button href={viewUrl} style={button}>
@@ -40,8 +60,11 @@ export function DocumentCompleted({
             </Button>
           </Section>
           <Hr style={hr} />
-          <Text style={muted}>如果按鈕無法點擊，把下面的連結貼到瀏覽器：</Text>
-          <Text style={link}>{viewUrl}</Text>
+          <Text style={muted}>按鈕無法點擊時，把連結貼到瀏覽器：</Text>
+          <Link href={viewUrl} style={link}>
+            {viewUrl}
+          </Link>
+          <Text style={footer}>portal.winlab.tw</Text>
         </Container>
       </Body>
     </Html>
@@ -50,47 +73,97 @@ export function DocumentCompleted({
 
 export default DocumentCompleted
 
+const C = {
+  bg: "#ffffff",
+  fg: "#171717",
+  mutedBg: "#f5f5f5",
+  mutedFg: "#737373",
+  border: "#e5e5e5",
+  primary: "#171717",
+  primaryFg: "#fafafa",
+} as const
+
 const body = {
-  backgroundColor: "#ffffff",
-  fontFamily:
-    '-apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang TC", "Noto Sans TC", sans-serif',
+  backgroundColor: C.bg,
+  color: C.fg,
+  fontFamily: FONT_STACK,
+  margin: 0,
+  padding: 0,
 }
 const container = {
   maxWidth: "560px",
   margin: "0 auto",
-  padding: "40px 24px",
+  padding: "48px 24px",
+}
+const brand = {
+  fontSize: "12px",
+  fontWeight: 500,
+  color: C.mutedFg,
+  letterSpacing: "0.02em",
+  margin: "0 0 24px 0",
+  textTransform: "uppercase" as const,
+}
+const hr = {
+  borderColor: C.border,
+  borderTop: `1px solid ${C.border}`,
+  borderBottom: "none",
+  margin: "24px 0",
 }
 const h1 = {
-  fontSize: "22px",
+  fontSize: "20px",
   fontWeight: 600,
-  color: "#111111",
-  margin: "0 0 24px 0",
+  color: C.fg,
+  lineHeight: "1.4",
+  margin: "0 0 20px 0",
 }
-const p = { fontSize: "15px", color: "#333333", lineHeight: "1.6" }
-const title = {
-  fontSize: "16px",
-  fontWeight: 600,
-  color: "#111111",
-  padding: "12px 16px",
-  backgroundColor: "#f4f4f5",
-  borderRadius: "6px",
-  margin: "8px 0 24px 0",
+const p = {
+  fontSize: "14px",
+  color: C.fg,
+  lineHeight: "1.7",
+  margin: "0 0 12px 0",
 }
-const buttonWrap = { margin: "24px 0" }
+const strong = { fontWeight: 600, color: C.fg }
+const docCard = {
+  border: `1px solid ${C.border}`,
+  borderRadius: "10px",
+  backgroundColor: C.mutedBg,
+  padding: "16px 20px",
+  margin: "8px 0 20px 0",
+}
+const docTitle = {
+  fontSize: "14px",
+  fontWeight: 500,
+  color: C.fg,
+  margin: 0,
+  lineHeight: "1.5",
+}
+const buttonWrap = { margin: "16px 0 8px 0" }
 const button = {
-  backgroundColor: "#111111",
-  color: "#ffffff",
-  padding: "12px 24px",
-  borderRadius: "6px",
-  fontSize: "15px",
+  backgroundColor: C.primary,
+  color: C.primaryFg,
+  padding: "12px 22px",
+  borderRadius: "10px",
+  fontSize: "14px",
   fontWeight: 500,
   textDecoration: "none",
   display: "inline-block",
+  fontFamily: FONT_STACK,
 }
-const hr = { borderColor: "#e4e4e7", margin: "32px 0" }
-const muted = { fontSize: "13px", color: "#71717a", margin: "0 0 4px 0" }
+const muted = {
+  fontSize: "12px",
+  color: C.mutedFg,
+  margin: "0 0 6px 0",
+  lineHeight: "1.5",
+}
 const link = {
-  fontSize: "13px",
-  color: "#71717a",
+  fontSize: "12px",
+  color: C.mutedFg,
+  textDecoration: "underline",
   wordBreak: "break-all" as const,
+}
+const footer = {
+  fontSize: "11px",
+  color: C.mutedFg,
+  margin: "40px 0 0 0",
+  letterSpacing: "0.02em",
 }

--- a/apps/portal/emails/approve/signer-invited.tsx
+++ b/apps/portal/emails/approve/signer-invited.tsx
@@ -2,10 +2,12 @@ import {
   Body,
   Button,
   Container,
+  Font,
   Head,
   Heading,
   Hr,
   Html,
+  Link,
   Preview,
   Section,
   Text,
@@ -17,30 +19,53 @@ export type SignerInvitedProps = {
   signUrl: string
 }
 
+// Portal runs in Geist Mono (see app/layout.tsx + globals.css). Match that
+// in email too; system mono fallback covers clients that skip <Font>.
+const FONT_STACK =
+  '"Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace'
+
 export function SignerInvited({
   documentTitle,
   creatorName,
   signUrl,
 }: SignerInvitedProps) {
   return (
-    <Html>
-      <Head />
+    <Html lang="zh-Hant">
+      <Head>
+        <Font
+          fontFamily="Geist Mono"
+          fallbackFontFamily="monospace"
+          webFont={{
+            url: "https://fonts.gstatic.com/s/geistmono/v3/or3sQ6P-YJ3kg-7SKRMNME-yy4Dt-S1r.woff2",
+            format: "woff2",
+          }}
+          fontWeight={400}
+          fontStyle="normal"
+        />
+      </Head>
       <Preview>{`${creatorName} 邀請你簽核：${documentTitle}`}</Preview>
       <Body style={body}>
         <Container style={container}>
+          <Text style={brand}>WinLab Approve</Text>
+          <Hr style={hr} />
           <Heading style={h1}>有一份文件等你簽名</Heading>
           <Text style={p}>
-            <strong>{creatorName}</strong> 邀請你簽核：
+            <strong style={strong}>{creatorName}</strong> 邀請你簽核：
           </Text>
-          <Text style={title}>{documentTitle}</Text>
+          <Section style={docCard}>
+            <Text style={docTitle}>{documentTitle}</Text>
+          </Section>
           <Section style={buttonWrap}>
             <Button href={signUrl} style={button}>
               前往簽名
             </Button>
           </Section>
           <Hr style={hr} />
-          <Text style={muted}>如果按鈕無法點擊，把下面的連結貼到瀏覽器：</Text>
-          <Text style={link}>{signUrl}</Text>
+          <Text style={muted}>按鈕無法點擊時，把連結貼到瀏覽器：</Text>
+          <Link href={signUrl} style={link}>
+            {signUrl}
+          </Link>
+          <Text style={footer}>portal.winlab.tw</Text>
         </Container>
       </Body>
     </Html>
@@ -49,47 +74,99 @@ export function SignerInvited({
 
 export default SignerInvited
 
+// Token map (see packages/ui/src/styles/globals.css — shadcn neutral scale).
+// Email clients can't touch CSS variables so we resolve to hex here.
+const C = {
+  bg: "#ffffff",
+  fg: "#171717",
+  mutedBg: "#f5f5f5",
+  mutedFg: "#737373",
+  border: "#e5e5e5",
+  primary: "#171717",
+  primaryFg: "#fafafa",
+} as const
+
 const body = {
-  backgroundColor: "#ffffff",
-  fontFamily:
-    '-apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang TC", "Noto Sans TC", sans-serif',
+  backgroundColor: C.bg,
+  color: C.fg,
+  fontFamily: FONT_STACK,
+  margin: 0,
+  padding: 0,
 }
 const container = {
   maxWidth: "560px",
   margin: "0 auto",
-  padding: "40px 24px",
+  padding: "48px 24px",
+}
+const brand = {
+  fontSize: "12px",
+  fontWeight: 500,
+  color: C.mutedFg,
+  letterSpacing: "0.02em",
+  margin: "0 0 24px 0",
+  textTransform: "uppercase" as const,
+}
+const hr = {
+  borderColor: C.border,
+  borderTop: `1px solid ${C.border}`,
+  borderBottom: "none",
+  margin: "24px 0",
 }
 const h1 = {
-  fontSize: "22px",
+  fontSize: "20px",
   fontWeight: 600,
-  color: "#111111",
-  margin: "0 0 24px 0",
+  color: C.fg,
+  lineHeight: "1.4",
+  margin: "0 0 20px 0",
 }
-const p = { fontSize: "15px", color: "#333333", lineHeight: "1.6" }
-const title = {
-  fontSize: "16px",
-  fontWeight: 600,
-  color: "#111111",
-  padding: "12px 16px",
-  backgroundColor: "#f4f4f5",
-  borderRadius: "6px",
-  margin: "8px 0 24px 0",
+const p = {
+  fontSize: "14px",
+  color: C.fg,
+  lineHeight: "1.7",
+  margin: "0 0 12px 0",
 }
-const buttonWrap = { margin: "24px 0" }
+const strong = { fontWeight: 600, color: C.fg }
+const docCard = {
+  border: `1px solid ${C.border}`,
+  borderRadius: "10px",
+  backgroundColor: C.mutedBg,
+  padding: "16px 20px",
+  margin: "8px 0 28px 0",
+}
+const docTitle = {
+  fontSize: "14px",
+  fontWeight: 500,
+  color: C.fg,
+  margin: 0,
+  lineHeight: "1.5",
+}
+const buttonWrap = { margin: "0 0 8px 0" }
 const button = {
-  backgroundColor: "#111111",
-  color: "#ffffff",
-  padding: "12px 24px",
-  borderRadius: "6px",
-  fontSize: "15px",
+  backgroundColor: C.primary,
+  color: C.primaryFg,
+  padding: "12px 22px",
+  borderRadius: "10px",
+  fontSize: "14px",
   fontWeight: 500,
   textDecoration: "none",
   display: "inline-block",
+  fontFamily: FONT_STACK,
 }
-const hr = { borderColor: "#e4e4e7", margin: "32px 0" }
-const muted = { fontSize: "13px", color: "#71717a", margin: "0 0 4px 0" }
+const muted = {
+  fontSize: "12px",
+  color: C.mutedFg,
+  margin: "0 0 6px 0",
+  lineHeight: "1.5",
+}
 const link = {
-  fontSize: "13px",
-  color: "#71717a",
+  fontSize: "12px",
+  color: C.mutedFg,
+  textDecoration: "underline",
   wordBreak: "break-all" as const,
+}
+const footer = {
+  fontSize: "11px",
+  color: C.mutedFg,
+  margin: "40px 0 0 0",
+  letterSpacing: "0.02em",
 }

--- a/apps/portal/lib/approve/email-drain.ts
+++ b/apps/portal/lib/approve/email-drain.ts
@@ -108,7 +108,7 @@ async function sendOne(
       html = await render(
         SignerInvited({
           documentTitle: doc.title,
-          creatorName: creator?.name ?? creator?.email ?? "Portal",
+          creatorName: creator?.name ?? creator?.email ?? "WinLab",
           signUrl: `${siteUrl()}/approve/sign/${doc.id}`,
         })
       )

--- a/apps/portal/lib/email/resend.ts
+++ b/apps/portal/lib/email/resend.ts
@@ -2,7 +2,7 @@ import { Resend } from "resend"
 
 // winlab.tw mail lives on notifications.winlab.tw in Resend (verified in
 // ap-northeast-1). Keeping a single From identity so replies land consistently.
-export const MAIL_FROM = "Portal Approve <approve@notifications.winlab.tw>"
+export const MAIL_FROM = "WinLab Approve <approve@notifications.winlab.tw>"
 
 export function getResend() {
   const key = process.env.RESEND_API_KEY


### PR DESCRIPTION
## Summary

- Sender identity `Portal Approve` → `WinLab Approve`
- Templates now dress like the app: Geist Mono, shadcn neutral tokens, 10px radius, mono-quiet layout
- Single source of truth for color (token map mirroring globals.css)

## Design token mapping

| Role | Portal CSS var (oklch) | Email hex |
|------|------------------------|-----------|
| background | `--background` 1 0 0 | `#ffffff` |
| foreground | `--foreground` 0.145 | `#171717` |
| primary / button bg | `--primary` 0.205 | `#171717` |
| primary fg | `--primary-foreground` | `#fafafa` |
| muted bg | `--muted` 0.97 | `#f5f5f5` |
| muted fg | `--muted-foreground` 0.556 | `#737373` |
| border | `--border` 0.922 | `#e5e5e5` |
| radius | `--radius` 0.625rem | `10px` |

Plus `<Font>` for Geist Mono (Google Fonts gstatic), system monospace fallback for clients that drop the link.

## Visual structure

1. Small uppercase `WINLAB APPROVE` wordmark (mono muted, like PortalShell corners)
2. Hairline rule
3. Heading + one-liner
4. Document title in a subtle bordered card
5. Primary button
6. Hairline rule
7. Fallback link + `portal.winlab.tw` footer

## Test plan

- [ ] Vercel preview deploys
- [ ] Trigger a signer-invited and document-completed mail from preview
- [ ] Check Gmail web, Apple Mail, and iOS Gmail — font should be Geist Mono where supported, system mono elsewhere
- [ ] Verify layout holds on narrow mobile widths
- [ ] Verify click-through on both buttons lands on the right page