### PR TITLE
fix(gallery): catch stray ?code= and forward to /auth/callback

### DIFF
--- a/apps/gallery/lib/supabase/middleware.ts
+++ b/apps/gallery/lib/supabase/middleware.ts
@@ -5,6 +5,18 @@ import { NextResponse, type NextRequest } from "next/server"
 // and the page itself also gates redundantly. This middleware refreshes the
 // session token and bounces unauth users out of /upload to /auth/login.
 export async function updateSession(request: NextRequest) {
+  // OAuth fallback. If Supabase's "Redirect URLs" allow-list is missing our
+  // /auth/callback URL, Supabase quietly falls back to Site URL (root) and
+  // dumps the PKCE `code` query string there. Catch it and forward to the
+  // real callback so the exchange still finishes — user shouldn't have to
+  // care about a Dashboard misconfiguration.
+  const oauthCode = request.nextUrl.searchParams.get("code")
+  if (oauthCode && request.nextUrl.pathname !== "/auth/callback") {
+    const url = request.nextUrl.clone()
+    url.pathname = "/auth/callback"
+    return NextResponse.redirect(url)
+  }
+
   let supabaseResponse = NextResponse.next({ request })
 
   const supabase = createServerClient(


### PR DESCRIPTION
## Why

Supabase's OAuth flow falls back to **Site URL** when the `redirectTo` you pass to `signInWithOAuth` isn't whitelisted under Auth → URL Configuration → Redirect URLs. That means a Dashboard misconfig silently kicks the PKCE `code` to the wrong path (e.g. `/?code=…`) and SSO never finishes.

Loki hit this on `localhost:3000/?code=…` after Keycloak. Root cause is the missing entry in the Dashboard, but the user shouldn't need to debug it — middleware should just route the code home.

## What changed

`apps/gallery/lib/supabase/middleware.ts` now checks for `?code=` on every request. If it's not already on `/auth/callback`, redirect there preserving query params so `exchangeCodeForSession` runs.

```
GET /?code=abc        → 307 → /auth/callback?code=abc
GET /auth/callback?code=x → handled normally (no loop)
```

## Test plan
- [x] curl confirms `/?code=fake` → 307 → `/auth/callback?code=fake`
- [x] curl confirms `/auth/callback?code=x` does **not** loop (goes to auth-code-error after exchange fails)
- [ ] Real OAuth round-trip after Dashboard's Redirect URLs include both `http://localhost:3000/auth/callback` and `https://gallery.winlab.tw/auth/callback`

## Followup

This is a defensive fallback. The root fix is **adding both `/auth/callback` URLs to Supabase's Redirect URLs allow-list** so Supabase never has to fall back to Site URL.