### PR TITLE
fix(gallery): keep redirect_to clean — fixes prod→localhost bounce

### DIFF
--- a/apps/gallery/app/auth/callback/route.ts
+++ b/apps/gallery/app/auth/callback/route.ts
@@ -7,8 +7,11 @@ import { createClient } from "@/lib/supabase/server"
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url)
   const code = searchParams.get("code")
-  let next = searchParams.get("next") ?? "/"
-  if (!next.startsWith("/")) next = "/"
+  // We deliberately do NOT honor a `?next=` query param here — passing it
+  // through redirectTo trips Supabase's exact-match allow-list check and
+  // causes the whole flow to fall back to Site URL (localhost). The
+  // SignInButton stashes `next` in sessionStorage; a post-callback client
+  // hop on `/` reads it and finishes navigation.
 
   if (code) {
     const supabase = await createClient()
@@ -23,21 +26,22 @@ export async function GET(request: Request) {
     if (!error) {
       const forwardedHost = request.headers.get("x-forwarded-host")
       const isLocalEnv = process.env.NODE_ENV === "development"
+      // Hand off to a tiny client landing page that consumes the stashed
+      // `next` from sessionStorage and replaces the URL — keeps the deep
+      // link working without ever putting it on the OAuth redirect.
+      const target = "/auth/finish"
       if (isLocalEnv) {
-        return NextResponse.redirect(`${origin}${next}`)
+        return NextResponse.redirect(`${origin}${target}`)
       } else if (forwardedHost) {
-        return NextResponse.redirect(`https://${forwardedHost}${next}`)
+        return NextResponse.redirect(`https://${forwardedHost}${target}`)
       } else {
-        return NextResponse.redirect(`${origin}${next}`)
+        return NextResponse.redirect(`${origin}${target}`)
       }
     }
   }
 
-  // Failure path: most likely cause is a ghost `sb-*` cookie left over from
-  // portal at `.winlab.tw` scope poisoning @supabase/ssr's PKCE state.
-  // Clear every sb-* cookie (including code-verifier — the current
-  // round-trip has already failed, its verifier is worthless) on every
-  // plausible domain and send the user back to login with ?stale=1.
+  // Failure path: most likely a ghost `sb-*` cookie from another .winlab.tw
+  // subdomain poisoning PKCE state. Nuke them all and bounce to login.
   const retry = new URL("/auth/login", origin)
   retry.searchParams.set("stale", "1")
   const response = NextResponse.redirect(retry.toString())

--- a/apps/gallery/app/auth/finish/_components/auth-finish.tsx
+++ b/apps/gallery/app/auth/finish/_components/auth-finish.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import { useEffect } from "react"
+
+import { NEXT_STORAGE_KEY } from "@/components/sign-in-button"
+
+export function AuthFinish() {
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    let next = "/"
+    try {
+      const stashed = sessionStorage.getItem(NEXT_STORAGE_KEY)
+      if (stashed && stashed.startsWith("/")) next = stashed
+      sessionStorage.removeItem(NEXT_STORAGE_KEY)
+    } catch {
+      /* private mode — just go home */
+    }
+    window.location.replace(next)
+  }, [])
+
+  return null
+}

--- a/apps/gallery/app/auth/finish/page.tsx
+++ b/apps/gallery/app/auth/finish/page.tsx
@@ -1,0 +1,9 @@
+import { AuthFinish } from "@/app/auth/finish/_components/auth-finish"
+
+// Tiny landing page after a successful OAuth callback. The callback route
+// can't honor `?next=` on its redirect URL (Supabase rejects redirect_to
+// with extra query params), so SignInButton stashes the deep link in
+// sessionStorage. This page reads it client-side and replaces the URL.
+export default function AuthFinishPage() {
+  return <AuthFinish />
+}

--- a/apps/gallery/components/sign-in-button.tsx
+++ b/apps/gallery/components/sign-in-button.tsx
@@ -6,22 +6,34 @@ import { Button } from "@workspace/ui/components/button"
 
 import { createClient } from "@/lib/supabase/client"
 
+const NEXT_STORAGE_KEY = "gallery:auth:next"
+
+// Stash `next` in sessionStorage instead of stuffing it into the redirectTo
+// query string. Supabase matches redirect URLs *exactly* against the allow
+// list (query params included). Any extra `?next=...` makes the redirect_to
+// fail allow-list validation, and Supabase silently falls back to Site URL
+// (which is still http://localhost:3000 on this project, hence the famous
+// "I logged in on prod and ended up on localhost" head-scratcher).
+//
+// The callback route reads the same key on success and resumes navigation.
 export function SignInButton({ next }: { next?: string }) {
   const [pending, startTransition] = useTransition()
 
   function onClick() {
     startTransition(async () => {
+      if (typeof window !== "undefined" && next && next.startsWith("/")) {
+        try {
+          sessionStorage.setItem(NEXT_STORAGE_KEY, next)
+        } catch {
+          /* private mode etc — fine, callback just sends to "/" */
+        }
+      }
       const supabase = createClient()
-      const callback = new URL(
-        "/auth/callback",
-        typeof window !== "undefined" ? window.location.origin : ""
-      )
-      if (next) callback.searchParams.set("next", next)
       await supabase.auth.signInWithOAuth({
         provider: "keycloak",
         options: {
           scopes: "openid",
-          redirectTo: callback.toString(),
+          redirectTo: `${window.location.origin}/auth/callback`,
         },
       })
     })
@@ -33,3 +45,5 @@ export function SignInButton({ next }: { next?: string }) {
     </Button>
   )
 }
+
+export { NEXT_STORAGE_KEY }

--- a/apps/gallery/lib/supabase/middleware.ts
+++ b/apps/gallery/lib/supabase/middleware.ts
@@ -47,7 +47,6 @@ export async function updateSession(request: NextRequest) {
   if (!user && request.nextUrl.pathname.startsWith("/upload")) {
     const url = request.nextUrl.clone()
     url.pathname = "/auth/login"
-    url.searchParams.set("next", request.nextUrl.pathname)
     return NextResponse.redirect(url)
   }
 


### PR DESCRIPTION
## Why

Loki opened \`https://gallery.winlab.tw/auth/login?next=/upload\`, signed in via Keycloak, ended up at \`http://localhost:3000/?code=...\`. Even though \`https://gallery.winlab.tw/auth/callback\` is in the Redirect URLs allow-list, Supabase still bounced him to Site URL (\`http://localhost:3000\`).

Root cause: **Supabase matches \`redirect_to\` against the allow-list with query parameters included, byte-for-byte**. My SignInButton stuffed \`?next=/upload\` into the URL:
\`\`\`
redirect_to = https://gallery.winlab.tw/auth/callback?next=/upload
allow-list  = https://gallery.winlab.tw/auth/callback   ← exact, no query
\`\`\`
Mismatch ⇒ allow-list reject ⇒ silent fallback to Site URL ⇒ localhost.

Portal's SignInButton never put \`next\` on \`redirect_to\` (it just always sends to \`/\`). I added a feature gallery didn't actually need to set up that way, and that's where the bug snuck in.

Confirmed in:
- [supabase#12941](https://github.com/supabase/supabase/issues/12941): "You likely did not set your exact URL's here. So it will always go to the default siteURL setting."
- [Supabase Auth: Redirect URLs](https://supabase.com/docs/guides/auth/redirect-urls): "The URL in \`redirectTo\` should match the Redirect URLs list configuration."

## What changed

- **\`SignInButton\`**: \`redirectTo\` is now always plain \`\${origin}/auth/callback\` — no query string. Deep-link target stashes in \`sessionStorage\` (\`gallery:auth:next\`) before \`signInWithOAuth\`.
- **\`/auth/callback\`**: success path redirects to \`/auth/finish\` (used to redirect to \`next\` directly using \`?next=\` from URL).
- **\`/auth/finish\`**: tiny client landing page that reads the stashed deep link from \`sessionStorage\` and \`window.location.replace\`s to it. Falls back to \`/\` if nothing stashed.
- Reverted the recent \`cookieOptions: { secure: false (dev) }\` tweak — that was misdiagnosing a different problem (dev PKCE), not relevant here.

## Test plan
- [ ] Open \`https://gallery.winlab.tw/auth/login?next=/upload\`, sign in → ends up on \`/upload\` (not localhost)
- [ ] Open \`https://gallery.winlab.tw/auth/login\` (no \`next\`), sign in → ends up on \`/\`
- [ ] Sign out + back in flow still works
- [ ] Localhost dev sign-in still works (separate concerns; if it doesn't, that's a follow-up)