### PR TITLE
chore(profile): show only top bento pick + include restaurant

### DIFF
--- a/apps/portal/app/profile/_components/profile-stats.tsx
+++ b/apps/portal/app/profile/_components/profile-stats.tsx
@@ -15,7 +15,7 @@ export function ProfileStatsView({ stats }: { stats: ProfileStats }) {
   const product = pickReferenceProduct()
 
   const { bento, leave, approve, trip } = stats
-  const top = bento.top_items
+  const top = bento.top_item
   const variety =
     bento.total_orders > 0
       ? Math.round((bento.unique_items / bento.total_orders) * 100)
@@ -38,15 +38,11 @@ export function ProfileStatsView({ stats }: { stats: ProfileStats }) {
         />
         <FieldRow
           label="本命便當"
-          value={top[0] ? `${top[0].name} × ${top[0].count}` : "還沒有最愛"}
-        />
-        <FieldRow
-          label="第二名"
-          value={top[1] ? `${top[1].name} × ${top[1].count}` : "—"}
-        />
-        <FieldRow
-          label="第三名"
-          value={top[2] ? `${top[2].name} × ${top[2].count}` : "—"}
+          value={
+            top
+              ? `${top.restaurant_name} ${top.name} × ${top.count}`
+              : "還沒有最愛"
+          }
         />
         <FieldRow
           label="嚐鮮指數"

--- a/apps/portal/lib/profile/stats.ts
+++ b/apps/portal/lib/profile/stats.ts
@@ -5,7 +5,7 @@ export type BentoStats = {
   total_orders: number
   total_spent: number
   unique_items: number
-  top_items: Array<{ name: string; count: number }>
+  top_item: { name: string; restaurant_name: string; count: number } | null
 }
 
 export type LeaveStats = {

--- a/supabase/migrations/2026-04-28-profile-bento-restaurant.sql
+++ b/supabase/migrations/2026-04-28-profile-bento-restaurant.sql
@@ -1,0 +1,52 @@
+-- bento_profile_stats follow-up: top_items rolled back to a single
+-- "本命便當" (top_item) and now includes the restaurant name. The 2nd /
+-- 3rd place rows added more noise than signal — one favourite per
+-- person hits harder.
+
+create or replace function public.bento_profile_stats(p_user_id uuid)
+returns jsonb
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with mine as (
+    select
+      mi.id            as menu_item_id,
+      mi.name          as menu_item_name,
+      r.name           as restaurant_name,
+      mi.price         as price
+    from public.bento_order_items oi
+    join public.bento_menu_items mi on mi.id = oi.menu_item_id
+    join public.bento_menus       r  on r.id  = mi.restaurant_id
+    where oi.user_id = p_user_id
+      and auth.uid() = p_user_id
+  ),
+  totals as (
+    select
+      count(*)::int                      as total_orders,
+      coalesce(sum(price), 0)::int       as total_spent,
+      count(distinct menu_item_id)::int  as unique_items
+    from mine
+  ),
+  top_pick as (
+    select menu_item_name, restaurant_name, count(*)::int as cnt
+    from mine
+    group by menu_item_name, restaurant_name
+    order by cnt desc, menu_item_name asc
+    limit 1
+  )
+  select jsonb_build_object(
+    'total_orders', (select total_orders from totals),
+    'total_spent',  (select total_spent  from totals),
+    'unique_items', (select unique_items from totals),
+    'top_item', (
+      select jsonb_build_object(
+        'name',            menu_item_name,
+        'restaurant_name', restaurant_name,
+        'count',           cnt
+      )
+      from top_pick
+    )
+  );
+$$;


### PR DESCRIPTION
## Summary

- 拿掉「第二名 / 第三名」兩列 — 一道本命才有畫面
- 本命便當改成顯示「餐廳名 餐點名 × N」，好讓人記得餐點之外的店家
- Migration `2026-04-28-profile-bento-restaurant.sql` replace `bento_profile_stats`，新 shape：\`top_item: {name, restaurant_name, count} | null\`

## Verification

- [x] Migration applied，已用真實資料驗證 \`top_item = {name: "排骨飯", count: 3, restaurant_name: "和味精緻自助餐"}\`
- [x] \`bun run typecheck\` 通過
- [x] \`bun run lint\` 0 新增 error

## Test plan

- [ ] \`/profile\` 確認便當帳本只剩 4 列：總次數、總開銷、本命便當、嚐鮮指數
- [ ] 本命便當顯示「店家 餐點 × 次數」格式