### PR TITLE
chore(portal): translate Profile note to match siblings

### DIFF
--- a/apps/portal/app/page.tsx
+++ b/apps/portal/app/page.tsx
@@ -13,7 +13,7 @@ const apps = [
   { href: "/leave", label: "Leave", note: "請假登記" },
   { href: "/approve", label: "Approve", note: "文件簽核" },
   { href: "/trip", label: "Trip", note: "出差文件" },
-  { href: "/profile", label: "Profile", note: "Your account" },
+  { href: "/profile", label: "Profile", note: "個人帳號" },
 ]
 
 export default async function Page() {


### PR DESCRIPTION
Sole stray English on the home menu — the other four notes are 4-char Chinese phrases. `個人帳號` keeps the same meaning as `Your account` and lines up visually with 便當訂購 / 請假登記 / 文件簽核 / 出差文件.