### PR TITLE
fix(gallery): port portal's stale cookie defense for PKCE

### DIFF
--- a/apps/gallery/app/auth/callback/route.ts
+++ b/apps/gallery/app/auth/callback/route.ts
@@ -1,5 +1,7 @@
+import { cookies } from "next/headers"
 import { NextResponse } from "next/server"
 
+import { clearStaleSupabaseCookiesOnResponse } from "@/lib/auth/clear-stale-cookies"
 import { createClient } from "@/lib/supabase/server"
 
 export async function GET(request: Request) {
@@ -31,5 +33,17 @@ export async function GET(request: Request) {
     }
   }
 
-  return NextResponse.redirect(`${origin}/auth/auth-code-error`)
+  // Failure path: most likely cause is a ghost `sb-*` cookie left over from
+  // portal at `.winlab.tw` scope poisoning @supabase/ssr's PKCE state.
+  // Clear every sb-* cookie (including code-verifier — the current
+  // round-trip has already failed, its verifier is worthless) on every
+  // plausible domain and send the user back to login with ?stale=1.
+  const retry = new URL("/auth/login", origin)
+  retry.searchParams.set("stale", "1")
+  const response = NextResponse.redirect(retry.toString())
+
+  const cookieStore = await cookies()
+  clearStaleSupabaseCookiesOnResponse(response, cookieStore)
+
+  return response
 }

--- a/apps/gallery/app/auth/login/page.tsx
+++ b/apps/gallery/app/auth/login/page.tsx
@@ -2,27 +2,34 @@ import { redirect } from "next/navigation"
 
 import { PortalShell } from "@workspace/ui/components/portal-shell"
 
+import { AuthStateReset } from "@/components/auth-state-reset"
 import { SignInButton } from "@/components/sign-in-button"
 import { getCurrentUser } from "@/lib/user"
 
 type LoginPageProps = {
-  searchParams: Promise<{ next?: string }>
+  searchParams: Promise<{ next?: string; stale?: string }>
 }
 
 export default async function LoginPage({ searchParams }: LoginPageProps) {
   const user = await getCurrentUser()
-  const { next } = await searchParams
+  const { next, stale } = await searchParams
   const safeNext = next && next.startsWith("/") ? next : "/"
   if (user) redirect(safeNext)
 
   return (
     <PortalShell appName="Gallery" appHref="/" cornerClassName="text-lg">
+      <AuthStateReset />
       <div className="flex min-h-[60vh] flex-col justify-center gap-8">
         <div className="flex flex-col gap-2">
           <h1 className="text-5xl italic md:text-6xl">Sign in</h1>
           <p className="text-lg text-muted-foreground md:text-xl">
             Continue with your WinLab SSO account.
           </p>
+          {stale === "1" ? (
+            <p className="mt-2 text-sm text-muted-foreground italic">
+              Cleared a leftover session. Try signing in again.
+            </p>
+          ) : null}
         </div>
         <SignInButton next={safeNext} />
       </div>

--- a/apps/gallery/components/auth-state-reset.tsx
+++ b/apps/gallery/components/auth-state-reset.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import { useEffect } from "react"
+
+// Nukes every local Supabase auth artefact. Mounted on /auth/login so any
+// user arriving to sign in gets a clean slate — no ghost cookie, no stale
+// localStorage session, no orphan sessionStorage flag. Mirror of portal's
+// AuthStateReset, with gallery.winlab.tw added to the domain list because
+// the same `.winlab.tw`-scoped ghost cookies poison this subdomain too.
+//
+// Why each piece matters:
+// - localStorage: @supabase/ssr browser client stores session JSON here and
+//   auto-refreshes on page mount. A stale entry spawns a refresh loop
+//   (grant_type=refresh_token + over_request_rate_limit) that poisons IP
+//   rate limits and can make exchangeCodeForSession fail with 429.
+// - sessionStorage: @supabase/ssr occasionally puts PKCE scratch state
+//   there. Clear for completeness.
+// - document.cookie: our server-side clear handles this too, but JS can
+//   only see & clear non-HttpOnly entries on the current domain. The old
+//   portal set cookies with domain=.winlab.tw, so we blast that scope too
+//   (writing a cookie with matching Domain and Max-Age=0 removes it).
+export function AuthStateReset() {
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    const nukeStorage = (storage: Storage) => {
+      for (let i = storage.length - 1; i >= 0; i--) {
+        const key = storage.key(i)
+        if (key?.startsWith("sb-")) storage.removeItem(key)
+      }
+    }
+
+    try {
+      nukeStorage(localStorage)
+      nukeStorage(sessionStorage)
+    } catch {
+      // Safari private mode etc — nothing to do, carry on.
+    }
+
+    const domains: (string | undefined)[] = [
+      undefined, // host-only current deployment
+      ".winlab.tw", // old portal's explicit scope
+      "portal.winlab.tw",
+      "gallery.winlab.tw",
+    ]
+    for (const entry of document.cookie.split("; ")) {
+      const name = entry.split("=")[0]
+      if (!name?.startsWith("sb-")) continue
+      for (const domain of domains) {
+        const domainPart = domain ? `; domain=${domain}` : ""
+        document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/${domainPart}`
+      }
+    }
+  }, [])
+
+  return null
+}

--- a/apps/gallery/lib/auth/clear-stale-cookies.ts
+++ b/apps/gallery/lib/auth/clear-stale-cookies.ts
@@ -1,0 +1,42 @@
+import type { NextResponse } from "next/server"
+import type { cookies as nextCookies } from "next/headers"
+
+// Same disease as portal: any user who already signed into portal.winlab.tw
+// (host-only) or the legacy `.winlab.tw`-scoped portal carries `sb-*` ghost
+// cookies that the browser merges with our own when they land on
+// gallery.winlab.tw. Two values share a name; @supabase/ssr picks one,
+// PKCE verifier reconciles wrong, exchangeCodeForSession fails — and
+// Supabase's own retry path can fall back to Site URL, which is what put
+// the `?code=` on localhost in the first place.
+//
+// Policy on callback failure: nuke every `sb-*` cookie on every plausible
+// scope. The current attempt's verifier dies with the ghosts, but the
+// current attempt has already failed — next click starts fresh.
+const DOMAINS_TO_CLEAR = [
+  undefined, // host-only (current deployment)
+  ".winlab.tw", // old portal's explicit scope, still poisoning subdomains
+  "portal.winlab.tw",
+  "gallery.winlab.tw",
+]
+
+export function clearStaleSupabaseCookiesOnResponse(
+  response: NextResponse,
+  cookieStore: Awaited<ReturnType<typeof nextCookies>>
+) {
+  const staleNames = cookieStore
+    .getAll()
+    .map((c) => c.name)
+    .filter((name) => name.startsWith("sb-"))
+
+  for (const name of staleNames) {
+    for (const domain of DOMAINS_TO_CLEAR) {
+      response.cookies.set(name, "", {
+        maxAge: 0,
+        path: "/",
+        ...(domain ? { domain } : {}),
+      })
+    }
+  }
+
+  return staleNames.length
+}


### PR DESCRIPTION
## Why

Loki tried logging into gallery (dev localhost:3000) and OAuth exchange consistently 400'd:
\`\`\`
GET /auth/callback?code=984abb28-... 307 → /auth/auth-code-error
\`\`\`
Same disease portal cured a couple of PRs ago — any user who signed into the legacy \`.winlab.tw\`-scoped portal (or portal.winlab.tw) carries ghost \`sb-*\` cookies the browser also serves to gallery. \`@supabase/ssr\` merges them under one name, picks the wrong PKCE verifier, exchange dies. Without a cleanup path the user is stuck in a loop.

I copied portal's \`SignInButton\` when I built gallery but missed the matching \`AuthStateReset\` (login page) and \`clearStaleSupabaseCookiesOnResponse\` (callback failure path). That's the actual oversight Loki was calling out — portal already had the playbook, I shouldn't have re-invented anything.

## What changed

Direct ports of portal's defense, expanded to include \`gallery.winlab.tw\` in the domain list:

- \`apps/gallery/lib/auth/clear-stale-cookies.ts\` — server-side nuke of every \`sb-*\` cookie on every plausible domain scope (\`undefined\`, \`.winlab.tw\`, \`portal.winlab.tw\`, \`gallery.winlab.tw\`). Called from the callback failure path.
- \`apps/gallery/components/auth-state-reset.tsx\` — client-side localStorage / sessionStorage / document.cookie nuke. Mounted on \`/auth/login\`.
- \`apps/gallery/app/auth/callback/route.ts\` — success path unchanged; failure path now redirects to \`/auth/login?stale=1\` with \`sb-*\` cookies pre-cleared. Login page shows a one-line "Cleared a leftover session." note when \`?stale=1\`.

## Test plan
- [x] Typecheck + lint clean
- [ ] Loki reproduces the failed login locally → callback returns 307 to \`/auth/login?stale=1\`, ghost cookies gone, next click signs in successfully
- [ ] Same flow on \`https://gallery.winlab.tw\` once Vercel project is set up