### PR TITLE
chore(profile): drop emoji from reference product line

### DIFF
--- a/apps/portal/app/profile/_components/profile-stats.tsx
+++ b/apps/portal/app/profile/_components/profile-stats.tsx
@@ -33,7 +33,7 @@ export function ProfileStatsView({ stats }: { stats: ProfileStats }) {
               : `NT$ ${bento.total_spent}（≈ ${spendInReference(
                   bento.total_spent,
                   product
-                )} ${product.unit}${product.emoji} ${product.name}）`
+                )} ${product.unit} ${product.name}）`
           }
         />
         <FieldRow

--- a/apps/portal/lib/profile/stats.ts
+++ b/apps/portal/lib/profile/stats.ts
@@ -38,14 +38,13 @@ export type ProfileStats = {
 export type ReferenceProduct = {
   name: string
   price: number
-  emoji: string
   unit: string
 }
 
 export const REFERENCE_PRODUCTS: ReferenceProduct[] = [
-  { name: "7-11 茶葉蛋", price: 10, emoji: "🥚", unit: "顆" },
-  { name: "大樂透", price: 50, emoji: "🎰", unit: "注" },
-  { name: "麥當勞大麥克", price: 75, emoji: "🍔", unit: "顆" },
+  { name: "7-11 茶葉蛋", price: 10, unit: "顆" },
+  { name: "大樂透", price: 50, unit: "注" },
+  { name: "麥當勞大麥克", price: 75, unit: "顆" },
 ]
 
 export function pickReferenceProduct(): ReferenceProduct {


### PR DESCRIPTION
便當總開銷的換算行不再帶 emoji，純文字「≈ 32 注 大樂透」更乾淨。