### PR TITLE
feat(portal): link out to gallery from the apps list

### DIFF
--- a/apps/portal/app/page.tsx
+++ b/apps/portal/app/page.tsx
@@ -14,6 +14,7 @@ const apps = [
   { href: "/approve", label: "Approve", note: "文件簽核" },
   { href: "/trip", label: "Trip", note: "出差文件" },
   { href: "/profile", label: "Profile", note: "個人帳號" },
+  { href: "https://gallery.winlab.tw", label: "Gallery", note: "藝術畫廊" },
 ]
 
 export default async function Page() {


### PR DESCRIPTION
## Summary
- Adds a Gallery row to portal's apps list, pointing at `https://gallery.winlab.tw` so folks can hop over from the home screen.
- Notes consistent 4-character label (藝術畫廊) to match siblings.

## Test plan
- [x] `bun run typecheck --filter=portal`
- [ ] Visit `/` while signed in, click Gallery row, lands on gallery.winlab.tw