### PR TITLE
feat(profile): replace auth dump with fun lab stats

### DIFF
--- a/apps/portal/app/profile/_components/profile-stats.tsx
+++ b/apps/portal/app/profile/_components/profile-stats.tsx
@@ -1,0 +1,91 @@
+import {
+  formatBytes,
+  formatDelay,
+  leaveFlavor,
+  pickReferenceProduct,
+  type ProfileStats,
+  spendInReference,
+} from "@/lib/profile/stats"
+
+import { FieldRow, Section } from "./profile-ui"
+
+// Server Component on purpose: random product picks once per request, no
+// hydration mismatch, no client JS shipped for this.
+export function ProfileStatsView({ stats }: { stats: ProfileStats }) {
+  const product = pickReferenceProduct()
+
+  const { bento, leave, approve, trip } = stats
+  const top = bento.top_items
+  const variety =
+    bento.total_orders > 0
+      ? Math.round((bento.unique_items / bento.total_orders) * 100)
+      : 0
+
+  return (
+    <div className="flex flex-col gap-10">
+      <Section title="便當帳本" description="點過幾次、花了多少、最愛吃什麼。">
+        <FieldRow label="訂便當總次數" value={`${bento.total_orders} 次`} />
+        <FieldRow
+          label="便當總開銷"
+          value={
+            bento.total_spent === 0
+              ? "—"
+              : `NT$ ${bento.total_spent}（≈ ${spendInReference(
+                  bento.total_spent,
+                  product
+                )} ${product.unit}${product.emoji} ${product.name}）`
+          }
+        />
+        <FieldRow
+          label="本命便當"
+          value={top[0] ? `${top[0].name} × ${top[0].count}` : "還沒有最愛"}
+        />
+        <FieldRow
+          label="第二名"
+          value={top[1] ? `${top[1].name} × ${top[1].count}` : "—"}
+        />
+        <FieldRow
+          label="第三名"
+          value={top[2] ? `${top[2].name} × ${top[2].count}` : "—"}
+        />
+        <FieldRow
+          label="嚐鮮指數"
+          value={
+            bento.total_orders === 0
+              ? "—"
+              : `${variety}%（試過 ${bento.unique_items} 種品項）`
+          }
+        />
+      </Section>
+
+      <Section title="請假記錄" description="還沒被點名前的小確幸。">
+        <FieldRow label="請假總天數" value={leaveFlavor(leave.total_days)} />
+        <FieldRow
+          label="首次請假"
+          value={leave.first_date ?? "—"}
+          mono={!!leave.first_date}
+        />
+      </Section>
+
+      <Section title="簽核戰績" description="文件流轉裡的你。">
+        <FieldRow label="發起過幾份" value={`${approve.created_count} 份`} />
+        <FieldRow label="簽過幾份" value={`${approve.signed_count} 份`} />
+        <FieldRow
+          label="平均拖延"
+          value={formatDelay(approve.avg_sign_delay_seconds)}
+        />
+      </Section>
+
+      <Section title="出差紀錄" description="跑了多少趟、報帳幾個檔。">
+        <FieldRow label="跑過幾趟" value={`${trip.trips_joined} 趟`} />
+        <FieldRow label="上傳檔案數" value={`${trip.files_uploaded} 個`} />
+        <FieldRow
+          label="總憑證容量"
+          value={
+            trip.total_size_bytes > 0 ? formatBytes(trip.total_size_bytes) : "—"
+          }
+        />
+      </Section>
+    </div>
+  )
+}

--- a/apps/portal/app/profile/_components/profile-ui.tsx
+++ b/apps/portal/app/profile/_components/profile-ui.tsx
@@ -54,27 +54,3 @@ export function FieldRow({
     </div>
   )
 }
-
-export function JsonBlock({ data }: { data: unknown }) {
-  return (
-    <pre className="max-h-80 overflow-auto rounded-lg bg-muted/50 p-4 font-mono text-xs leading-relaxed text-muted-foreground">
-      {JSON.stringify(data, null, 2)}
-    </pre>
-  )
-}
-
-export function maskToken(token: string | null | undefined): string {
-  if (!token) return ""
-  if (token.length <= 16) return "•".repeat(token.length)
-  return `${token.slice(0, 8)}…${token.slice(-4)}`
-}
-
-export function formatUnixSeconds(seconds: number | undefined): string {
-  if (!seconds) return ""
-  const date = new Date(seconds * 1000)
-  const now = Date.now()
-  const diffMs = date.getTime() - now
-  const mins = Math.round(diffMs / 60_000)
-  const rel = mins >= 0 ? `in ${mins} min` : `${Math.abs(mins)} min ago`
-  return `${date.toISOString()} (${rel})`
-}

--- a/apps/portal/app/profile/page.tsx
+++ b/apps/portal/app/profile/page.tsx
@@ -3,22 +3,20 @@ import Link from "next/link"
 import { PortalShell } from "@/components/portal-shell"
 import { SignOutButton } from "@/components/sign-out-button"
 import { UserCard } from "@/components/user-card"
-import { getProfile, normalizeUser } from "@/lib/user"
+import type { ProfileStats } from "@/lib/profile/stats"
+import { createClient } from "@/lib/supabase/server"
+import { getCurrentUser } from "@/lib/user"
 
-import {
-  FieldRow,
-  JsonBlock,
-  Section,
-  formatUnixSeconds,
-  maskToken,
-} from "./_components/profile-ui"
+import { ProfileStatsView } from "./_components/profile-stats"
 
 export default async function ProfilePage() {
-  const profile = (await getProfile())!
-  const { user, session } = profile
-  const display = normalizeUser(user)
-  const identities = user.identities ?? []
-  const factors = user.factors ?? []
+  const user = (await getCurrentUser())!
+  const supabase = await createClient()
+  const { data, error } = await supabase.rpc("get_profile_stats", {
+    p_user_id: user.id,
+  })
+  if (error) throw error
+  const stats = data as ProfileStats | null
 
   return (
     <PortalShell
@@ -34,176 +32,21 @@ export default async function ProfilePage() {
         <div className="flex flex-col gap-1">
           <h1 className="font-medium">Profile</h1>
           <p className="text-sm text-muted-foreground">
-            Everything Supabase knows about you right now.
+            一些關於你的有趣數據。
           </p>
         </div>
 
         <UserCard
-          name={display.name}
-          email={display.email}
-          avatarUrl={display.avatarUrl}
+          name={user.name}
+          email={user.email}
+          avatarUrl={user.avatarUrl}
         />
 
-        <Section title="Identity">
-          <FieldRow label="User ID" value={user.id} mono />
-          <FieldRow label="Email" value={user.email} mono />
-          <FieldRow label="Phone" value={user.phone} mono />
-          <FieldRow label="Role" value={user.role} />
-          <FieldRow label="Audience" value={user.aud} />
-          <FieldRow label="SSO user" value={user.is_sso_user ? "yes" : "no"} />
-          <FieldRow
-            label="Anonymous"
-            value={user.is_anonymous ? "yes" : "no"}
-          />
-        </Section>
-
-        <Section title="Timestamps">
-          <FieldRow label="Created" value={user.created_at} mono />
-          <FieldRow label="Updated" value={user.updated_at} mono />
-          <FieldRow label="Last sign-in" value={user.last_sign_in_at} mono />
-          <FieldRow label="Confirmed" value={user.confirmed_at} mono />
-          <FieldRow
-            label="Email confirmed"
-            value={user.email_confirmed_at}
-            mono
-          />
-          <FieldRow
-            label="Phone confirmed"
-            value={user.phone_confirmed_at}
-            mono
-          />
-        </Section>
-
-        <Section
-          title="User metadata"
-          description="Provider-supplied claims, mirrored from Keycloak."
-        >
-          <div className="p-4">
-            <JsonBlock data={user.user_metadata} />
-          </div>
-        </Section>
-
-        <Section
-          title="App metadata"
-          description="Server-controlled metadata. `provider` = initial sign-in provider."
-        >
-          <div className="p-4">
-            <JsonBlock data={user.app_metadata} />
-          </div>
-        </Section>
-
-        <Section
-          title={`Identities (${identities.length})`}
-          description="Linked OAuth accounts. Keycloak is one provider; more can be attached."
-        >
-          {identities.length === 0 ? (
-            <div className="px-4 py-3 text-xs text-muted-foreground italic">
-              none
-            </div>
-          ) : (
-            identities.map((identity) => (
-              <div
-                key={identity.identity_id}
-                className="flex flex-col gap-3 p-4"
-              >
-                <div className="flex items-center justify-between">
-                  <span className="text-sm font-medium">
-                    {identity.provider}
-                  </span>
-                  <span className="font-mono text-xs text-muted-foreground">
-                    {identity.identity_id}
-                  </span>
-                </div>
-                <JsonBlock data={identity.identity_data ?? {}} />
-                <div className="flex justify-between text-xs text-muted-foreground">
-                  <span>created {identity.created_at ?? "—"}</span>
-                  <span>last {identity.last_sign_in_at ?? "—"}</span>
-                </div>
-              </div>
-            ))
-          )}
-        </Section>
-
-        <Section
-          title={`MFA factors (${factors.length})`}
-          description="TOTP / phone / webauthn enrolments."
-        >
-          {factors.length === 0 ? (
-            <div className="px-4 py-3 text-xs text-muted-foreground italic">
-              none
-            </div>
-          ) : (
-            factors.map((factor) => (
-              <div key={factor.id} className="flex flex-col gap-2 p-4 text-xs">
-                <div className="flex justify-between">
-                  <span className="font-medium">
-                    {factor.friendly_name ?? factor.factor_type}
-                  </span>
-                  <span className="text-muted-foreground">{factor.status}</span>
-                </div>
-                <div className="flex justify-between text-muted-foreground">
-                  <span className="font-mono">{factor.id}</span>
-                  <span>{factor.factor_type}</span>
-                </div>
-              </div>
-            ))
-          )}
-        </Section>
-
-        <Section
-          title="Session"
-          description="Cookie-backed Supabase session. Tokens masked."
-        >
-          {session ? (
-            <>
-              <FieldRow label="Token type" value={session.token_type} />
-              <FieldRow
-                label="Expires at"
-                value={formatUnixSeconds(session.expires_at)}
-                mono
-              />
-              <FieldRow
-                label="Expires in (s)"
-                value={session.expires_in}
-                mono
-              />
-              <FieldRow
-                label="Access token"
-                value={maskToken(session.access_token)}
-                mono
-              />
-              <FieldRow
-                label="Refresh token"
-                value={maskToken(session.refresh_token)}
-                mono
-              />
-              <FieldRow
-                label="Provider token"
-                value={maskToken(session.provider_token)}
-                mono
-              />
-              <FieldRow
-                label="Provider refresh token"
-                value={maskToken(session.provider_refresh_token)}
-                mono
-              />
-            </>
-          ) : (
-            <div className="px-4 py-3 text-xs text-muted-foreground italic">
-              No session cookie — this shouldn&apos;t happen if you reached this
-              page.
-            </div>
-          )}
-        </Section>
-
-        <Section
-          title="Raw user object"
-          description="Full AuthUser, in case something above got dropped."
-        >
-          <div className="p-4">
-            <JsonBlock data={user} />
-          </div>
-        </Section>
+        {stats ? (
+          <ProfileStatsView stats={stats} />
+        ) : (
+          <p className="text-sm text-muted-foreground italic">無法載入數據。</p>
+        )}
 
         <div className="flex justify-end">
           <SignOutButton />

--- a/apps/portal/lib/profile/stats.ts
+++ b/apps/portal/lib/profile/stats.ts
@@ -1,0 +1,84 @@
+// Shapes returned by public.get_profile_stats(uuid). Mirrors the SQL —
+// keep them in lockstep when adding new fields.
+
+export type BentoStats = {
+  total_orders: number
+  total_spent: number
+  unique_items: number
+  top_items: Array<{ name: string; count: number }>
+}
+
+export type LeaveStats = {
+  total_days: number
+  first_date: string | null
+}
+
+export type ApproveStats = {
+  created_count: number
+  signed_count: number
+  avg_sign_delay_seconds: number
+}
+
+export type TripStats = {
+  trips_joined: number
+  files_uploaded: number
+  total_size_bytes: number
+}
+
+export type ProfileStats = {
+  bento: BentoStats
+  leave: LeaveStats
+  approve: ApproveStats
+  trip: TripStats
+}
+
+// "All-citizen" anchor goods: things every Taiwanese knows the price of,
+// rotated on each render so the conversion stays fresh. Prices are NTD
+// and rounded to whole units the calculator can divide cleanly.
+export type ReferenceProduct = {
+  name: string
+  price: number
+  emoji: string
+  unit: string
+}
+
+export const REFERENCE_PRODUCTS: ReferenceProduct[] = [
+  { name: "7-11 茶葉蛋", price: 10, emoji: "🥚", unit: "顆" },
+  { name: "大樂透", price: 50, emoji: "🎰", unit: "注" },
+  { name: "麥當勞大麥克", price: 75, emoji: "🍔", unit: "顆" },
+]
+
+export function pickReferenceProduct(): ReferenceProduct {
+  const idx = Math.floor(Math.random() * REFERENCE_PRODUCTS.length)
+  return REFERENCE_PRODUCTS[idx]!
+}
+
+// "你的便當錢可以買 N 顆茶葉蛋" — round down so we don't lie upward.
+export function spendInReference(spent: number, product: ReferenceProduct) {
+  return Math.floor(spent / product.price)
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  if (bytes < 1024 * 1024 * 1024)
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`
+}
+
+export function formatDelay(seconds: number): string {
+  if (seconds <= 0) return "—"
+  const hours = seconds / 3600
+  if (hours < 1) return `${Math.round(seconds / 60)} 分`
+  if (hours < 48) return `${hours.toFixed(1)} 小時`
+  return `${(hours / 24).toFixed(1)} 天`
+}
+
+// Days → relatable scale. The 9-day cycle is ~Taiwan-round-the-island
+// by bicycle, the canonical local reference.
+export function leaveFlavor(days: number): string {
+  if (days === 0) return "今年還沒請過假，是個工作機器"
+  if (days < 3) return `${days} 天，還在發育期`
+  const laps = (days / 9).toFixed(1)
+  return `${days} 天，可以單車環島 ${laps} 圈`
+}

--- a/supabase/migrations/2026-04-28-profile-stats-rpc.sql
+++ b/supabase/migrations/2026-04-28-profile-stats-rpc.sql
@@ -1,0 +1,160 @@
+-- Profile stats: per-app aggregations exposed via SECURITY DEFINER RPCs so
+-- the profile page makes exactly one round-trip instead of N. Each sub-
+-- function self-gates on auth.uid() = p_user_id; passing someone else's
+-- uid silently returns zeros — no privilege escalation, no info leak
+-- (zero stats look the same as "user exists but never used the app").
+--
+-- New apps wire in by adding a sibling function and one entry in
+-- get_profile_stats(). Decentralised authorship, single round-trip.
+
+create or replace function public.bento_profile_stats(p_user_id uuid)
+returns jsonb
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with mine as (
+    select
+      mi.id    as menu_item_id,
+      mi.name  as menu_item_name,
+      mi.price as price
+    from public.bento_order_items oi
+    join public.bento_menu_items mi on mi.id = oi.menu_item_id
+    where oi.user_id = p_user_id
+      and auth.uid() = p_user_id
+  ),
+  totals as (
+    select
+      count(*)::int                      as total_orders,
+      coalesce(sum(price), 0)::int       as total_spent,
+      count(distinct menu_item_id)::int  as unique_items
+    from mine
+  ),
+  top_items as (
+    select jsonb_agg(
+      jsonb_build_object('name', menu_item_name, 'count', cnt)
+      order by cnt desc, menu_item_name asc
+    ) as items
+    from (
+      select menu_item_name, count(*)::int as cnt
+      from mine
+      group by menu_item_name
+      order by cnt desc, menu_item_name asc
+      limit 3
+    ) t
+  )
+  select jsonb_build_object(
+    'total_orders', (select total_orders from totals),
+    'total_spent',  (select total_spent  from totals),
+    'unique_items', (select unique_items from totals),
+    'top_items',    coalesce((select items from top_items), '[]'::jsonb)
+  );
+$$;
+
+create or replace function public.leave_profile_stats(p_user_id uuid)
+returns jsonb
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with mine as (
+    select date
+    from public.leaves
+    where user_id = p_user_id
+      and auth.uid() = p_user_id
+  )
+  select jsonb_build_object(
+    'total_days', (select count(*)::int from mine),
+    'first_date', (select min(date) from mine)
+  );
+$$;
+
+create or replace function public.approve_profile_stats(p_user_id uuid)
+returns jsonb
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select jsonb_build_object(
+    'created_count', (
+      select count(*)::int
+      from public.approve_documents
+      where created_by = p_user_id
+        and auth.uid() = p_user_id
+    ),
+    'signed_count', (
+      select count(*)::int
+      from public.approve_signers
+      where signer_id = p_user_id
+        and status = 'signed'
+        and auth.uid() = p_user_id
+    ),
+    'avg_sign_delay_seconds', (
+      select coalesce(
+        extract(epoch from avg(signed_at - created_at))::bigint,
+        0
+      )
+      from public.approve_signers
+      where signer_id = p_user_id
+        and status = 'signed'
+        and signed_at is not null
+        and auth.uid() = p_user_id
+    )
+  );
+$$;
+
+create or replace function public.trip_profile_stats(p_user_id uuid)
+returns jsonb
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select jsonb_build_object(
+    'trips_joined', (
+      select count(distinct trip_id)::int
+      from public.trip_files
+      where user_id = p_user_id
+        and auth.uid() = p_user_id
+    ),
+    'files_uploaded', (
+      select count(*)::int
+      from public.trip_files
+      where user_id = p_user_id
+        and auth.uid() = p_user_id
+    ),
+    'total_size_bytes', (
+      select coalesce(sum(size_bytes), 0)::bigint
+      from public.trip_files
+      where user_id = p_user_id
+        and auth.uid() = p_user_id
+    )
+  );
+$$;
+
+create or replace function public.get_profile_stats(p_user_id uuid)
+returns jsonb
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select case
+    when auth.uid() = p_user_id then jsonb_build_object(
+      'bento',   public.bento_profile_stats(p_user_id),
+      'leave',   public.leave_profile_stats(p_user_id),
+      'approve', public.approve_profile_stats(p_user_id),
+      'trip',    public.trip_profile_stats(p_user_id)
+    )
+    else null
+  end;
+$$;
+
+grant execute on function public.bento_profile_stats(uuid)   to authenticated;
+grant execute on function public.leave_profile_stats(uuid)   to authenticated;
+grant execute on function public.approve_profile_stats(uuid) to authenticated;
+grant execute on function public.trip_profile_stats(uuid)    to authenticated;
+grant execute on function public.get_profile_stats(uuid)     to authenticated;


### PR DESCRIPTION
## Summary

- 換掉 profile 頁的 Supabase auth dump，改成 4 個 app 的有梗統計：便當帳本、請假記錄、簽核戰績、出差紀錄
- 單一 \`get_profile_stats\` RPC 聚合 4 個 \`SECURITY DEFINER\` 子 function — 一次 round-trip
- 每個子 function self-gates on \`auth.uid() = p_user_id\`，跨 user 取值返回 null（已驗證）
- 便當總開銷會隨機換算成「N 顆茶葉蛋 / N 注大樂透 / N 顆大麥克」，每次刷新換不同錨點
- 請假天數換算成單車環島 N 圈
- 拓樸：新 app 加 stats 只要寫一個 \`<app>_profile_stats\` function + 在 aggregator 補一行

## Verification

- [x] \`bun run typecheck\` — 通過
- [x] \`bun run lint\` — 0 新增 error
- [x] \`bun run build\` — 通過，\`/profile\` 為 dynamic route
- [x] 直接 SQL 呼叫 \`get_profile_stats\` 拿到正確 shape，含 18 筆 bento / 2 筆 leave / 5 筆 approve / 4 筆 trip files
- [x] 跨 user 呼叫返回 null（auth guard 有效）

## Test plan

- [ ] 在 dev server 開 \`/profile\`，確認所有區塊都有資料且文案有梗
- [ ] 重新整理頁面，確認錨點商品在三個之間隨機切換
- [ ] 用沒資料的帳號登入，確認顯示 "—" 而不是 0 / NaN