### PR TITLE
fix(gallery): unstick mobile uploads — raise 1 MB cap and welcome HEIC/HEIF

### DIFF
--- a/apps/gallery/app/upload/actions.ts
+++ b/apps/gallery/app/upload/actions.ts
@@ -13,6 +13,8 @@ const ALLOWED_MIME = new Set([
   "image/webp",
   "image/gif",
   "image/avif",
+  "image/heic",
+  "image/heif",
 ])
 
 export async function uploadGalleryImage(
@@ -116,6 +118,10 @@ function guessExtension(mime: string, filename: string): string {
       return "gif"
     case "image/avif":
       return "avif"
+    case "image/heic":
+      return "heic"
+    case "image/heif":
+      return "heif"
     default:
       return "bin"
   }

--- a/apps/gallery/next.config.mjs
+++ b/apps/gallery/next.config.mjs
@@ -10,6 +10,14 @@ const nextConfig = {
       },
     ],
   },
+  // Default Server Action body cap is 1 MB. Phone originals (HEIC ~3 MB,
+  // JPEG ~5–8 MB) blow right past it — desktop screenshots squeak under,
+  // hence the "works on laptop, dies on phone" mystery.
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "20mb",
+    },
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- Lifts Server Action body limit from default 1 MB → 20 MB so phone-original photos actually fit.
- Adds `image/heic` / `image/heif` to the upload allow-list (iPhones default to HEIC).
- `guessExtension` now maps both new MIMEs.

## Why
Phone originals (HEIC ~3 MB, JPEG ~5–8 MB) blow past the 1 MB cap; laptop uploads tend to be screenshots that squeak under. Hence the "works on desktop, fails on mobile" mystery.

## Test plan
- [x] `bun run typecheck --filter=gallery`
- [ ] On iPhone Safari: upload a freshly taken photo (HEIC), confirm it lands and renders in the grid.
- [ ] On Android Chrome: upload a 4–8 MB JPEG, confirm success.
- [ ] On desktop: existing PNG/JPEG flow still works.