### PR TITLE
feat(trip): make signature dynamic — stamp at view, not at upload

### DIFF
--- a/apps/portal/app/trip/_components/admin-folder-list.tsx
+++ b/apps/portal/app/trip/_components/admin-folder-list.tsx
@@ -8,8 +8,13 @@ import { Button } from "@workspace/ui/components/button"
 import { Skeleton } from "@workspace/ui/components/skeleton"
 
 import {
+  useTripMemberSignatures,
+  type MemberSignature,
+} from "@/hooks/trip/use-sign-prefs"
+import {
   useDownloadAllFiles,
   useDownloadUserFiles,
+  type SignConfig,
 } from "@/hooks/trip/use-trip-files"
 import type { TripFileWithUser } from "@/lib/trip/types"
 
@@ -38,23 +43,45 @@ function groupByUser(files: TripFileWithUser[]): Folder[] {
   )
 }
 
+// Build a map<userId, SignConfig> from the RPC result. A user appears only if
+// they have a signature AND have toggled signing on.
+function buildSignMap(
+  members: Map<string, MemberSignature> | undefined
+): Map<string, SignConfig> {
+  const out = new Map<string, SignConfig>()
+  if (!members) return out
+  for (const [userId, m] of members) {
+    if (m.enabled && m.signature) {
+      out.set(userId, { signature: m.signature, corner: m.corner })
+    }
+  }
+  return out
+}
+
 export function AdminFolderList({
+  tripId,
   tripName,
   files,
   isLoading,
   canDelete,
 }: {
+  tripId: string
   tripName: string
   files: TripFileWithUser[]
   isLoading: boolean
   canDelete: boolean
 }) {
   const folders = useMemo(() => groupByUser(files), [files])
+  const memberSigsQuery = useTripMemberSignatures(tripId)
+  const signMap = useMemo(
+    () => buildSignMap(memberSigsQuery.data),
+    [memberSigsQuery.data]
+  )
   const downloadAll = useDownloadAllFiles()
 
   const handleDownloadAll = async () => {
     try {
-      await downloadAll.mutateAsync({ tripName, files })
+      await downloadAll.mutateAsync({ tripName, files, memberSigns: signMap })
       toast.success("壓縮完成")
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "下載失敗")
@@ -104,6 +131,7 @@ export function AdminFolderList({
               key={folder.userId}
               folder={folder}
               tripName={tripName}
+              memberSign={signMap.get(folder.userId) ?? null}
               canDelete={canDelete}
             />
           ))}
@@ -116,10 +144,12 @@ export function AdminFolderList({
 function AdminFolder({
   folder,
   tripName,
+  memberSign,
   canDelete,
 }: {
   folder: Folder
   tripName: string
+  memberSign: SignConfig
   canDelete: boolean
 }) {
   const [open, setOpen] = useState(false)
@@ -131,6 +161,7 @@ function AdminFolder({
         tripName,
         userName: folder.userName,
         files: folder.files,
+        memberSign,
       })
       toast.success("壓縮完成")
     } catch (error) {
@@ -177,6 +208,7 @@ function AdminFolder({
               key={file.id}
               tripId={file.trip_id}
               file={file}
+              sign={memberSign}
               canEdit={false}
               canDelete={canDelete}
             />

--- a/apps/portal/app/trip/_components/file-card.tsx
+++ b/apps/portal/app/trip/_components/file-card.tsx
@@ -9,6 +9,7 @@ import {
   useDeleteTripFile,
   useDownloadSingleFile,
   useOpenTripFile,
+  type SignConfig,
 } from "@/hooks/trip/use-trip-files"
 import type { TripFileWithUser } from "@/lib/trip/types"
 
@@ -18,11 +19,14 @@ import { EditDescriptionDialog } from "./edit-description-dialog"
 export function FileCard({
   tripId,
   file,
+  sign,
   canEdit,
   canDelete,
 }: {
   tripId: string
   file: TripFileWithUser
+  // Resolved sign config for this file's owner. Null = render unsigned.
+  sign: SignConfig
   canEdit: boolean
   canDelete: boolean
 }) {
@@ -45,8 +49,8 @@ export function FileCard({
   const handleOpen = async () => {
     try {
       await openFile.mutateAsync({
-        storage_path: file.storage_path,
-        filename: file.filename,
+        file: { storage_path: file.storage_path, filename: file.filename },
+        sign,
       })
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "開啟失敗")
@@ -56,8 +60,8 @@ export function FileCard({
   const handleDownload = async () => {
     try {
       await downloadFile.mutateAsync({
-        storage_path: file.storage_path,
-        filename: file.filename,
+        file: { storage_path: file.storage_path, filename: file.filename },
+        sign,
       })
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "下載失敗")
@@ -84,6 +88,7 @@ export function FileCard({
         className="size-8 shrink-0 text-muted-foreground"
         aria-label="開啟"
         onClick={handleOpen}
+        disabled={openFile.isPending}
       >
         <ExternalLink className="size-4" />
       </Button>
@@ -93,6 +98,7 @@ export function FileCard({
         className="size-8 shrink-0 text-muted-foreground"
         aria-label="下載"
         onClick={handleDownload}
+        disabled={downloadFile.isPending}
       >
         <Download className="size-4" />
       </Button>

--- a/apps/portal/app/trip/_components/file-list.tsx
+++ b/apps/portal/app/trip/_components/file-list.tsx
@@ -2,6 +2,10 @@
 
 import { Skeleton } from "@workspace/ui/components/skeleton"
 
+import { useSignPrefs } from "@/hooks/trip/use-sign-prefs"
+import type { SignConfig } from "@/hooks/trip/use-trip-files"
+import { useAuth } from "@/hooks/use-auth"
+import { useSavedSignature } from "@/hooks/use-saved-signature"
 import type { TripFileWithUser } from "@/lib/trip/types"
 
 import { FileCard } from "./file-card"
@@ -17,6 +21,13 @@ export function FileList({
   isLoading: boolean
   canEdit: boolean
 }) {
+  const { user } = useAuth()
+  const { signature } = useSavedSignature(user?.id)
+  const { prefs } = useSignPrefs(user?.id)
+
+  const sign: SignConfig =
+    prefs.enabled && signature ? { signature, corner: prefs.corner } : null
+
   if (isLoading && files.length === 0) {
     return (
       <section className="flex flex-col gap-4">
@@ -47,6 +58,7 @@ export function FileList({
               key={file.id}
               tripId={tripId}
               file={file}
+              sign={sign}
               canEdit={canEdit}
               canDelete={canEdit}
             />

--- a/apps/portal/app/trip/_components/trip-detail.tsx
+++ b/apps/portal/app/trip/_components/trip-detail.tsx
@@ -60,6 +60,7 @@ export function TripDetail({ tripId }: { tripId: string }) {
 
       {isAdmin ? (
         <AdminFolderList
+          tripId={tripId}
           tripName={trip.name}
           files={files ?? []}
           isLoading={filesLoading}

--- a/apps/portal/app/trip/_components/upload-zone.tsx
+++ b/apps/portal/app/trip/_components/upload-zone.tsx
@@ -1,13 +1,14 @@
 "use client"
 
 import { Pencil, Upload } from "lucide-react"
-import { useEffect, useRef, useState } from "react"
+import { useRef, useState } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@workspace/ui/components/button"
 import { Checkbox } from "@workspace/ui/components/checkbox"
 
 import { SignaturePad } from "@/components/signature-pad"
+import { useSignPrefs, useUpdateSignPrefs } from "@/hooks/trip/use-sign-prefs"
 import { useUploadTripFiles } from "@/hooks/trip/use-trip-files"
 import {
   useSavedSignature,
@@ -15,10 +16,6 @@ import {
 } from "@/hooks/use-saved-signature"
 import { TRIP_FILE_ACCEPT } from "@/lib/trip/convert"
 import { SIGNATURE_POSITIONS, type SignaturePosition } from "@/lib/trip/sign"
-
-const LS_ENABLED = "trip:auto-sign:enabled"
-const LS_POSITION = "trip:auto-sign:position"
-const VALID_POSITIONS = new Set<SignaturePosition>(["tl", "tr", "bl", "br"])
 
 export function UploadZone({
   tripId,
@@ -35,49 +32,38 @@ export function UploadZone({
   } | null>(null)
   const upload = useUploadTripFiles(tripId)
 
-  const { signature, isLoading: sigLoading } = useSavedSignature(userId)
+  const { signature } = useSavedSignature(userId)
   const saveSignature = useSaveSignature(userId)
+  const { prefs } = useSignPrefs(userId)
+  const updatePrefs = useUpdateSignPrefs(userId)
 
-  const [autoSign, setAutoSign] = useState(false)
-  const [position, setPosition] = useState<SignaturePosition>("br")
-  const [hydrated, setHydrated] = useState(false)
-
-  // Load preferences from localStorage after mount, then default-enable when
-  // user has a signature on file. We only auto-enable on first ever visit
-  // (no stored value yet) so we don't fight the user's own off-toggle.
-  useEffect(() => {
-    const storedEnabled = localStorage.getItem(LS_ENABLED)
-    const storedPos = localStorage.getItem(LS_POSITION)
-    if (storedPos && VALID_POSITIONS.has(storedPos as SignaturePosition)) {
-      setPosition(storedPos as SignaturePosition)
+  const onAutoSignChange = async (next: boolean) => {
+    if (next && !signature) {
+      toast.error("還沒設定簽名 — 先按「設定簽名」")
+      return
     }
-    if (storedEnabled !== null) {
-      setAutoSign(storedEnabled === "1")
+    try {
+      await updatePrefs.mutateAsync({ enabled: next })
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "儲存偏好失敗")
     }
-    setHydrated(true)
-  }, [])
-
-  useEffect(() => {
-    if (!hydrated) return
-    if (localStorage.getItem(LS_ENABLED) === null && signature && !sigLoading) {
-      setAutoSign(true)
-    }
-  }, [hydrated, signature, sigLoading])
-
-  const onAutoSignChange = (next: boolean) => {
-    setAutoSign(next)
-    localStorage.setItem(LS_ENABLED, next ? "1" : "0")
   }
-  const onPositionChange = (next: SignaturePosition) => {
-    setPosition(next)
-    localStorage.setItem(LS_POSITION, next)
+
+  const onCornerChange = async (next: SignaturePosition) => {
+    try {
+      await updatePrefs.mutateAsync({ corner: next })
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "儲存偏好失敗")
+    }
   }
 
   const handleSignatureConfirm = async (dataUrl: string) => {
     try {
       await saveSignature.mutateAsync(dataUrl)
       toast.success("簽名已儲存")
-      if (!autoSign) onAutoSignChange(true)
+      if (!prefs.enabled) {
+        await updatePrefs.mutateAsync({ enabled: true })
+      }
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "儲存簽名失敗")
     }
@@ -87,18 +73,11 @@ export function UploadZone({
     const files = fileList ? Array.from(fileList) : []
     if (files.length === 0) return
 
-    if (autoSign && !signature) {
-      toast.error("打勾自動簽名但還沒設定簽名 — 先按「編輯簽名」")
-      return
-    }
-
     setProgress({ done: 0, total: files.length })
     try {
       await upload.mutateAsync({
         userId,
         files,
-        signature:
-          autoSign && signature ? { dataUrl: signature, position } : null,
         onProgress: (done, total) => setProgress({ done, total }),
       })
       toast.success(
@@ -166,24 +145,24 @@ export function UploadZone({
       <div className="flex flex-wrap items-center gap-x-4 gap-y-3 rounded-xl border border-border bg-card p-4">
         <label className="flex items-center gap-2">
           <Checkbox
-            checked={autoSign}
+            checked={prefs.enabled}
             onCheckedChange={(v) => onAutoSignChange(v === true)}
-            disabled={isUploading}
+            disabled={updatePrefs.isPending}
           />
           <span className="text-sm">自動簽名（每頁）</span>
         </label>
 
-        {autoSign && (
+        {prefs.enabled && (
           <div className="flex items-center gap-1">
             {SIGNATURE_POSITIONS.map((p) => (
               <Button
                 key={p.id}
                 type="button"
                 size="sm"
-                variant={position === p.id ? "default" : "outline"}
+                variant={prefs.corner === p.id ? "default" : "outline"}
                 className="h-7 px-2 text-xs"
-                onClick={() => onPositionChange(p.id)}
-                disabled={isUploading}
+                onClick={() => onCornerChange(p.id)}
+                disabled={updatePrefs.isPending}
               >
                 {p.label}
               </Button>
@@ -198,7 +177,6 @@ export function UploadZone({
               size="sm"
               variant="ghost"
               className="ml-auto h-7 px-2 text-xs"
-              disabled={isUploading}
             >
               <Pencil className="size-3" />
               {signature ? "編輯簽名" : "設定簽名"}

--- a/apps/portal/hooks/trip/use-sign-prefs.ts
+++ b/apps/portal/hooks/trip/use-sign-prefs.ts
@@ -1,0 +1,121 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { createClient } from "@/lib/supabase/client"
+import type { SignaturePosition } from "@/lib/trip/sign"
+
+import { queryKeys } from "./query-keys"
+
+export type SignPrefs = {
+  enabled: boolean
+  corner: SignaturePosition
+}
+
+const DEFAULT_PREFS: SignPrefs = { enabled: false, corner: "br" }
+
+const PREFS_KEY = (userId: string) => ["trip", "sign-prefs", userId] as const
+
+export function useSignPrefs(userId: string | null | undefined) {
+  const supabase = createClient()
+
+  const query = useQuery({
+    queryKey: PREFS_KEY(userId ?? "anon"),
+    enabled: !!userId,
+    queryFn: async (): Promise<SignPrefs> => {
+      const { data, error } = await supabase
+        .from("user_sign_prefs")
+        .select("enabled, corner")
+        .eq("user_id", userId!)
+        .maybeSingle()
+      if (error) throw error
+      if (!data) return DEFAULT_PREFS
+      return {
+        enabled: !!data.enabled,
+        corner: (data.corner ?? "br") as SignaturePosition,
+      }
+    },
+    placeholderData: DEFAULT_PREFS,
+  })
+
+  return { prefs: query.data ?? DEFAULT_PREFS, ...query }
+}
+
+export function useUpdateSignPrefs(userId: string | null | undefined) {
+  const supabase = createClient()
+  const qc = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (next: Partial<SignPrefs>) => {
+      if (!userId) throw new Error("not signed in")
+      const { error } = await supabase.from("user_sign_prefs").upsert(
+        {
+          user_id: userId,
+          enabled: next.enabled,
+          corner: next.corner,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: "user_id" }
+      )
+      if (error) throw error
+    },
+    onMutate: async (next) => {
+      if (!userId) return
+      await qc.cancelQueries({ queryKey: PREFS_KEY(userId) })
+      const prev = qc.getQueryData<SignPrefs>(PREFS_KEY(userId))
+      qc.setQueryData<SignPrefs>(PREFS_KEY(userId), {
+        enabled: next.enabled ?? prev?.enabled ?? false,
+        corner: next.corner ?? prev?.corner ?? "br",
+      })
+      return { prev }
+    },
+    onError: (_e, _v, ctx) => {
+      if (userId && ctx?.prev) {
+        qc.setQueryData(PREFS_KEY(userId), ctx.prev)
+      }
+    },
+    onSettled: () => {
+      if (userId) qc.invalidateQueries({ queryKey: PREFS_KEY(userId) })
+    },
+  })
+}
+
+export type MemberSignature = {
+  member_id: string
+  signature: string
+  enabled: boolean
+  corner: SignaturePosition
+}
+
+// Admin-only: fetch saved signature + pref for every member who has files
+// in the trip. RPC enforces is_trip_admin() server-side.
+export function useTripMemberSignatures(tripId: string | undefined) {
+  const supabase = createClient()
+
+  return useQuery({
+    queryKey: [...queryKeys.files.byTrip(tripId ?? ""), "member-sigs"] as const,
+    enabled: !!tripId,
+    queryFn: async (): Promise<Map<string, MemberSignature>> => {
+      const { data, error } = await supabase.rpc(
+        "trip_admin_get_member_signatures",
+        { p_trip_id: tripId! }
+      )
+      if (error) throw error
+      const map = new Map<string, MemberSignature>()
+      for (const row of (data ?? []) as Array<{
+        member_id: string
+        signature: string
+        enabled: boolean
+        corner: string
+      }>) {
+        map.set(row.member_id, {
+          member_id: row.member_id,
+          signature: row.signature,
+          enabled: !!row.enabled,
+          corner: (row.corner ?? "br") as SignaturePosition,
+        })
+      }
+      return map
+    },
+  })
+}

--- a/apps/portal/hooks/trip/use-trip-files.ts
+++ b/apps/portal/hooks/trip/use-trip-files.ts
@@ -13,6 +13,14 @@ import { queryKeys } from "./query-keys"
 
 const SIGNED_URL_TTL_SECONDS = 60 * 10
 
+// Optional sign config passed by callers. If `signature` and `enabled` is
+// true, we stamp the corresponding corner. Otherwise the file is returned /
+// served exactly as it sits in storage.
+export type SignConfig = {
+  signature: string
+  corner: SignaturePosition
+} | null
+
 export function useTripFiles(tripId: string | undefined) {
   const supabase = createClient()
 
@@ -59,6 +67,8 @@ export function useTripFiles(tripId: string | undefined) {
   })
 }
 
+// Upload always stores the unsigned, converted PDF. Signing is now applied
+// at view / download time so that the toggle stays dynamic.
 export function useUploadTripFiles(tripId: string) {
   const supabase = createClient()
   const queryClient = useQueryClient()
@@ -67,7 +77,6 @@ export function useUploadTripFiles(tripId: string) {
     mutationFn: async (params: {
       userId: string
       files: File[]
-      signature?: { dataUrl: string; position: SignaturePosition } | null
       onProgress?: (done: number, total: number) => void
     }) => {
       const total = params.files.length
@@ -75,19 +84,12 @@ export function useUploadTripFiles(tripId: string) {
 
       for (const file of params.files) {
         const converted = await fileToPdf(file)
-        const blob = params.signature
-          ? await stampSignatureOnPdf(
-              converted.blob,
-              params.signature.dataUrl,
-              params.signature.position
-            )
-          : converted.blob
         const fileUuid = crypto.randomUUID()
         const path = tripFilePath(tripId, params.userId, fileUuid)
 
         const upload = await supabase.storage
           .from(TRIP_BUCKET)
-          .upload(path, blob, { contentType: "application/pdf" })
+          .upload(path, converted.blob, { contentType: "application/pdf" })
         if (upload.error) throw upload.error
 
         const insert = await supabase.from("trip_files").insert({
@@ -95,10 +97,9 @@ export function useUploadTripFiles(tripId: string) {
           user_id: params.userId,
           storage_path: path,
           filename: converted.filename,
-          size_bytes: blob.size,
+          size_bytes: converted.blob.size,
         })
         if (insert.error) {
-          // Best-effort cleanup of the orphaned object on DB failure.
           await supabase.storage.from(TRIP_BUCKET).remove([path])
           throw insert.error
         }
@@ -159,41 +160,73 @@ export function useDeleteTripFile(tripId: string) {
   })
 }
 
-// Open one file in a new tab via a short-lived signed URL.
+// --- Read sites: fetch + (optionally) stamp + open / save / zip --------
+
+async function fetchAndMaybeStamp(
+  supabase: ReturnType<typeof createClient>,
+  storagePath: string,
+  sign: SignConfig
+): Promise<Blob> {
+  const { data, error } = await supabase.storage
+    .from(TRIP_BUCKET)
+    .createSignedUrl(storagePath, SIGNED_URL_TTL_SECONDS)
+  if (error) throw error
+
+  const res = await fetch(data.signedUrl)
+  if (!res.ok) throw new Error(`下載失敗（${res.status}）`)
+  const raw = await res.blob()
+  if (!sign) return raw
+  return stampSignatureOnPdf(raw, sign.signature, sign.corner)
+}
+
+// Open in new tab. Always uses a blob URL since the bytes may have been
+// stamped client-side; revoke on next tick after the tab takes over.
 export function useOpenTripFile() {
   const supabase = createClient()
 
   return useMutation({
-    mutationFn: async (file: { storage_path: string; filename: string }) => {
-      const { data, error } = await supabase.storage
-        .from(TRIP_BUCKET)
-        .createSignedUrl(file.storage_path, SIGNED_URL_TTL_SECONDS, {
-          download: file.filename,
-        })
-      if (error) throw error
-      window.open(data.signedUrl, "_blank", "noopener,noreferrer")
+    mutationFn: async (params: {
+      file: { storage_path: string; filename: string }
+      sign: SignConfig
+    }) => {
+      const blob = await fetchAndMaybeStamp(
+        supabase,
+        params.file.storage_path,
+        params.sign
+      )
+      const url = URL.createObjectURL(blob)
+      window.open(url, "_blank", "noopener,noreferrer")
+      setTimeout(() => URL.revokeObjectURL(url), 60_000)
     },
   })
 }
 
-// Bulk download helpers: build signed URLs, then stream into a zip.
+export function useDownloadSingleFile() {
+  const supabase = createClient()
 
-async function signMany(
-  supabase: ReturnType<typeof createClient>,
-  paths: string[]
-): Promise<Map<string, string>> {
-  const { data, error } = await supabase.storage
-    .from(TRIP_BUCKET)
-    .createSignedUrls(paths, SIGNED_URL_TTL_SECONDS)
-  if (error) throw error
-  const map = new Map<string, string>()
-  for (const row of data ?? []) {
-    if (row.signedUrl && row.path) map.set(row.path, row.signedUrl)
-  }
-  return map
+  return useMutation({
+    mutationFn: async (params: {
+      file: { storage_path: string; filename: string }
+      sign: SignConfig
+    }) => {
+      const blob = await fetchAndMaybeStamp(
+        supabase,
+        params.file.storage_path,
+        params.sign
+      )
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement("a")
+      a.href = url
+      a.download = params.file.filename
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      URL.revokeObjectURL(url)
+    },
+  })
 }
 
-// Admin: download every file uploaded by one user inside the trip.
+// Admin: zip every file from one member, stamping per the member's pref.
 export function useDownloadUserFiles() {
   const supabase = createClient()
 
@@ -202,17 +235,20 @@ export function useDownloadUserFiles() {
       tripName: string
       userName: string
       files: TripFileWithUser[]
+      memberSign: SignConfig // pre-resolved by caller from RPC
     }) => {
       if (params.files.length === 0) throw new Error("這位成員還沒有檔案")
-      const urlMap = await signMany(
-        supabase,
-        params.files.map((f) => f.storage_path)
-      )
       const used = new Set<string>()
-      const entries = params.files.map((f) => ({
-        name: uniquifyName(used, f.filename),
-        url: urlMap.get(f.storage_path) ?? "",
-      }))
+      const entries = await Promise.all(
+        params.files.map(async (f) => ({
+          name: uniquifyName(used, f.filename),
+          blob: await fetchAndMaybeStamp(
+            supabase,
+            f.storage_path,
+            params.memberSign
+          ),
+        }))
+      )
       await saveZip(
         `${safeFolderName(params.tripName)}_${safeFolderName(params.userName)}.zip`,
         entries
@@ -221,7 +257,9 @@ export function useDownloadUserFiles() {
   })
 }
 
-// Admin: download all files in trip, grouped into per-user folders.
+// Admin: zip every file in trip, stamping each according to its uploader's
+// pref. The caller passes a `Map<userId, SignConfig>` already resolved via
+// the RPC so we don't fan-out per-file lookups.
 export function useDownloadAllFiles() {
   const supabase = createClient()
 
@@ -229,47 +267,24 @@ export function useDownloadAllFiles() {
     mutationFn: async (params: {
       tripName: string
       files: TripFileWithUser[]
+      memberSigns: Map<string, SignConfig>
     }) => {
       if (params.files.length === 0) throw new Error("這個 trip 還沒有檔案")
-      const urlMap = await signMany(
-        supabase,
-        params.files.map((f) => f.storage_path)
-      )
       const usedPerFolder = new Map<string, Set<string>>()
-      const entries = params.files.map((f) => {
-        const folder = safeFolderName(f.user?.name ?? f.user_id ?? "unknown")
-        const used = usedPerFolder.get(folder) ?? new Set<string>()
-        usedPerFolder.set(folder, used)
-        const name = uniquifyName(used, f.filename)
-        return {
-          name: `${folder}/${name}`,
-          url: urlMap.get(f.storage_path) ?? "",
-        }
-      })
-      await saveZip(`${safeFolderName(params.tripName)}.zip`, entries)
-    },
-  })
-}
-
-// Member: single-file fallback when the user wants a local copy.
-export function useDownloadSingleFile() {
-  const supabase = createClient()
-
-  return useMutation({
-    mutationFn: async (file: { storage_path: string; filename: string }) => {
-      const { data, error } = await supabase.storage
-        .from(TRIP_BUCKET)
-        .createSignedUrl(file.storage_path, SIGNED_URL_TTL_SECONDS, {
-          download: file.filename,
+      const entries = await Promise.all(
+        params.files.map(async (f) => {
+          const folder = safeFolderName(f.user?.name ?? f.user_id ?? "unknown")
+          const used = usedPerFolder.get(folder) ?? new Set<string>()
+          usedPerFolder.set(folder, used)
+          const name = uniquifyName(used, f.filename)
+          const sign = (f.user_id && params.memberSigns.get(f.user_id)) || null
+          return {
+            name: `${folder}/${name}`,
+            blob: await fetchAndMaybeStamp(supabase, f.storage_path, sign),
+          }
         })
-      if (error) throw error
-      const a = document.createElement("a")
-      a.href = data.signedUrl
-      a.rel = "noopener noreferrer"
-      a.download = file.filename
-      document.body.appendChild(a)
-      a.click()
-      a.remove()
+      )
+      await saveZip(`${safeFolderName(params.tripName)}.zip`, entries)
     },
   })
 }

--- a/apps/portal/lib/trip/zip.ts
+++ b/apps/portal/lib/trip/zip.ts
@@ -4,7 +4,7 @@ import { downloadZip } from "client-zip"
 
 export type ZipEntry = {
   name: string
-  url: string
+  blob: Blob
 }
 
 export async function saveZip(
@@ -14,17 +14,8 @@ export async function saveZip(
   if (entries.length === 0) {
     throw new Error("沒有可下載的檔案")
   }
-
-  const inputs = entries.map(async (entry) => {
-    const res = await fetch(entry.url)
-    if (!res.ok) {
-      throw new Error(`下載 ${entry.name} 失敗（${res.status}）`)
-    }
-    return { name: entry.name, input: res }
-  })
-
-  const resolved = await Promise.all(inputs)
-  const blob = await downloadZip(resolved).blob()
+  const inputs = entries.map((e) => ({ name: e.name, input: e.blob }))
+  const blob = await downloadZip(inputs).blob()
   triggerDownload(blob, filename)
 }
 

--- a/supabase/migrations/2026-04-27-trip-dynamic-signing.sql
+++ b/supabase/migrations/2026-04-27-trip-dynamic-signing.sql
@@ -1,0 +1,68 @@
+-- Trip auto-sign V2: PDFs in storage stay unsigned. Signing is applied at
+-- view / download time using the user's saved signature + global preference.
+
+-- Per-user global signing preference. One row per user; default off.
+-- Column is `corner` rather than `position` because the latter is a reserved
+-- word in Postgres SQL grammar.
+create table public.user_sign_prefs (
+  user_id    uuid primary key references public.user_profiles(id) on delete cascade,
+  enabled    boolean not null default false,
+  corner     text not null default 'br'
+               check (corner in ('tl','tr','bl','br')),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.user_sign_prefs enable row level security;
+
+create policy "user_sign_prefs_select"
+on public.user_sign_prefs for select
+using (
+  user_id = auth.uid()
+  or public.is_trip_admin()
+);
+
+create policy "user_sign_prefs_insert_own"
+on public.user_sign_prefs for insert
+with check (user_id = auth.uid());
+
+create policy "user_sign_prefs_update_own"
+on public.user_sign_prefs for update
+using (user_id = auth.uid())
+with check (user_id = auth.uid());
+
+create policy "user_sign_prefs_delete_own"
+on public.user_sign_prefs for delete
+using (user_id = auth.uid());
+
+-- Admin batch: returns saved-signature + pref for every member who has files
+-- in the given trip. Caller must be a trip admin (enforced inside).
+create or replace function public.trip_admin_get_member_signatures(p_trip_id uuid)
+returns table (
+  member_id uuid,
+  signature text,
+  enabled   boolean,
+  corner    text
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select
+    afv.user_id                  as member_id,
+    afv.value                    as signature,
+    coalesce(p.enabled, false)   as enabled,
+    coalesce(p.corner, 'br')     as corner
+  from public.approve_user_field_values afv
+  left join public.user_sign_prefs p on p.user_id = afv.user_id
+  where afv.category = 'signature'
+    and afv.user_id in (
+      select distinct tf.user_id
+      from public.trip_files tf
+      where tf.trip_id = p_trip_id
+        and tf.user_id is not null
+    )
+    and public.is_trip_admin();
+$$;
+
+grant execute on function public.trip_admin_get_member_signatures(uuid) to authenticated;


### PR DESCRIPTION
## Why

V1 baked the signature into the PDF at upload time, so the toggle was a one-shot choice. If you uploaded with the toggle off and then turned it on, the existing files stayed unsigned. The user expectation is dynamic — tick = signed, untick = unsigned, on existing files too.

## How

PDFs in storage are now always raw (the unsigned converted output). Signing happens at every read site using the user's saved signature + a DB-backed preference.

* `user_sign_prefs` (one row per user, columns `enabled` + `corner`) replaces the V1 localStorage. Toggle / corner picker now writes through to the DB so the same state is shared across browsers and survives reloads.
* `trip_admin_get_member_signatures(trip_id)` RPC lets a trip admin resolve every member's saved signature + pref in one server-side call (RLS-checked via `is_trip_admin()`), so the bulk zip can stamp each file with the uploader's intended signature.
* Upload pipeline writes the unsigned converted PDF only.
* Open / single download / per-member zip / download-all all fetch the raw object, stamp client-side per the (user, pref) tuple, then serve.

## Test plan

- [ ] Upload a file with toggle off → file is unsigned everywhere
- [ ] Turn toggle on → same existing file now opens / downloads with the signature
- [ ] Turn toggle off → signature disappears again
- [ ] Switch corner → reflected on next open / download without re-uploading
- [ ] Admin Download All: zip contains files stamped per each member's own toggle / corner / saved signature
- [ ] Cross-app: signature drawn in `/approve` is the one used here

## Known cleanup

The two existing test files in production were uploaded under V1 and have signatures already burned in. With V2's overlay, viewing them with the toggle on will produce a double signature. Easiest fix: delete those two files via the UI and re-upload after this lands.