### PR TITLE
fix(trip): tighten admin scope + delete-order cleanup

### DIFF
--- a/apps/portal/hooks/trip/use-admin.ts
+++ b/apps/portal/hooks/trip/use-admin.ts
@@ -17,7 +17,7 @@ export function useTripAdmin() {
       if (!user) return null
       const { data: profile } = await supabase
         .from("user_profiles")
-        .select("is_admin, roles")
+        .select("roles")
         .eq("id", user.id)
         .single()
       return profile
@@ -25,11 +25,13 @@ export function useTripAdmin() {
     enabled: !!user,
   })
 
+  // Trip admin is scoped to roles.trip only — the global is_admin flag does
+  // NOT confer trip admin, because signatures are personal data and we don't
+  // want app-level role bleed across the portal. Stays in lockstep with the
+  // SQL is_trip_admin() helper.
   const roles = data?.roles as Record<string, string[]> | undefined
   const tripRoles = roles?.trip
-  const isAdmin =
-    data?.is_admin === true ||
-    (Array.isArray(tripRoles) && tripRoles.includes("admin"))
+  const isAdmin = Array.isArray(tripRoles) && tripRoles.includes("admin")
 
   return { isAdmin, isLoading }
 }

--- a/apps/portal/hooks/trip/use-trip-files.ts
+++ b/apps/portal/hooks/trip/use-trip-files.ts
@@ -100,7 +100,12 @@ export function useUploadTripFiles(tripId: string) {
           size_bytes: converted.blob.size,
         })
         if (insert.error) {
-          await supabase.storage.from(TRIP_BUCKET).remove([path])
+          const cleanup = await supabase.storage
+            .from(TRIP_BUCKET)
+            .remove([path])
+          if (cleanup.error) {
+            console.error("[trip] orphan storage cleanup failed", cleanup.error)
+          }
           throw insert.error
         }
 
@@ -142,15 +147,22 @@ export function useDeleteTripFile(tripId: string) {
 
   return useMutation({
     mutationFn: async (file: { id: string; storage_path: string }) => {
-      const { error: storageErr } = await supabase.storage
-        .from(TRIP_BUCKET)
-        .remove([file.storage_path])
-      if (storageErr) throw storageErr
+      // DB row is the source of truth — kill it first. If we removed the
+      // storage object first and then DB deletion failed (RLS, network),
+      // we'd leak a row pointing at nothing. The reverse case (DB row gone,
+      // storage object still around) is harmless: orphaned bytes get
+      // garbage-collected by a sweeper, RLS makes them unreadable anyway.
       const { error } = await supabase
         .from("trip_files")
         .delete()
         .eq("id", file.id)
       if (error) throw error
+      const cleanup = await supabase.storage
+        .from(TRIP_BUCKET)
+        .remove([file.storage_path])
+      if (cleanup.error) {
+        console.error("[trip] storage cleanup failed", cleanup.error)
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({

--- a/supabase/migrations/2026-04-27-trip-admin-scope.sql
+++ b/supabase/migrations/2026-04-27-trip-admin-scope.sql
@@ -1,0 +1,20 @@
+-- Tighten trip admin scope: signatures are personal data, so the global
+-- user_profiles.is_admin flag should NOT silently grant access to other
+-- members' saved signatures via trip_admin_get_member_signatures(). Only
+-- explicit roles.trip = ["admin"] confers trip admin.
+
+create or replace function public.is_trip_admin()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.user_profiles up
+    where up.id = auth.uid()
+      and up.roles ? 'trip'
+      and up.roles -> 'trip' ? 'admin'
+  );
+$$;


### PR DESCRIPTION
## Summary

Three review findings rolled up:

1. **Admin scope narrowed.** `is_trip_admin()` SQL helper and `useTripAdmin()` hook no longer treat `user_profiles.is_admin = true` as a trip admin. Only an explicit `roles.trip = [\"admin\"]` grants access. Signatures are personal data and we don't want app-level role bleed across the portal.
2. **Delete order swapped.** `useDeleteTripFile` now removes the DB row first, then the storage object. Reverse case (DB gone, storage still there) is harmless — orphan bytes are unreachable through RLS.
3. **Storage cleanup error visibility.** During upload rollback the storage `remove()` failure is now logged via `console.error` instead of being silently dropped.

## Verification

- Migration applied to production; before-and-after `is_trip_admin()` was checked
- No user currently has `is_admin = true`, so narrowing breaks nobody
- `loki.cs14@nycu.edu.tw` still has trip admin via `roles.trip = [\"admin\"]`
- typecheck + build green locally

## Deferred (separate issue, not this PR)

`useDownloadAllFiles` fans out unbounded `Promise.all` over every file in the trip — fine at lab scale today, but will OOM on large multi-member trips. Worth adding a concurrency cap when we cross ~50 files in one trip.