### PR TITLE
fix(bento): wrap close-order in confirm dialog + add reopen-order

### DIFF
--- a/apps/portal/app/bento/_components/order-detail.tsx
+++ b/apps/portal/app/bento/_components/order-detail.tsx
@@ -11,6 +11,7 @@ import {
   useCloseOrder,
   useDeleteOrder,
   useOrder,
+  useReopenOrder,
 } from "@/hooks/bento/use-orders"
 import { useAuth } from "@/hooks/use-auth"
 
@@ -26,6 +27,7 @@ export function OrderDetail({ orderId }: { orderId: string }) {
   const router = useRouter()
   const closeOrder = useCloseOrder()
   const deleteOrder = useDeleteOrder()
+  const reopenOrder = useReopenOrder()
 
   if (!order) {
     return (
@@ -66,6 +68,16 @@ export function OrderDetail({ orderId }: { orderId: string }) {
     }
   }
 
+  const handleReopen = async () => {
+    try {
+      await reopenOrder.mutateAsync(orderId)
+      toast.success("訂單已重新開啟")
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error("重新開啟失敗")
+      toast.error(err.message)
+    }
+  }
+
   return (
     <div className="flex flex-col gap-8">
       <OrderDetailHeader order={order} />
@@ -75,14 +87,17 @@ export function OrderDetail({ orderId }: { orderId: string }) {
           <AddOrderItemDialog orderId={orderId} />
           {isAdmin && (
             <>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleClose}
-                disabled={closeOrder.isPending}
-              >
-                {closeOrder.isPending ? "關閉中..." : "關閉訂單"}
-              </Button>
+              <ConfirmDialog
+                trigger={
+                  <Button variant="outline" size="sm">
+                    關閉訂單
+                  </Button>
+                }
+                title="確定要關閉訂單嗎？"
+                description="關閉後訂單將停止接受新增，可透過重新開啟恢復。"
+                confirmText="關閉"
+                onConfirm={handleClose}
+              />
               <ConfirmDialog
                 trigger={
                   <Button variant="ghost" size="sm">
@@ -97,6 +112,22 @@ export function OrderDetail({ orderId }: { orderId: string }) {
               />
             </>
           )}
+        </div>
+      )}
+
+      {!isActive && isAdmin && (
+        <div className="flex flex-wrap gap-2">
+          <ConfirmDialog
+            trigger={
+              <Button variant="outline" size="sm">
+                重新開啟訂單
+              </Button>
+            }
+            title="確定要重新開啟訂單嗎？"
+            description="重新開啟後，訂單將可以繼續接受訂餐。"
+            confirmText="開啟"
+            onConfirm={handleReopen}
+          />
         </div>
       )}
 

--- a/apps/portal/hooks/bento/use-orders.ts
+++ b/apps/portal/hooks/bento/use-orders.ts
@@ -205,3 +205,24 @@ export function useDeleteOrder() {
     },
   })
 }
+
+export function useReopenOrder() {
+  const supabase = createClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (orderId: string) => {
+      const { data, error } = await supabase
+        .from("bento_orders")
+        .update({ status: "active", closed_at: null })
+        .eq("id", orderId)
+        .select()
+        .single()
+      if (error) throw error
+      return data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.orders.all })
+    },
+  })
+}


### PR DESCRIPTION
## Summary

Closes #27.

- **`useReopenOrder`** mutation added to `use-orders.ts` — sets `status: "active"` and clears `closed_at: null`, symmetric with `useCloseOrder`
- **「關閉訂單」** now wrapped in `ConfirmDialog` so admin can't accidentally close an active order with one click
- **「重新開啟訂單」** button added for closed orders (admin only), also behind `ConfirmDialog` — mirrors `bento.winlab.tw` behaviour

## Test plan

- [ ] 以 admin 身份進入有效訂單頁面，點「關閉訂單」確認跳出對話框
- [ ] 對話框按「取消」確認訂單仍維持 active
- [ ] 對話框按「關閉」確認訂單變為 closed，按鈕區消失
- [ ] 以 admin 身份在已關閉訂單頁面，確認顯示「重新開啟訂單」按鈕
- [ ] 點「重新開啟訂單」確認跳出對話框後開啟，按鈕恢復為 active 狀態操作
- [ ] 非 admin 用戶在 closed 訂單頁面不應看到重新開啟按鈕