### PR TITLE
fix(ui): guard double-submit + keep sign boxes visible in dark mode

### DIFF
--- a/apps/portal/app/approve/_components/confirm-dialog.tsx
+++ b/apps/portal/app/approve/_components/confirm-dialog.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import type { ReactNode } from "react"
+import { useState, useTransition, type ReactNode } from "react"
 
 import {
   AlertDialog,
@@ -21,7 +21,7 @@ interface ConfirmDialogProps {
   confirmText?: string
   cancelText?: string
   variant?: "default" | "destructive"
-  onConfirm: () => void
+  onConfirm: () => void | Promise<void>
 }
 
 export function ConfirmDialog({
@@ -33,8 +33,29 @@ export function ConfirmDialog({
   variant = "default",
   onConfirm,
 }: ConfirmDialogProps) {
+  const [open, setOpen] = useState(false)
+  const [pending, startTransition] = useTransition()
+
+  function handleConfirm(e: React.MouseEvent<HTMLButtonElement>) {
+    // Hold the dialog open until the async work finishes so a spam-click
+    // can't fire onConfirm twice. AlertDialogAction would auto-close otherwise.
+    e.preventDefault()
+    startTransition(async () => {
+      try {
+        await onConfirm()
+      } finally {
+        setOpen(false)
+      }
+    })
+  }
+
   return (
-    <AlertDialog>
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!pending) setOpen(next)
+      }}
+    >
       <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>
       <AlertDialogContent>
         <AlertDialogHeader>
@@ -42,16 +63,17 @@ export function ConfirmDialog({
           <AlertDialogDescription>{description}</AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel>{cancelText}</AlertDialogCancel>
+          <AlertDialogCancel disabled={pending}>{cancelText}</AlertDialogCancel>
           <AlertDialogAction
-            onClick={onConfirm}
+            onClick={handleConfirm}
+            disabled={pending}
             className={
               variant === "destructive"
                 ? "text-destructive-foreground bg-destructive hover:bg-destructive/90"
                 : ""
             }
           >
-            {confirmText}
+            {pending ? "處理中..." : confirmText}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/apps/portal/app/approve/_components/document-editor.tsx
+++ b/apps/portal/app/approve/_components/document-editor.tsx
@@ -1,6 +1,13 @@
 "use client"
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from "react"
 import dynamic from "next/dynamic"
 import { useRouter } from "next/navigation"
 import { useQueryClient } from "@tanstack/react-query"
@@ -65,6 +72,7 @@ export function DocumentEditor({
 
   const router = useRouter()
   const queryClient = useQueryClient()
+  const [submitPending, startSubmit] = useTransition()
   const debounceRefs = useRef<Map<string, NodeJS.Timeout>>(new Map())
   const { url: signedUrl, refresh: refreshSignedUrl } = useApprovePdfUrl(
     documentId,
@@ -285,8 +293,13 @@ export function DocumentEditor({
               }
             }}
           />
-          <Button type="button" size="sm" onClick={onSubmit}>
-            送出
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => startSubmit(onSubmit)}
+            disabled={submitPending}
+          >
+            {submitPending ? "送出中..." : "送出"}
           </Button>
         </div>
       </div>

--- a/apps/portal/app/approve/_components/signature-pad.tsx
+++ b/apps/portal/app/approve/_components/signature-pad.tsx
@@ -80,7 +80,7 @@ export function SignaturePad({
           <TabsContent value="draw" className="space-y-2">
             <div
               ref={canvasBoxRef}
-              className="overflow-hidden rounded border bg-background"
+              className="overflow-hidden rounded border bg-white"
             >
               <SignatureCanvas
                 key={canvasWidth}
@@ -122,7 +122,7 @@ export function SignaturePad({
               <img
                 src={uploaded}
                 alt="signature preview"
-                className="max-h-40 rounded border bg-background"
+                className="max-h-40 rounded border bg-white"
               />
             )}
           </TabsContent>
@@ -134,7 +134,7 @@ export function SignaturePad({
             <img
               src={savedSignature}
               alt="last signature"
-              className="h-12 bg-background"
+              className="h-12 bg-white"
             />
             <span className="text-xs text-muted-foreground">上次簽名</span>
             <Button

--- a/apps/portal/app/approve/_components/signing-field.tsx
+++ b/apps/portal/app/approve/_components/signing-field.tsx
@@ -27,9 +27,12 @@ export function SigningField({
     height: field.height * pageSize.height,
   }
 
+  // Fields sit on top of a PDF (always white) so they must stay readable
+  // regardless of the portal's dark/light theme. Using `bg-background` would
+  // invert to near-black in dark mode and swallow the signature ink.
   if (field.category === "signature") {
     return (
-      <div className="absolute rounded border bg-background" style={style}>
+      <div className="absolute rounded border" style={style}>
         {value ? (
           <SignaturePad
             savedSignature={savedSignature}
@@ -52,7 +55,7 @@ export function SigningField({
             trigger={
               <button
                 type="button"
-                className="h-full w-full rounded-none text-xs text-muted-foreground hover:bg-muted/40"
+                className="h-full w-full rounded-none text-xs text-muted-foreground hover:bg-black/5"
               >
                 點擊簽名
               </button>
@@ -64,12 +67,12 @@ export function SigningField({
   }
 
   return (
-    <div className="absolute rounded border bg-background" style={style}>
+    <div className="absolute rounded border" style={style}>
       <input
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={field.label ?? def.label}
-        className="h-full w-full bg-transparent px-1 text-xs outline-none"
+        className="h-full w-full bg-transparent px-1 text-xs text-black outline-none placeholder:text-neutral-400"
       />
     </div>
   )

--- a/apps/portal/app/approve/_components/signing-view.tsx
+++ b/apps/portal/app/approve/_components/signing-view.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useState, useTransition } from "react"
 import dynamic from "next/dynamic"
 import { useRouter } from "next/navigation"
 import { useQueryClient } from "@tanstack/react-query"
@@ -64,6 +64,7 @@ export function SigningView({
 
   const router = useRouter()
   const queryClient = useQueryClient()
+  const [submitPending, startSubmit] = useTransition()
 
   const savedSignature =
     savedValues.find((v) => v.category === "signature")?.value ?? null
@@ -98,8 +99,13 @@ export function SigningView({
             進度 {filledCount}/{totalFields}
           </p>
         </div>
-        <Button size="sm" type="button" onClick={onSubmit}>
-          送出簽核
+        <Button
+          size="sm"
+          type="button"
+          onClick={() => startSubmit(onSubmit)}
+          disabled={submitPending}
+        >
+          {submitPending ? "送出中..." : "送出簽核"}
         </Button>
       </div>
 

--- a/apps/portal/app/bento/_components/confirm-dialog.tsx
+++ b/apps/portal/app/bento/_components/confirm-dialog.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import type { ReactNode } from "react"
+import { useState, useTransition, type ReactNode } from "react"
 
 import {
   AlertDialog,
@@ -21,7 +21,7 @@ interface ConfirmDialogProps {
   confirmText?: string
   cancelText?: string
   variant?: "default" | "destructive"
-  onConfirm: () => void
+  onConfirm: () => void | Promise<void>
 }
 
 export function ConfirmDialog({
@@ -33,8 +33,29 @@ export function ConfirmDialog({
   variant = "default",
   onConfirm,
 }: ConfirmDialogProps) {
+  const [open, setOpen] = useState(false)
+  const [pending, startTransition] = useTransition()
+
+  function handleConfirm(e: React.MouseEvent<HTMLButtonElement>) {
+    // Hold the dialog open until the async work finishes so a spam-click
+    // can't fire onConfirm twice. AlertDialogAction would auto-close otherwise.
+    e.preventDefault()
+    startTransition(async () => {
+      try {
+        await onConfirm()
+      } finally {
+        setOpen(false)
+      }
+    })
+  }
+
   return (
-    <AlertDialog>
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!pending) setOpen(next)
+      }}
+    >
       <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>
       <AlertDialogContent>
         <AlertDialogHeader>
@@ -42,16 +63,17 @@ export function ConfirmDialog({
           <AlertDialogDescription>{description}</AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel>{cancelText}</AlertDialogCancel>
+          <AlertDialogCancel disabled={pending}>{cancelText}</AlertDialogCancel>
           <AlertDialogAction
-            onClick={onConfirm}
+            onClick={handleConfirm}
+            disabled={pending}
             className={
               variant === "destructive"
                 ? "text-destructive-foreground bg-destructive hover:bg-destructive/90"
                 : ""
             }
           >
-            {confirmText}
+            {pending ? "處理中..." : confirmText}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/apps/portal/app/bento/_components/order-detail.tsx
+++ b/apps/portal/app/bento/_components/order-detail.tsx
@@ -75,8 +75,13 @@ export function OrderDetail({ orderId }: { orderId: string }) {
           <AddOrderItemDialog orderId={orderId} />
           {isAdmin && (
             <>
-              <Button variant="outline" size="sm" onClick={handleClose}>
-                關閉訂單
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleClose}
+                disabled={closeOrder.isPending}
+              >
+                {closeOrder.isPending ? "關閉中..." : "關閉訂單"}
               </Button>
               <ConfirmDialog
                 trigger={

--- a/apps/portal/app/leave/_components/confirm-dialog.tsx
+++ b/apps/portal/app/leave/_components/confirm-dialog.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import type { ReactNode } from "react"
+import { useState, useTransition, type ReactNode } from "react"
 
 import {
   AlertDialog,
@@ -21,7 +21,7 @@ interface ConfirmDialogProps {
   confirmText?: string
   cancelText?: string
   variant?: "default" | "destructive"
-  onConfirm: () => void
+  onConfirm: () => void | Promise<void>
 }
 
 export function ConfirmDialog({
@@ -33,8 +33,29 @@ export function ConfirmDialog({
   variant = "default",
   onConfirm,
 }: ConfirmDialogProps) {
+  const [open, setOpen] = useState(false)
+  const [pending, startTransition] = useTransition()
+
+  function handleConfirm(e: React.MouseEvent<HTMLButtonElement>) {
+    // Hold the dialog open until the async work finishes so a spam-click
+    // can't fire onConfirm twice. AlertDialogAction would auto-close otherwise.
+    e.preventDefault()
+    startTransition(async () => {
+      try {
+        await onConfirm()
+      } finally {
+        setOpen(false)
+      }
+    })
+  }
+
   return (
-    <AlertDialog>
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!pending) setOpen(next)
+      }}
+    >
       <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>
       <AlertDialogContent>
         <AlertDialogHeader>
@@ -42,16 +63,17 @@ export function ConfirmDialog({
           <AlertDialogDescription>{description}</AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel>{cancelText}</AlertDialogCancel>
+          <AlertDialogCancel disabled={pending}>{cancelText}</AlertDialogCancel>
           <AlertDialogAction
-            onClick={onConfirm}
+            onClick={handleConfirm}
+            disabled={pending}
             className={
               variant === "destructive"
                 ? "text-destructive-foreground bg-destructive hover:bg-destructive/90"
                 : ""
             }
           >
-            {confirmText}
+            {pending ? "處理中..." : confirmText}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/apps/portal/components/sign-in-button.tsx
+++ b/apps/portal/components/sign-in-button.tsx
@@ -1,24 +1,30 @@
 "use client"
 
+import { useTransition } from "react"
+
 import { Button } from "@workspace/ui/components/button"
 
 import { createClient } from "@/lib/supabase/client"
 
 export function SignInButton() {
-  async function onClick() {
-    const supabase = createClient()
-    await supabase.auth.signInWithOAuth({
-      provider: "keycloak",
-      options: {
-        scopes: "openid",
-        redirectTo: `${window.location.origin}/auth/callback`,
-      },
+  const [pending, startTransition] = useTransition()
+
+  function onClick() {
+    startTransition(async () => {
+      const supabase = createClient()
+      await supabase.auth.signInWithOAuth({
+        provider: "keycloak",
+        options: {
+          scopes: "openid",
+          redirectTo: `${window.location.origin}/auth/callback`,
+        },
+      })
     })
   }
 
   return (
-    <Button onClick={onClick} className="w-full">
-      Continue with Keycloak
+    <Button onClick={onClick} disabled={pending} className="w-full">
+      {pending ? "Redirecting..." : "Continue with Keycloak"}
     </Button>
   )
 }

--- a/apps/portal/components/sign-out-button.tsx
+++ b/apps/portal/components/sign-out-button.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useTransition } from "react"
 import { useRouter } from "next/navigation"
 
 import { Button } from "@workspace/ui/components/button"
@@ -8,17 +9,20 @@ import { createClient } from "@/lib/supabase/client"
 
 export function SignOutButton() {
   const router = useRouter()
+  const [pending, startTransition] = useTransition()
 
-  async function onClick() {
-    const supabase = createClient()
-    await supabase.auth.signOut()
-    router.replace("/auth/login")
-    router.refresh()
+  function onClick() {
+    startTransition(async () => {
+      const supabase = createClient()
+      await supabase.auth.signOut()
+      router.replace("/auth/login")
+      router.refresh()
+    })
   }
 
   return (
-    <Button variant="outline" size="sm" onClick={onClick}>
-      Sign out
+    <Button variant="outline" size="sm" onClick={onClick} disabled={pending}>
+      {pending ? "Signing out..." : "Sign out"}
     </Button>
   )
 }


### PR DESCRIPTION
## Summary

Two UX bugs spotted today, one root cause each:

1. **Mutating buttons don't disable during flight** — spam-click on `/approve/new/:id` 送出, signing 送出簽核, sign-in, sign-out, bento 關閉訂單, and every destructive ConfirmDialog across approve/bento/leave fires the action twice.
2. **Dark theme makes the signature field go solid black** on `/approve/sign/:id` because the overlay inherits `bg-background`, which flips to near-black in dark mode and swallows the black ink.

## What changed

### Double-submit guard (one pattern, eight call sites)

| File | Before | After |
|------|--------|-------|
| `approve/_components/confirm-dialog.tsx` | auto-closes on click, `onConfirm` fires without lock | holds open through the async `onConfirm` via `useTransition`, disables both Cancel/Action, swaps label to "處理中..." |
| `bento/_components/confirm-dialog.tsx` | same | same |
| `leave/_components/confirm-dialog.tsx` | same | same |
| `approve/_components/document-editor.tsx` | 送出 button fires onSubmit with no feedback | `useTransition` + `disabled` + "送出中..." |
| `approve/_components/signing-view.tsx` | 送出簽核 same | same pattern |
| `bento/_components/order-detail.tsx` | 關閉訂單 | uses `closeOrder.isPending` + "關閉中..." |
| `components/sign-in-button.tsx` | OAuth redirect fires without lock | `useTransition` + "Redirecting..." |
| `components/sign-out-button.tsx` | signOut + replace, no lock | `useTransition` + "Signing out..." |

The ConfirmDialog fix also stops the backdrop/ESC from closing the dialog mid-request, so we can't orphan the async work with a dangling modal close.

### Signature visibility

PDFs are always white. The signature overlay and the signature pad both used `bg-background`, which follows `next-themes` and becomes near-black in dark mode — hiding both the placed signature and (worse) the ink while the user is drawing.

- `signing-field.tsx` wrappers: dropped `bg-background`, now transparent so the white PDF shows through and dark ink is visible in both themes
- Text-field overlay: forced `text-black` + `placeholder:text-neutral-400` for the same reason
- `signature-pad.tsx` canvas + upload preview + last-signature preview: pinned to `bg-white` — WYSIWYG with the final PDF look

## Test plan

- [ ] Hard-click 送出 / 送出簽核 / 送出 rapidly → only one request fires, button shows loading label
- [ ] Open any delete ConfirmDialog → spam confirm → single mutation, dialog holds open until it returns
- [ ] Sign out → button shows "Signing out..." while redirect runs
- [ ] `/approve/sign/:id` in dark theme → sign box transparent, placed signature visible on white PDF
- [ ] Signature pad in dark theme → draw black ink on white canvas, visible while drawing
- [ ] Light theme still looks correct in all the above