### PR TITLE
feat(portal): move bill-splitting into /debt — schema renamed, ui re-skinned

### DIFF
--- a/apps/portal/app/api/cron/debt-monthly-settlements/route.ts
+++ b/apps/portal/app/api/cron/debt-monthly-settlements/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server"
+
+import { createAdminClient } from "@/lib/supabase/admin"
+
+// Generates the previous month's net-balance settlement rows. Idempotent via the
+// (period, from_user_id, to_user_id) unique index — safe for retries.
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+export async function GET(request: Request) {
+  const auth = request.headers.get("authorization")
+  if (auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new NextResponse("unauthorized", { status: 401 })
+  }
+
+  const supabase = createAdminClient()
+  const { error } = await supabase.rpc("debt_generate_monthly_settlements")
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/apps/portal/app/debt/_components/balance-overview.tsx
+++ b/apps/portal/app/debt/_components/balance-overview.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+import { IconChevronRight } from "@tabler/icons-react"
+
+import { Badge } from "@workspace/ui/components/badge"
+import { Checkbox } from "@workspace/ui/components/checkbox"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@workspace/ui/components/collapsible"
+
+import { useMarkItemPaid } from "@/hooks/debt/use-expenses"
+import type { BalanceEntry } from "@/lib/debt/types"
+
+interface BalanceOverviewProps {
+  iOwe: BalanceEntry[]
+  owedToMe: BalanceEntry[]
+}
+
+function BalanceRow({
+  entry,
+  showPaidToggle,
+}: {
+  entry: BalanceEntry
+  showPaidToggle?: boolean
+}) {
+  const markPaid = useMarkItemPaid()
+
+  return (
+    <Collapsible>
+      <CollapsibleTrigger className="flex w-full items-center justify-between rounded-md p-2 text-sm hover:bg-muted">
+        <span>{entry.userName ?? "(unknown)"}</span>
+        <div className="flex items-center gap-2">
+          <span className="font-medium">${entry.netAmount}</span>
+          <IconChevronRight className="size-4 transition-transform [[data-state=open]_&]:rotate-90" />
+        </div>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="ml-2 border-l pb-2 pl-3">
+          {entry.expenses.map((exp) => {
+            const isPaid = !!exp.paidAt
+            return (
+              <div
+                key={exp.itemId}
+                className="flex items-center justify-between py-1 text-xs text-muted-foreground"
+              >
+                <div className="flex items-center gap-2">
+                  {showPaidToggle && (
+                    <Checkbox
+                      checked={isPaid}
+                      onCheckedChange={(checked) => {
+                        markPaid.mutate({
+                          itemId: exp.itemId,
+                          paid: !!checked,
+                        })
+                      }}
+                    />
+                  )}
+                  <span className={isPaid ? "line-through opacity-50" : ""}>
+                    {exp.name}
+                  </span>
+                </div>
+                <span className={isPaid ? "line-through opacity-50" : ""}>
+                  ${exp.amount}
+                </span>
+              </div>
+            )
+          })}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}
+
+export function BalanceOverview({ iOwe, owedToMe }: BalanceOverviewProps) {
+  const totalIOwe = iOwe.reduce((s, e) => s + e.netAmount, 0)
+  const totalOwedToMe = owedToMe.reduce((s, e) => s + e.netAmount, 0)
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      <div className="rounded-3xl border p-4">
+        <div className="mb-3 flex items-center justify-between">
+          <h3 className="text-sm font-medium">你欠別人</h3>
+          {totalIOwe > 0 && <Badge variant="secondary">${totalIOwe}</Badge>}
+        </div>
+        {iOwe.length === 0 ? (
+          <p className="text-xs text-muted-foreground">沒有欠款</p>
+        ) : (
+          iOwe.map((entry) => <BalanceRow key={entry.userId} entry={entry} />)
+        )}
+      </div>
+
+      <div className="rounded-3xl border p-4">
+        <div className="mb-3 flex items-center justify-between">
+          <h3 className="text-sm font-medium">別人欠你</h3>
+          {totalOwedToMe > 0 && (
+            <Badge variant="secondary">${totalOwedToMe}</Badge>
+          )}
+        </div>
+        {owedToMe.length === 0 ? (
+          <p className="text-xs text-muted-foreground">沒有人欠你錢</p>
+        ) : (
+          owedToMe.map((entry) => (
+            <BalanceRow key={entry.userId} entry={entry} showPaidToggle />
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/portal/app/debt/_components/debt-home.tsx
+++ b/apps/portal/app/debt/_components/debt-home.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { IconPlus } from "@tabler/icons-react"
+import { useState } from "react"
+
+import { Button } from "@workspace/ui/components/button"
+
+import { useBalances } from "@/hooks/debt/use-balances"
+import { useMembers } from "@/hooks/debt/use-members"
+import { useMyExpenses } from "@/hooks/debt/use-expenses"
+import type { Expense } from "@/lib/debt/types"
+
+import { BalanceOverview } from "./balance-overview"
+import { ExpenseCard } from "./expense-card"
+import { ExpenseForm } from "./expense-form"
+
+export function DebtHome() {
+  const { data: balances } = useBalances()
+  const { data: expenses } = useMyExpenses()
+  const { data: members = [] } = useMembers()
+
+  const [showForm, setShowForm] = useState(false)
+  const [editingExpense, setEditingExpense] = useState<Expense | null>(null)
+
+  const handleEdit = (expense: Expense) => {
+    setEditingExpense(expense)
+    setShowForm(true)
+  }
+
+  const handleNew = () => {
+    setEditingExpense(null)
+    setShowForm(true)
+  }
+
+  const handleClose = () => {
+    setShowForm(false)
+    setEditingExpense(null)
+  }
+
+  return (
+    <div className="grid gap-6">
+      <section>
+        <BalanceOverview
+          iOwe={balances?.iOwe ?? []}
+          owedToMe={balances?.owedToMe ?? []}
+        />
+      </section>
+
+      <section>
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-sm font-medium">我的分帳</h2>
+          {!showForm && (
+            <Button size="sm" onClick={handleNew}>
+              <IconPlus />
+              新增
+            </Button>
+          )}
+        </div>
+
+        {showForm && (
+          <div className="mb-4">
+            <ExpenseForm expense={editingExpense} onClose={handleClose} />
+          </div>
+        )}
+
+        {!expenses || expenses.length === 0 ? (
+          <p className="text-xs text-muted-foreground">還沒有任何分帳紀錄</p>
+        ) : (
+          <div className="grid gap-1">
+            {expenses.map((expense) => (
+              <ExpenseCard
+                key={expense.id}
+                expense={expense}
+                members={members}
+                onEdit={handleEdit}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/apps/portal/app/debt/_components/expense-card.tsx
+++ b/apps/portal/app/debt/_components/expense-card.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { IconChevronRight, IconPencil } from "@tabler/icons-react"
+
+import { Button } from "@workspace/ui/components/button"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@workspace/ui/components/collapsible"
+
+import type { Expense, Member } from "@/lib/debt/types"
+
+interface ExpenseCardProps {
+  expense: Expense
+  members: Member[]
+  onEdit: (expense: Expense) => void
+  editable?: boolean
+}
+
+export function ExpenseCard({
+  expense,
+  members,
+  onEdit,
+  editable = true,
+}: ExpenseCardProps) {
+  const nameMap = new Map(members.map((m) => [m.id, m.name]))
+  const total = expense.items.reduce((s, i) => s + Number(i.amount), 0)
+  const date = new Date(expense.created_at).toLocaleDateString("zh-TW", {
+    month: "numeric",
+    day: "numeric",
+  })
+
+  return (
+    <Collapsible>
+      <div className="flex items-center gap-2">
+        <CollapsibleTrigger className="flex flex-1 items-center justify-between rounded-md p-2 text-sm hover:bg-muted">
+          <div className="flex items-center gap-2">
+            <IconChevronRight className="size-4 transition-transform [[data-state=open]_&]:rotate-90" />
+            <span>{expense.name}</span>
+            <span className="text-xs text-muted-foreground">{date}</span>
+          </div>
+          <span className="font-medium">${total}</span>
+        </CollapsibleTrigger>
+        {editable && (
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => onEdit(expense)}
+          >
+            <IconPencil />
+          </Button>
+        )}
+      </div>
+      <CollapsibleContent>
+        <div className="ml-8 border-l pb-2 pl-3">
+          {expense.items.map((item) => (
+            <div
+              key={item.id}
+              className="flex items-center justify-between py-1 text-xs text-muted-foreground"
+            >
+              <span>{nameMap.get(item.debtor_id) ?? "(unknown)"}</span>
+              <span>${Number(item.amount)}</span>
+            </div>
+          ))}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}

--- a/apps/portal/app/debt/_components/expense-form.tsx
+++ b/apps/portal/app/debt/_components/expense-form.tsx
@@ -1,0 +1,241 @@
+"use client"
+
+import { IconPlus, IconTrash, IconX } from "@tabler/icons-react"
+import { useEffect, useState } from "react"
+import { toast } from "sonner"
+
+import { Button } from "@workspace/ui/components/button"
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@workspace/ui/components/card"
+import { Input } from "@workspace/ui/components/input"
+import { Label } from "@workspace/ui/components/label"
+import { Separator } from "@workspace/ui/components/separator"
+
+import {
+  useCreateExpense,
+  useDeleteExpense,
+  useUpdateExpense,
+} from "@/hooks/debt/use-expenses"
+import { useMembers } from "@/hooks/debt/use-members"
+import { useAuth } from "@/hooks/use-auth"
+import type { Expense } from "@/lib/debt/types"
+
+import { MemberSelect } from "./member-select"
+
+interface DebtorRow {
+  key: string
+  debtorId: string
+  amount: string
+}
+
+interface ExpenseFormProps {
+  expense?: Expense | null
+  onClose: () => void
+}
+
+export function ExpenseForm({ expense, onClose }: ExpenseFormProps) {
+  const { user } = useAuth()
+  const { data: members = [] } = useMembers()
+  const createExpense = useCreateExpense()
+  const updateExpense = useUpdateExpense()
+  const deleteExpense = useDeleteExpense()
+
+  const [name, setName] = useState("")
+  const [description, setDescription] = useState("")
+  const [rows, setRows] = useState<DebtorRow[]>([
+    { key: crypto.randomUUID(), debtorId: "", amount: "" },
+  ])
+
+  const isEdit = !!expense
+
+  useEffect(() => {
+    if (expense) {
+      setName(expense.name)
+      setDescription(expense.description ?? "")
+      setRows(
+        expense.items.map((item) => ({
+          key: crypto.randomUUID(),
+          debtorId: item.debtor_id,
+          amount: String(item.amount),
+        }))
+      )
+    }
+  }, [expense])
+
+  const addRow = () => {
+    setRows([...rows, { key: crypto.randomUUID(), debtorId: "", amount: "" }])
+  }
+
+  const removeRow = (key: string) => {
+    if (rows.length <= 1) return
+    setRows(rows.filter((r) => r.key !== key))
+  }
+
+  const updateRow = (
+    key: string,
+    field: "debtorId" | "amount",
+    value: string
+  ) => {
+    setRows(rows.map((r) => (r.key === key ? { ...r, [field]: value } : r)))
+  }
+
+  const total = rows.reduce((sum, r) => sum + (Number(r.amount) || 0), 0)
+  const selectedDebtorIds = rows.map((r) => r.debtorId).filter(Boolean)
+
+  const handleSave = async () => {
+    const validRows = rows.filter((r) => r.debtorId && Number(r.amount) > 0)
+    if (!name.trim() || validRows.length === 0) {
+      toast.error("請填寫名稱和至少一筆分帳")
+      return
+    }
+
+    const items = validRows.map((r) => ({
+      debtor_id: r.debtorId,
+      amount: Number(r.amount),
+    }))
+
+    try {
+      if (isEdit) {
+        await updateExpense.mutateAsync({
+          id: expense!.id,
+          name: name.trim(),
+          description: description.trim() || undefined,
+          items,
+        })
+        toast.success("分帳已更新")
+      } else {
+        await createExpense.mutateAsync({
+          name: name.trim(),
+          description: description.trim() || undefined,
+          items,
+        })
+        toast.success("分帳已建立")
+      }
+      onClose()
+    } catch (err: unknown) {
+      const msg =
+        (err as { message?: string })?.message ??
+        (err as { details?: string })?.details ??
+        JSON.stringify(err)
+      toast.error(`操作失敗：${msg}`)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!expense) return
+    try {
+      await deleteExpense.mutateAsync(expense.id)
+      toast.success("分帳已刪除")
+      onClose()
+    } catch {
+      toast.error("刪除失敗")
+    }
+  }
+
+  const isPending =
+    createExpense.isPending ||
+    updateExpense.isPending ||
+    deleteExpense.isPending
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">
+          {isEdit ? "編輯分帳" : "新增分帳"}
+        </CardTitle>
+        <CardAction>
+          <Button variant="ghost" size="icon-sm" onClick={onClose}>
+            <IconX />
+          </Button>
+        </CardAction>
+      </CardHeader>
+      <CardContent className="grid gap-4">
+        <div className="grid gap-2">
+          <Label htmlFor="name">名稱</Label>
+          <Input
+            id="name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="名稱"
+          />
+        </div>
+
+        <div className="grid gap-2">
+          <Label htmlFor="description">備註（選填）</Label>
+          <Input
+            id="description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="備註"
+          />
+        </div>
+
+        <Separator />
+
+        <div className="grid gap-3">
+          <Label>分帳明細</Label>
+          {rows.map((row) => (
+            <div key={row.key} className="flex items-center gap-2">
+              <div className="flex-1">
+                <MemberSelect
+                  members={members}
+                  value={row.debtorId}
+                  onSelect={(id) => updateRow(row.key, "debtorId", id)}
+                  excludeIds={[
+                    user?.id ?? "",
+                    ...selectedDebtorIds.filter((id) => id !== row.debtorId),
+                  ]}
+                />
+              </div>
+              <Input
+                type="number"
+                min="0"
+                step="1"
+                className="w-24"
+                value={row.amount}
+                onChange={(e) => updateRow(row.key, "amount", e.target.value)}
+                placeholder="金額"
+              />
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => removeRow(row.key)}
+                disabled={rows.length <= 1}
+              >
+                <IconTrash />
+              </Button>
+            </div>
+          ))}
+
+          <Button variant="outline" size="sm" onClick={addRow}>
+            <IconPlus />
+            新增
+          </Button>
+        </div>
+      </CardContent>
+      <CardFooter className="justify-between">
+        <span className="text-sm text-muted-foreground">合計：${total}</span>
+        <div className="flex gap-2">
+          {isEdit && (
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={isPending}
+            >
+              刪除
+            </Button>
+          )}
+          <Button onClick={handleSave} disabled={isPending}>
+            {isPending ? "處理中..." : "儲存"}
+          </Button>
+        </div>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/apps/portal/app/debt/_components/member-select.tsx
+++ b/apps/portal/app/debt/_components/member-select.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import { IconChevronDown } from "@tabler/icons-react"
+import { useState } from "react"
+
+import { Button } from "@workspace/ui/components/button"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@workspace/ui/components/command"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@workspace/ui/components/popover"
+
+import type { Member } from "@/lib/debt/types"
+
+interface MemberSelectProps {
+  members: Member[]
+  value: string
+  onSelect: (memberId: string) => void
+  excludeIds?: string[]
+  placeholder?: string
+}
+
+export function MemberSelect({
+  members,
+  value,
+  onSelect,
+  excludeIds = [],
+  placeholder = "選擇成員",
+}: MemberSelectProps) {
+  const [open, setOpen] = useState(false)
+  const filtered = members.filter((m) => !excludeIds.includes(m.id))
+  const selected = filtered.find((m) => m.id === value) ?? null
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className="w-full justify-between"
+        >
+          <span className={selected ? "" : "text-muted-foreground"}>
+            {selected?.name ?? placeholder}
+          </span>
+          <IconChevronDown data-icon="inline-end" className="opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-(--radix-popover-trigger-width) p-0">
+        <Command>
+          <CommandInput placeholder="搜尋成員" />
+          <CommandList>
+            <CommandEmpty>找不到成員</CommandEmpty>
+            <CommandGroup>
+              {filtered.map((member) => (
+                <CommandItem
+                  key={member.id}
+                  value={member.name ?? member.id}
+                  data-checked={member.id === value}
+                  onSelect={() => {
+                    onSelect(member.id)
+                    setOpen(false)
+                  }}
+                >
+                  {member.name ?? "(unnamed)"}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/portal/app/debt/_components/query-provider.tsx
+++ b/apps/portal/app/debt/_components/query-provider.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { useState, type ReactNode } from "react"
+
+export function QueryProvider({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 1000 * 60,
+            refetchOnWindowFocus: false,
+          },
+        },
+      })
+  )
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}

--- a/apps/portal/app/debt/_components/settlement-card.tsx
+++ b/apps/portal/app/debt/_components/settlement-card.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { IconArrowRight, IconCheck } from "@tabler/icons-react"
+import { toast } from "sonner"
+
+import { Badge } from "@workspace/ui/components/badge"
+import { Button } from "@workspace/ui/components/button"
+
+import {
+  useConfirmSettlement,
+  type SettlementWithNames,
+} from "@/hooks/debt/use-settlements"
+import { useAuth } from "@/hooks/use-auth"
+
+interface SettlementCardProps {
+  settlement: SettlementWithNames
+}
+
+export function SettlementCard({ settlement }: SettlementCardProps) {
+  const { user } = useAuth()
+  const confirm = useConfirmSettlement()
+
+  const isFrom = settlement.from_user_id === user?.id
+  const isTo = settlement.to_user_id === user?.id
+  const myConfirmed = isFrom
+    ? settlement.from_confirmed
+    : isTo
+      ? settlement.to_confirmed
+      : true
+
+  const handleConfirm = async () => {
+    try {
+      await confirm.mutateAsync(settlement.id)
+      toast.success(isFrom ? "已確認轉帳" : "已確認收款")
+    } catch {
+      toast.error("確認失敗")
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-between rounded-md border p-3 text-sm">
+      <div className="flex items-center gap-2">
+        <span>{settlement.from_user_name}</span>
+        <IconArrowRight className="size-4 text-muted-foreground" />
+        <span>{settlement.to_user_name}</span>
+        <span className="font-medium">${settlement.amount}</span>
+        <Badge variant="secondary">{settlement.period}</Badge>
+      </div>
+
+      <div className="flex items-center gap-2">
+        {settlement.from_confirmed && (
+          <Badge variant="outline" className="text-xs">
+            已轉
+          </Badge>
+        )}
+        {settlement.to_confirmed && (
+          <Badge variant="outline" className="text-xs">
+            已收
+          </Badge>
+        )}
+        {!myConfirmed && (
+          <Button
+            size="sm"
+            onClick={handleConfirm}
+            disabled={confirm.isPending}
+          >
+            <IconCheck />
+            {isFrom ? "確認已轉" : "確認已收"}
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/portal/app/debt/_components/settlements-list.tsx
+++ b/apps/portal/app/debt/_components/settlements-list.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { useMySettlements } from "@/hooks/debt/use-settlements"
+
+import { SettlementCard } from "./settlement-card"
+
+export function SettlementsList() {
+  const { data: settlements, isLoading } = useMySettlements()
+
+  if (isLoading && !settlements) {
+    return <p className="text-sm text-muted-foreground">載入結算紀錄中...</p>
+  }
+
+  if (!settlements || settlements.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        目前沒有待結算項目。每月 10 號自動產生上個月的結算單。
+      </p>
+    )
+  }
+
+  return (
+    <div className="grid gap-2">
+      {settlements.map((s) => (
+        <SettlementCard key={s.id} settlement={s} />
+      ))}
+    </div>
+  )
+}

--- a/apps/portal/app/debt/layout.tsx
+++ b/apps/portal/app/debt/layout.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+
+import { Toaster } from "@workspace/ui/components/sonner"
+
+import { PortalShell } from "@/components/portal-shell"
+
+import { QueryProvider } from "./_components/query-provider"
+
+export const metadata: Metadata = {
+  title: "Debt | Portal",
+  description: "WinLab bill-splitting.",
+}
+
+export default function DebtLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <QueryProvider>
+      <PortalShell
+        appName="Debt"
+        appHref="/debt"
+        topRight={
+          <nav>
+            <Link
+              href="/debt/settlements"
+              className="transition-colors hover:text-foreground"
+            >
+              Settlements
+            </Link>
+          </nav>
+        }
+        bottomLeft={
+          <Link href="/" className="transition-colors hover:text-foreground">
+            Portal
+          </Link>
+        }
+      >
+        {children}
+      </PortalShell>
+      <Toaster />
+    </QueryProvider>
+  )
+}

--- a/apps/portal/app/debt/page.tsx
+++ b/apps/portal/app/debt/page.tsx
@@ -1,0 +1,5 @@
+import { DebtHome } from "./_components/debt-home"
+
+export default function DebtPage() {
+  return <DebtHome />
+}

--- a/apps/portal/app/debt/settlements/page.tsx
+++ b/apps/portal/app/debt/settlements/page.tsx
@@ -1,0 +1,15 @@
+import { SettlementsList } from "../_components/settlements-list"
+
+export default function DebtSettlementsPage() {
+  return (
+    <div className="grid gap-6">
+      <div className="flex flex-col gap-1">
+        <h1 className="font-medium">結算單</h1>
+        <p className="text-sm text-muted-foreground">
+          每月 10 號自動產生上個月的淨額結算。雙方確認後關閉。
+        </p>
+      </div>
+      <SettlementsList />
+    </div>
+  )
+}

--- a/apps/portal/app/page.tsx
+++ b/apps/portal/app/page.tsx
@@ -13,6 +13,7 @@ const apps = [
   { href: "/leave", label: "Leave", note: "請假登記" },
   { href: "/approve", label: "Approve", note: "文件簽核" },
   { href: "/trip", label: "Trip", note: "出差文件" },
+  { href: "/debt", label: "Debt", note: "分帳記帳" },
   { href: "/profile", label: "Profile", note: "個人帳號" },
   { href: "https://gallery.winlab.tw", label: "Gallery", note: "藝術畫廊" },
 ]

--- a/apps/portal/hooks/debt/query-keys.ts
+++ b/apps/portal/hooks/debt/query-keys.ts
@@ -1,0 +1,17 @@
+export const queryKeys = {
+  members: {
+    all: ["debt", "members"] as const,
+  },
+  expenses: {
+    all: ["debt", "expenses"] as const,
+    mine: () => [...queryKeys.expenses.all, "mine"] as const,
+  },
+  balances: {
+    all: ["debt", "balances"] as const,
+    mine: () => [...queryKeys.balances.all, "mine"] as const,
+  },
+  settlements: {
+    all: ["debt", "settlements"] as const,
+    mine: () => [...queryKeys.settlements.all, "mine"] as const,
+  },
+}

--- a/apps/portal/hooks/debt/use-balances.ts
+++ b/apps/portal/hooks/debt/use-balances.ts
@@ -1,0 +1,64 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+
+import { useAuth } from "@/hooks/use-auth"
+import { computeBalances, getUnsettledPeriodStart } from "@/lib/debt/balance"
+import type { Balances } from "@/lib/debt/types"
+import { createClient } from "@/lib/supabase/client"
+
+import { queryKeys } from "./query-keys"
+
+export function useBalances() {
+  const supabase = createClient()
+  const { user } = useAuth()
+
+  return useQuery({
+    queryKey: queryKeys.balances.mine(),
+    queryFn: async (): Promise<Balances> => {
+      if (!user) return { iOwe: [], owedToMe: [] }
+
+      const { data: latestSettlement } = await supabase
+        .from("debt_settlements")
+        .select("period")
+        .order("period", { ascending: false })
+        .limit(1)
+        .maybeSingle()
+
+      const periodStart = getUnsettledPeriodStart(
+        latestSettlement?.period ?? null
+      )
+
+      const { data: items, error } = await supabase
+        .from("debt_expense_items")
+        .select(
+          "id, debtor_id, amount, paid_at, expense:debt_expenses!inner(id, name, creator_id, created_at)"
+        )
+        .gte("expense.created_at", periodStart)
+
+      if (error) throw error
+      if (!items || items.length === 0) return { iOwe: [], owedToMe: [] }
+
+      const userIds = new Set<string>()
+      for (const item of items) {
+        const expense = item.expense as unknown as { creator_id: string }
+        userIds.add(item.debtor_id)
+        userIds.add(expense.creator_id)
+      }
+
+      const { data: profiles } = await supabase
+        .from("user_profiles")
+        .select("id, name")
+        .in("id", Array.from(userIds))
+
+      const nameMap = new Map((profiles ?? []).map((p) => [p.id, p.name]))
+
+      return computeBalances(
+        items as unknown as Parameters<typeof computeBalances>[0],
+        user.id,
+        nameMap
+      )
+    },
+    enabled: !!user,
+  })
+}

--- a/apps/portal/hooks/debt/use-expenses.ts
+++ b/apps/portal/hooks/debt/use-expenses.ts
@@ -1,0 +1,122 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { useAuth } from "@/hooks/use-auth"
+import type { Expense } from "@/lib/debt/types"
+import { createClient } from "@/lib/supabase/client"
+
+import { queryKeys } from "./query-keys"
+
+export function useMyExpenses() {
+  const supabase = createClient()
+  const { user } = useAuth()
+
+  return useQuery({
+    queryKey: queryKeys.expenses.mine(),
+    queryFn: async () => {
+      if (!user) return []
+      const { data, error } = await supabase
+        .from("debt_expenses")
+        .select("*, items:debt_expense_items(id, debtor_id, amount)")
+        .eq("creator_id", user.id)
+        .order("created_at", { ascending: false })
+
+      if (error) throw error
+      return (data ?? []) as Expense[]
+    },
+    enabled: !!user,
+  })
+}
+
+interface ExpenseInput {
+  name: string
+  description?: string
+  items: { debtor_id: string; amount: number }[]
+}
+
+export function useCreateExpense() {
+  const supabase = createClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input: ExpenseInput) => {
+      const { data, error } = await supabase.rpc("debt_create_expense", {
+        p_name: input.name,
+        p_description: input.description || null,
+        p_items: input.items,
+      })
+
+      if (error) throw error
+      return data as string
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.expenses.all })
+      queryClient.invalidateQueries({ queryKey: queryKeys.balances.all })
+    },
+  })
+}
+
+interface UpdateExpenseInput extends ExpenseInput {
+  id: string
+}
+
+export function useUpdateExpense() {
+  const supabase = createClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (input: UpdateExpenseInput) => {
+      const { error } = await supabase.rpc("debt_update_expense", {
+        p_expense_id: input.id,
+        p_name: input.name,
+        p_description: input.description || null,
+        p_items: input.items,
+      })
+
+      if (error) throw error
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.expenses.all })
+      queryClient.invalidateQueries({ queryKey: queryKeys.balances.all })
+    },
+  })
+}
+
+export function useMarkItemPaid() {
+  const supabase = createClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ itemId, paid }: { itemId: string; paid: boolean }) => {
+      const { error } = await supabase.rpc("debt_mark_item_paid", {
+        p_item_id: itemId,
+        p_paid: paid,
+      })
+      if (error) throw error
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.balances.all })
+    },
+  })
+}
+
+export function useDeleteExpense() {
+  const supabase = createClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await supabase
+        .from("debt_expenses")
+        .delete()
+        .eq("id", id)
+
+      if (error) throw error
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.expenses.all })
+      queryClient.invalidateQueries({ queryKey: queryKeys.balances.all })
+    },
+  })
+}

--- a/apps/portal/hooks/debt/use-members.ts
+++ b/apps/portal/hooks/debt/use-members.ts
@@ -1,0 +1,25 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+
+import type { Member } from "@/lib/debt/types"
+import { createClient } from "@/lib/supabase/client"
+
+import { queryKeys } from "./query-keys"
+
+export function useMembers() {
+  const supabase = createClient()
+
+  return useQuery({
+    queryKey: queryKeys.members.all,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("user_profiles")
+        .select("id, name")
+        .order("name")
+
+      if (error) throw error
+      return data as Member[]
+    },
+  })
+}

--- a/apps/portal/hooks/debt/use-settlements.ts
+++ b/apps/portal/hooks/debt/use-settlements.ts
@@ -1,0 +1,92 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { useAuth } from "@/hooks/use-auth"
+import type { Member, Settlement } from "@/lib/debt/types"
+import { createClient } from "@/lib/supabase/client"
+
+import { queryKeys } from "./query-keys"
+
+export interface SettlementWithNames extends Settlement {
+  from_user_name: string | null
+  to_user_name: string | null
+}
+
+export function useMySettlements() {
+  const supabase = createClient()
+  const { user } = useAuth()
+
+  return useQuery({
+    queryKey: queryKeys.settlements.mine(),
+    queryFn: async () => {
+      if (!user) return [] as SettlementWithNames[]
+      const { data, error } = await supabase
+        .from("debt_settlements")
+        .select("*")
+        .or(`from_user_id.eq.${user.id},to_user_id.eq.${user.id}`)
+        .is("settled_at", null)
+        .order("created_at", { ascending: false })
+
+      if (error) throw error
+      if (!data || data.length === 0) return [] as SettlementWithNames[]
+
+      const userIds = new Set<string>()
+      for (const s of data) {
+        userIds.add(s.from_user_id)
+        userIds.add(s.to_user_id)
+      }
+
+      const { data: profiles } = await supabase
+        .from("user_profiles")
+        .select("id, name")
+        .in("id", Array.from(userIds))
+
+      const nameMap = new Map(
+        (profiles ?? []).map((p: Member) => [p.id, p.name])
+      )
+
+      return data.map((s) => ({
+        ...s,
+        from_user_name: nameMap.get(s.from_user_id) ?? null,
+        to_user_name: nameMap.get(s.to_user_id) ?? null,
+      })) as SettlementWithNames[]
+    },
+    enabled: !!user,
+  })
+}
+
+export function useConfirmSettlement() {
+  const supabase = createClient()
+  const { user } = useAuth()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (settlementId: string) => {
+      if (!user) throw new Error("Not authenticated")
+
+      const { data: settlement } = await supabase
+        .from("debt_settlements")
+        .select("from_user_id, to_user_id")
+        .eq("id", settlementId)
+        .single()
+
+      if (!settlement) throw new Error("Settlement not found")
+
+      if (settlement.from_user_id === user.id) {
+        const { error } = await supabase.rpc("debt_confirm_settlement_from", {
+          p_settlement_id: settlementId,
+        })
+        if (error) throw error
+      } else if (settlement.to_user_id === user.id) {
+        const { error } = await supabase.rpc("debt_confirm_settlement_to", {
+          p_settlement_id: settlementId,
+        })
+        if (error) throw error
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.settlements.all })
+    },
+  })
+}

--- a/apps/portal/lib/debt/balance.ts
+++ b/apps/portal/lib/debt/balance.ts
@@ -1,0 +1,98 @@
+import type { BalanceEntry, BalanceExpense, Balances } from "@/lib/debt/types"
+
+interface ExpenseItemRow {
+  id: string
+  debtor_id: string
+  amount: number
+  paid_at: string | null
+  expense: {
+    id: string
+    name: string
+    creator_id: string
+    created_at: string
+  }
+}
+
+// Settlement period is "YYYY-MM"; the next month's first instant is when the
+// post-settlement window starts. If we've never settled, look back to epoch.
+export function getUnsettledPeriodStart(latestPeriod: string | null): string {
+  if (!latestPeriod) return "1970-01-01T00:00:00Z"
+
+  const match = latestPeriod.match(/^(\d{4})-(\d{2})$/)
+  if (!match) return "1970-01-01T00:00:00Z"
+
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const nextMonth = month === 12 ? 1 : month + 1
+  const nextYear = month === 12 ? year + 1 : year
+  return `${nextYear}-${String(nextMonth).padStart(2, "0")}-01T00:00:00Z`
+}
+
+export function computeBalances(
+  items: ExpenseItemRow[],
+  userId: string,
+  nameMap: Map<string, string | null>
+): Balances {
+  const balanceMap = new Map<
+    string,
+    { net: number; total: number; expenses: Map<string, BalanceExpense> }
+  >()
+
+  for (const item of items) {
+    const { expense } = item
+    const amount = Number(item.amount)
+    const isPaid = !!item.paid_at
+    let otherId: string
+    let sign: number
+
+    if (expense.creator_id === userId) {
+      otherId = item.debtor_id
+      sign = 1
+    } else if (item.debtor_id === userId) {
+      otherId = expense.creator_id
+      sign = -1
+    } else {
+      continue
+    }
+
+    const entry = balanceMap.get(otherId) ?? {
+      net: 0,
+      total: 0,
+      expenses: new Map(),
+    }
+    entry.total += sign * amount
+    if (!isPaid) {
+      entry.net += sign * amount
+    }
+
+    entry.expenses.set(`${expense.id}:${item.id}`, {
+      id: expense.id,
+      itemId: item.id,
+      name: expense.name,
+      amount,
+      paidAt: item.paid_at,
+      createdAt: expense.created_at,
+    })
+    balanceMap.set(otherId, entry)
+  }
+
+  const iOwe: BalanceEntry[] = []
+  const owedToMe: BalanceEntry[] = []
+
+  for (const [uid, { net, total, expenses }] of balanceMap) {
+    if (total === 0) continue
+    const entry: BalanceEntry = {
+      userId: uid,
+      userName: nameMap.get(uid) ?? null,
+      netAmount: Math.abs(net),
+      expenses: Array.from(expenses.values()),
+    }
+    if (total > 0) owedToMe.push(entry)
+    else iOwe.push(entry)
+  }
+
+  iOwe.sort((a, b) => b.netAmount - a.netAmount)
+  owedToMe.sort((a, b) => b.netAmount - a.netAmount)
+
+  return { iOwe, owedToMe }
+}

--- a/apps/portal/lib/debt/types.ts
+++ b/apps/portal/lib/debt/types.ts
@@ -1,0 +1,54 @@
+export interface Member {
+  id: string
+  name: string | null
+}
+
+export interface ExpenseItem {
+  id: string
+  expense_id: string
+  debtor_id: string
+  amount: number
+  created_at: string
+}
+
+export interface Expense {
+  id: string
+  creator_id: string
+  name: string
+  description: string | null
+  created_at: string
+  items: ExpenseItem[]
+}
+
+export interface Settlement {
+  id: string
+  period: string
+  from_user_id: string
+  to_user_id: string
+  amount: number
+  from_confirmed: boolean
+  to_confirmed: boolean
+  settled_at: string | null
+  created_at: string
+}
+
+export interface BalanceExpense {
+  id: string
+  itemId: string
+  name: string
+  amount: number
+  paidAt: string | null
+  createdAt: string
+}
+
+export interface BalanceEntry {
+  userId: string
+  userName: string | null
+  netAmount: number
+  expenses: BalanceExpense[]
+}
+
+export interface Balances {
+  iOwe: BalanceEntry[]
+  owedToMe: BalanceEntry[]
+}

--- a/packages/ui/src/components/collapsible.tsx
+++ b/packages/ui/src/components/collapsible.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import * as React from "react"
+import { Collapsible as CollapsiblePrimitive } from "radix-ui"
+
+function Collapsible({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
+}
+
+function CollapsibleTrigger({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleTrigger
+      data-slot="collapsible-trigger"
+      {...props}
+    />
+  )
+}
+
+function CollapsibleContent({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleContent
+      data-slot="collapsible-content"
+      {...props}
+    />
+  )
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/supabase/migrations/2026-05-02-debt-app.sql
+++ b/supabase/migrations/2026-05-02-debt-app.sql
@@ -1,0 +1,336 @@
+-- debt app: bill-splitting (migrated from debit.winlab.tw).
+-- Net-balance bookkeeping with monthly cron-generated settlements.
+--
+-- Schema mirrors the legacy `debit_*` tables but renamed to `debt_*` to align
+-- with the app namespace. RPCs and helpers are also `debt_`-prefixed so the new
+-- tables can run side-by-side with the old ones during transition. A follow-up
+-- migration drops `debit_*` once portal /debt is verified stable.
+
+-- =============================================================================
+-- Tables
+-- =============================================================================
+
+create table public.debt_expenses (
+  id           uuid primary key default gen_random_uuid(),
+  creator_id   uuid not null references public.user_profiles(id) default auth.uid(),
+  name         text not null,
+  description  text,
+  created_at   timestamptz not null default now()
+);
+
+create index debt_expenses_creator_created
+  on public.debt_expenses (creator_id, created_at desc);
+
+create table public.debt_expense_items (
+  id           uuid primary key default gen_random_uuid(),
+  expense_id   uuid not null references public.debt_expenses(id) on delete cascade,
+  debtor_id    uuid not null references public.user_profiles(id),
+  amount       numeric not null check (amount > 0),
+  paid_at      timestamptz,
+  created_at   timestamptz not null default now()
+);
+
+create index debt_expense_items_debtor on public.debt_expense_items (debtor_id);
+create index debt_expense_items_expense on public.debt_expense_items (expense_id);
+
+create table public.debt_settlements (
+  id              uuid primary key default gen_random_uuid(),
+  period          text not null check (period ~ '^\d{4}-\d{2}$'),
+  from_user_id    uuid not null references public.user_profiles(id),
+  to_user_id      uuid not null references public.user_profiles(id),
+  amount          numeric not null check (amount > 0),
+  from_confirmed  boolean not null default false,
+  to_confirmed    boolean not null default false,
+  settled_at      timestamptz,
+  created_at      timestamptz not null default now(),
+  check (from_user_id <> to_user_id),
+  unique (period, from_user_id, to_user_id)
+);
+
+create index debt_settlements_users
+  on public.debt_settlements (from_user_id, to_user_id, period);
+
+-- =============================================================================
+-- Trigger: debtor cannot be the same as expense creator
+-- =============================================================================
+
+create or replace function public.debt_check_debtor_not_creator()
+returns trigger
+language plpgsql
+as $$
+begin
+  if new.debtor_id = (select creator_id from public.debt_expenses where id = new.expense_id) then
+    raise exception 'debtor cannot be the same as expense creator';
+  end if;
+  return new;
+end;
+$$;
+
+create trigger trg_debt_check_debtor_not_creator
+before insert or update on public.debt_expense_items
+for each row
+execute function public.debt_check_debtor_not_creator();
+
+-- =============================================================================
+-- Helper: is current user a debtor on this expense?
+-- (security definer to avoid recursive RLS evaluation in the SELECT policy)
+-- =============================================================================
+
+create or replace function public.is_debt_expense_debtor(expense_uuid uuid)
+returns boolean
+language sql
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1 from public.debt_expense_items
+    where expense_id = expense_uuid and debtor_id = auth.uid()
+  );
+$$;
+
+-- =============================================================================
+-- RLS
+-- =============================================================================
+
+alter table public.debt_expenses      enable row level security;
+alter table public.debt_expense_items enable row level security;
+alter table public.debt_settlements   enable row level security;
+
+-- debt_expenses: creator full CRUD; debtor read-only.
+create policy "debt_expenses_select" on public.debt_expenses
+for select using (creator_id = auth.uid() or public.is_debt_expense_debtor(id));
+
+create policy "debt_expenses_insert" on public.debt_expenses
+for insert with check (creator_id = auth.uid());
+
+create policy "debt_expenses_update" on public.debt_expenses
+for update using (creator_id = auth.uid());
+
+create policy "debt_expenses_delete" on public.debt_expenses
+for delete using (creator_id = auth.uid());
+
+-- debt_expense_items: debtor reads their own row; creator full CRUD on their expense's items.
+create policy "debt_expense_items_select" on public.debt_expense_items
+for select using (
+  debtor_id = auth.uid()
+  or expense_id in (select id from public.debt_expenses where creator_id = auth.uid())
+);
+
+create policy "debt_expense_items_insert" on public.debt_expense_items
+for insert with check (
+  expense_id in (select id from public.debt_expenses where creator_id = auth.uid())
+);
+
+create policy "debt_expense_items_update" on public.debt_expense_items
+for update using (
+  expense_id in (select id from public.debt_expenses where creator_id = auth.uid())
+);
+
+create policy "debt_expense_items_delete" on public.debt_expense_items
+for delete using (
+  expense_id in (select id from public.debt_expenses where creator_id = auth.uid())
+);
+
+-- debt_settlements: involved users can read; writes only via RPC (no INSERT/UPDATE/DELETE policy).
+create policy "debt_settlements_select" on public.debt_settlements
+for select using (from_user_id = auth.uid() or to_user_id = auth.uid());
+
+-- =============================================================================
+-- RPC: expense create / update / mark item paid (creator-scoped writes)
+-- =============================================================================
+
+create or replace function public.debt_create_expense(
+  p_name text,
+  p_description text,
+  p_items jsonb
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_expense_id uuid;
+  v_item jsonb;
+begin
+  insert into public.debt_expenses (creator_id, name, description)
+  values (auth.uid(), p_name, p_description)
+  returning id into v_expense_id;
+
+  for v_item in select * from jsonb_array_elements(p_items)
+  loop
+    insert into public.debt_expense_items (expense_id, debtor_id, amount)
+    values (
+      v_expense_id,
+      (v_item->>'debtor_id')::uuid,
+      (v_item->>'amount')::numeric
+    );
+  end loop;
+
+  return v_expense_id;
+end;
+$$;
+
+create or replace function public.debt_update_expense(
+  p_expense_id uuid,
+  p_name text,
+  p_description text,
+  p_items jsonb
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_item jsonb;
+begin
+  if not exists (select 1 from public.debt_expenses where id = p_expense_id and creator_id = auth.uid()) then
+    raise exception 'expense not found or not authorized';
+  end if;
+
+  update public.debt_expenses set name = p_name, description = p_description where id = p_expense_id;
+
+  delete from public.debt_expense_items where expense_id = p_expense_id;
+
+  for v_item in select * from jsonb_array_elements(p_items)
+  loop
+    insert into public.debt_expense_items (expense_id, debtor_id, amount)
+    values (
+      p_expense_id,
+      (v_item->>'debtor_id')::uuid,
+      (v_item->>'amount')::numeric
+    );
+  end loop;
+end;
+$$;
+
+create or replace function public.debt_mark_item_paid(
+  p_item_id uuid,
+  p_paid boolean
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  update public.debt_expense_items ei
+  set paid_at = case when p_paid then now() else null end
+  from public.debt_expenses e
+  where ei.id = p_item_id
+    and ei.expense_id = e.id
+    and e.creator_id = auth.uid();
+end;
+$$;
+
+-- =============================================================================
+-- RPC: settlement confirmation (only the involved party can confirm)
+-- =============================================================================
+
+create or replace function public.debt_confirm_settlement_from(p_settlement_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  update public.debt_settlements
+  set
+    from_confirmed = true,
+    settled_at = case when to_confirmed = true then now() else settled_at end
+  where id = p_settlement_id and from_user_id = auth.uid();
+
+  if not found then
+    raise exception 'settlement not found or not authorized';
+  end if;
+end;
+$$;
+
+create or replace function public.debt_confirm_settlement_to(p_settlement_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  update public.debt_settlements
+  set
+    to_confirmed = true,
+    settled_at = case when from_confirmed = true then now() else settled_at end
+  where id = p_settlement_id and to_user_id = auth.uid();
+
+  if not found then
+    raise exception 'settlement not found or not authorized';
+  end if;
+end;
+$$;
+
+-- =============================================================================
+-- RPC: monthly cron — generate settlement rows from the previous month's nets
+-- =============================================================================
+
+create or replace function public.debt_generate_monthly_settlements()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_period text;
+  v_period_start timestamptz;
+  v_period_end timestamptz;
+begin
+  v_period       := to_char(now() - interval '1 month', 'YYYY-MM');
+  v_period_start := date_trunc('month', now() - interval '1 month');
+  v_period_end   := date_trunc('month', now());
+
+  insert into public.debt_settlements (period, from_user_id, to_user_id, amount)
+  select v_period, from_user, to_user, net_amount
+  from (
+    select
+      case when net_a_to_b > 0 then user_b else user_a end as from_user,
+      case when net_a_to_b > 0 then user_a else user_b end as to_user,
+      abs(net_a_to_b) as net_amount
+    from (
+      select
+        least(e.creator_id, ei.debtor_id) as user_a,
+        greatest(e.creator_id, ei.debtor_id) as user_b,
+        sum(
+          case
+            when e.creator_id = least(e.creator_id, ei.debtor_id) then ei.amount
+            else -ei.amount
+          end
+        ) as net_a_to_b
+      from public.debt_expense_items ei
+      join public.debt_expenses e on e.id = ei.expense_id
+      where e.created_at >= v_period_start
+        and e.created_at <  v_period_end
+      group by least(e.creator_id, ei.debtor_id), greatest(e.creator_id, ei.debtor_id)
+    ) paired
+    where net_a_to_b <> 0
+  ) settlements
+  on conflict (period, from_user_id, to_user_id) do nothing;
+end;
+$$;
+
+-- =============================================================================
+-- Data migration: copy existing debit_* rows into debt_* (preserves IDs)
+-- =============================================================================
+
+insert into public.debt_expenses (id, creator_id, name, description, created_at)
+select id, creator_id, name, description, created_at
+from public.debit_expenses;
+
+insert into public.debt_expense_items (id, expense_id, debtor_id, amount, paid_at, created_at)
+select id, expense_id, debtor_id, amount, paid_at, created_at
+from public.debit_expense_items;
+
+insert into public.debt_settlements (
+  id, period, from_user_id, to_user_id, amount,
+  from_confirmed, to_confirmed, settled_at, created_at
+)
+select
+  id, period, from_user_id, to_user_id, amount,
+  from_confirmed, to_confirmed, settled_at, created_at
+from public.debit_settlements;

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,10 @@
     {
       "path": "/api/cron/approve-emails",
       "schedule": "0 4 * * *"
+    },
+    {
+      "path": "/api/cron/debt-monthly-settlements",
+      "schedule": "0 0 10 * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Brings debit.winlab.tw's logic home as the new `/debt` app inside portal.
- Tables rebuilt as `debt_*` (RPCs / triggers / RLS likewise prefixed); legacy `debit_*` stays untouched until debit.winlab.tw is sunset, then we drop it in a follow-up.
- UI re-skinned on `@workspace/ui` + tabler icons; the combobox is rebuilt on `Popover` + `Command` so we don't pull in `@base-ui/react`.
- `/debt` shows balance overview + my expenses; `/debt/settlements` lives behind the top-right nav. Monthly cron at `0 0 10 * *` calls `debt_generate_monthly_settlements`.
- Migration `2026-05-02-debt-app.sql` was applied to Supabase before this PR (9 expenses + 18 items copied; 0 settlements existed).

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean (only pre-existing `react-hooks/set-state-in-effect` warnings)
- [x] dev server compiles `/debt`, `/debt/settlements`, `/api/cron/debt-monthly-settlements`
- [x] middleware redirects unauth'd `/debt*` to `/auth/login`
- [x] cron route returns 401 without `CRON_SECRET`
- [x] balance overview matches debit.winlab.tw for the same logged-in user (verified manually)
- [ ] cron RPC fires successfully on the 10th (will know next month)