### PR TITLE
feat(portal): move reimburse bookkeeping into /reimburse — schema renamed, ui re-skinned

### DIFF
--- a/apps/gallery/next-env.d.ts
+++ b/apps/gallery/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts"
+import "./.next/types/routes.d.ts"
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/portal/app/api/reimburse/advance/route.ts
+++ b/apps/portal/app/api/reimburse/advance/route.ts
@@ -1,0 +1,188 @@
+import { promises as fs } from "node:fs"
+import path from "node:path"
+
+import { NextResponse, type NextRequest } from "next/server"
+import { PDFDocument, StandardFonts } from "pdf-lib"
+
+import { createClient } from "@/lib/supabase/server"
+import { REIMBURSE_BUCKETS } from "@/lib/reimburse/types"
+
+interface AdvancePayload {
+  applicant_name: string
+  item_name: string
+  item_amount: number
+  item_comment: string | null
+  invoice_date: string
+  invoice_path: string
+  signature_path: string
+}
+
+// StandardFonts.Helvetica is WinAnsi-only; strip any non-ASCII so we don't
+// crash when applicants enter Chinese names. The signature image still gives
+// the page authorial weight.
+function toAscii(input: string): string {
+  return input.replace(/[^\x20-\x7E]/g, "")
+}
+
+function dateForFilename(invoiceDate: string): string {
+  const clean = invoiceDate.replace(/-/g, "")
+  if (clean.length === 8) return clean
+  const now = new Date()
+  return [
+    now.getFullYear(),
+    String(now.getMonth() + 1).padStart(2, "0"),
+    String(now.getDate()).padStart(2, "0"),
+  ].join("")
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const payload = (await request.json()) as AdvancePayload
+    const {
+      applicant_name,
+      item_name,
+      item_amount,
+      item_comment,
+      invoice_date,
+      invoice_path,
+      signature_path,
+    } = payload
+
+    if (
+      !applicant_name ||
+      !item_name ||
+      !Number.isFinite(item_amount) ||
+      !invoice_date ||
+      !invoice_path ||
+      !signature_path
+    ) {
+      return NextResponse.json(
+        { message: "缺少必要欄位，請確認資料後重試" },
+        { status: 400 }
+      )
+    }
+
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser()
+
+    if (userError || !user) {
+      return NextResponse.json(
+        { message: "請先登入再進行操作" },
+        { status: 401 }
+      )
+    }
+
+    const templatePath = path.join(
+      process.cwd(),
+      "public",
+      "reimburse",
+      "advance.pdf"
+    )
+    const templateBytes = await fs.readFile(templatePath)
+
+    const { data: invoiceFile, error: invoiceErr } = await supabase.storage
+      .from(REIMBURSE_BUCKETS.invoices)
+      .download(invoice_path)
+    if (invoiceErr || !invoiceFile) {
+      return NextResponse.json({ message: "取得發票檔案失敗" }, { status: 400 })
+    }
+    const invoiceBytes = await invoiceFile.arrayBuffer()
+
+    const { data: signatureFile, error: sigErr } = await supabase.storage
+      .from(REIMBURSE_BUCKETS.signatures)
+      .download(signature_path)
+    if (sigErr || !signatureFile) {
+      return NextResponse.json({ message: "取得簽名檔案失敗" }, { status: 400 })
+    }
+    const signatureBytes = await signatureFile.arrayBuffer()
+
+    const templatePdf = await PDFDocument.load(templateBytes)
+    const textFont = await templatePdf.embedFont(StandardFonts.Helvetica)
+    const firstPage = templatePdf.getPage(0)
+    const { width, height } = firstPage.getSize()
+
+    firstPage.drawText(toAscii(applicant_name), {
+      x: 90,
+      y: height - 110,
+      size: 12,
+      font: textFont,
+    })
+    firstPage.drawText(toAscii(item_name), {
+      x: 90,
+      y: height - 170,
+      size: 12,
+      font: textFont,
+    })
+    firstPage.drawText(item_amount.toString(), {
+      x: width - 150,
+      y: height - 170,
+      size: 12,
+      font: textFont,
+    })
+    if (item_comment) {
+      firstPage.drawText(toAscii(item_comment), {
+        x: 90,
+        y: height - 200,
+        size: 10,
+        font: textFont,
+        maxWidth: width - 180,
+        lineHeight: 12,
+      })
+    }
+    firstPage.drawText(invoice_date, {
+      x: width - 180,
+      y: height - 110,
+      size: 12,
+      font: textFont,
+    })
+
+    const sigImage = await templatePdf.embedPng(signatureBytes)
+    const sigWidth = 180
+    const sigHeight = 60
+    firstPage.drawImage(sigImage, {
+      x: width - sigWidth - 80,
+      y: 80,
+      width: sigWidth,
+      height: sigHeight,
+    })
+
+    const invoicePdf = await PDFDocument.load(invoiceBytes)
+    const copiedPages = await templatePdf.copyPages(
+      invoicePdf,
+      invoicePdf.getPageIndices()
+    )
+    copiedPages.forEach((p) => templatePdf.addPage(p))
+
+    const finalBytes = await templatePdf.save()
+
+    const safeName = applicant_name.replace(/[^a-zA-Z0-9一-龥_-]/g, "")
+    const datePart = dateForFilename(invoice_date)
+    const outputPath = `${user.id}/advance_${safeName || "user"}_${datePart}.pdf`
+
+    const { error: uploadErr } = await supabase.storage
+      .from(REIMBURSE_BUCKETS.advances)
+      .upload(outputPath, finalBytes, {
+        cacheControl: "3600",
+        upsert: true,
+        contentType: "application/pdf",
+      })
+
+    if (uploadErr) {
+      return NextResponse.json(
+        { message: "上傳合成後 PDF 失敗" },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({ path: outputPath }, { status: 200 })
+  } catch (error) {
+    console.error("[reimburse] advance pdf failed", error)
+    return NextResponse.json(
+      { message: "產生報帳 PDF 失敗，請稍後再試" },
+      { status: 500 }
+    )
+  }
+}

--- a/apps/portal/app/page.tsx
+++ b/apps/portal/app/page.tsx
@@ -14,6 +14,7 @@ const apps = [
   { href: "/approve", label: "Approve", note: "文件簽核" },
   { href: "/trip", label: "Trip", note: "出差文件" },
   { href: "/debt", label: "Debt", note: "分帳記帳" },
+  { href: "/reimburse", label: "Reimburse", note: "實驗室帳本" },
   { href: "/profile", label: "Profile", note: "個人帳號" },
   { href: "https://gallery.winlab.tw", label: "Gallery", note: "藝術畫廊" },
 ]

--- a/apps/portal/app/reimburse/_components/add-egress-dialog.tsx
+++ b/apps/portal/app/reimburse/_components/add-egress-dialog.tsx
@@ -1,0 +1,235 @@
+"use client"
+
+import { Plus } from "lucide-react"
+import { useRouter } from "next/navigation"
+import { useState } from "react"
+import { toast } from "sonner"
+
+import { Button } from "@workspace/ui/components/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@workspace/ui/components/dialog"
+import { Input } from "@workspace/ui/components/input"
+import { Label } from "@workspace/ui/components/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@workspace/ui/components/select"
+import { Textarea } from "@workspace/ui/components/textarea"
+
+import type { EgressStatus } from "@/lib/reimburse/types"
+
+import { addEgressAction } from "../actions"
+
+const EMPTY_FORM = {
+  applicant_name: "",
+  item_name: "",
+  item_amount: "",
+  item_comment: "",
+  invoice_date: "",
+  transfer_date: "",
+  transfer_fee: "",
+  status: "pending" as EgressStatus,
+}
+
+export function AddEgressDialog() {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [formData, setFormData] = useState(EMPTY_FORM)
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setLoading(true)
+    try {
+      const result = await addEgressAction({
+        applicant_name: formData.applicant_name,
+        item_name: formData.item_name,
+        item_amount: parseFloat(formData.item_amount),
+        item_comment: formData.item_comment || null,
+        invoice_date: formData.invoice_date,
+        invoice_files: [],
+        transfer_date: formData.transfer_date || null,
+        transfer_fee: formData.transfer_fee
+          ? parseFloat(formData.transfer_fee)
+          : null,
+        status: formData.status,
+      })
+
+      if (result.success) {
+        setOpen(false)
+        setFormData(EMPTY_FORM)
+        router.refresh()
+        toast.success("已新增支出")
+      } else {
+        toast.error(result.error)
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline">
+          <Plus />
+          新增支出
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[600px]">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>新增支出記錄</DialogTitle>
+            <DialogDescription>請填寫以下資訊以新增支出記錄</DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="applicant_name">
+                  申請人 <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="applicant_name"
+                  value={formData.applicant_name}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      applicant_name: e.target.value,
+                    })
+                  }
+                  required
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="item_name">
+                  項目名稱 <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="item_name"
+                  value={formData.item_name}
+                  onChange={(e) =>
+                    setFormData({ ...formData, item_name: e.target.value })
+                  }
+                  required
+                />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="item_amount">
+                  金額 <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="item_amount"
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={formData.item_amount}
+                  onChange={(e) =>
+                    setFormData({ ...formData, item_amount: e.target.value })
+                  }
+                  required
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="invoice_date">
+                  發票日期 <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="invoice_date"
+                  type="date"
+                  value={formData.invoice_date}
+                  onChange={(e) =>
+                    setFormData({ ...formData, invoice_date: e.target.value })
+                  }
+                  required
+                />
+              </div>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="item_comment">備註</Label>
+              <Textarea
+                id="item_comment"
+                rows={3}
+                value={formData.item_comment}
+                onChange={(e) =>
+                  setFormData({ ...formData, item_comment: e.target.value })
+                }
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="transfer_date">轉帳日期</Label>
+                <Input
+                  id="transfer_date"
+                  type="date"
+                  value={formData.transfer_date}
+                  onChange={(e) =>
+                    setFormData({ ...formData, transfer_date: e.target.value })
+                  }
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="transfer_fee">轉帳手續費</Label>
+                <Input
+                  id="transfer_fee"
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={formData.transfer_fee}
+                  onChange={(e) =>
+                    setFormData({ ...formData, transfer_fee: e.target.value })
+                  }
+                />
+              </div>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="status">狀態</Label>
+              <Select
+                value={formData.status}
+                onValueChange={(value) =>
+                  setFormData({
+                    ...formData,
+                    status: value as EgressStatus,
+                  })
+                }
+              >
+                <SelectTrigger id="status" className="w-full">
+                  <SelectValue placeholder="選擇狀態" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="pending">待審核</SelectItem>
+                  <SelectItem value="approved">已審核</SelectItem>
+                  <SelectItem value="rejected">已拒絕</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={loading}
+            >
+              取消
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? "新增中…" : "新增"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/portal/app/reimburse/_components/add-ingress-dialog.tsx
+++ b/apps/portal/app/reimburse/_components/add-ingress-dialog.tsx
@@ -1,0 +1,142 @@
+"use client"
+
+import { Plus } from "lucide-react"
+import { useRouter } from "next/navigation"
+import { useState } from "react"
+import { toast } from "sonner"
+
+import { Button } from "@workspace/ui/components/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@workspace/ui/components/dialog"
+import { Input } from "@workspace/ui/components/input"
+import { Label } from "@workspace/ui/components/label"
+import { Textarea } from "@workspace/ui/components/textarea"
+
+import { addIngressAction } from "../actions"
+
+const EMPTY_FORM = {
+  ingress_date: "",
+  ingress_amount: "",
+  ingress_comment: "",
+}
+
+export function AddIngressDialog() {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [formData, setFormData] = useState(EMPTY_FORM)
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setLoading(true)
+    try {
+      const result = await addIngressAction({
+        ingress_date: formData.ingress_date,
+        ingress_amount: parseFloat(formData.ingress_amount),
+        ingress_comment: formData.ingress_comment || null,
+        ingress_files: [],
+      })
+
+      if (result.success) {
+        setOpen(false)
+        setFormData(EMPTY_FORM)
+        router.refresh()
+        toast.success("已新增收入")
+      } else {
+        toast.error(result.error)
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline">
+          <Plus />
+          新增收入
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[500px]">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>新增收入記錄</DialogTitle>
+            <DialogDescription>請填寫以下資訊以新增收入記錄</DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="ingress_date">
+                  日期 <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="ingress_date"
+                  type="date"
+                  value={formData.ingress_date}
+                  onChange={(e) =>
+                    setFormData({ ...formData, ingress_date: e.target.value })
+                  }
+                  required
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="ingress_amount">
+                  金額 <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="ingress_amount"
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={formData.ingress_amount}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      ingress_amount: e.target.value,
+                    })
+                  }
+                  required
+                />
+              </div>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="ingress_comment">備註</Label>
+              <Textarea
+                id="ingress_comment"
+                rows={3}
+                value={formData.ingress_comment}
+                onChange={(e) =>
+                  setFormData({
+                    ...formData,
+                    ingress_comment: e.target.value,
+                  })
+                }
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={loading}
+            >
+              取消
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? "新增中…" : "新增"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/portal/app/reimburse/_components/add-reimburse-dialog.tsx
+++ b/apps/portal/app/reimburse/_components/add-reimburse-dialog.tsx
@@ -1,0 +1,428 @@
+"use client"
+
+import { Upload } from "lucide-react"
+import { useEffect, useRef, useState } from "react"
+import { toast } from "sonner"
+
+import { Button } from "@workspace/ui/components/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@workspace/ui/components/dialog"
+import { Input } from "@workspace/ui/components/input"
+import { Label } from "@workspace/ui/components/label"
+import { Textarea } from "@workspace/ui/components/textarea"
+
+import { useAuth } from "@/hooks/use-auth"
+import { createClient } from "@/lib/supabase/client"
+import { REIMBURSE_BUCKETS } from "@/lib/reimburse/types"
+
+interface FormState {
+  applicant_name: string
+  item_name: string
+  item_amount: string
+  item_comment: string
+  invoice_date: string
+}
+
+const EMPTY_FORM: FormState = {
+  applicant_name: "",
+  item_name: "",
+  item_amount: "",
+  item_comment: "",
+  invoice_date: "",
+}
+
+const SIGNATURE_BG = "#f8fafc"
+
+export function AddReimburseDialog() {
+  const supabase = createClient()
+  const { user } = useAuth()
+
+  const [open, setOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [formData, setFormData] = useState<FormState>(EMPTY_FORM)
+  const [invoiceFile, setInvoiceFile] = useState<File | null>(null)
+  const [invoicePath, setInvoicePath] = useState<string | null>(null)
+
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const isDrawingRef = useRef(false)
+  const [signaturePath, setSignaturePath] = useState<string | null>(null)
+  const [loadingSignature, setLoadingSignature] = useState(false)
+
+  const fillCanvasWhite = () => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return
+    ctx.fillStyle = SIGNATURE_BG
+    ctx.fillRect(0, 0, canvas.width, canvas.height)
+  }
+
+  // Reload signature each time the dialog opens. Saved at
+  // reimburse-signatures/signatures/<userId>.png — same convention as the old
+  // standalone reimburse app, so existing signatures keep working.
+  useEffect(() => {
+    if (!open || !user) return
+
+    let cancelled = false
+    const path = `signatures/${user.id}.png`
+
+    const load = async () => {
+      setLoadingSignature(true)
+      fillCanvasWhite()
+      try {
+        const { data, error } = await supabase.storage
+          .from(REIMBURSE_BUCKETS.signatures)
+          .createSignedUrl(path, 60)
+        if (cancelled) return
+        if (error || !data?.signedUrl) {
+          setSignaturePath(null)
+          return
+        }
+        setSignaturePath(path)
+        const blob = await (await fetch(data.signedUrl)).blob()
+        if (cancelled) return
+        const img = new Image()
+        img.onload = () => {
+          if (cancelled) return
+          const canvas = canvasRef.current
+          if (!canvas) return
+          const ctx = canvas.getContext("2d")
+          if (!ctx) return
+          fillCanvasWhite()
+          ctx.drawImage(img, 0, 0, canvas.width, canvas.height)
+        }
+        img.src = URL.createObjectURL(blob)
+      } catch (err) {
+        if (!cancelled) console.error("[reimburse] load signature failed", err)
+      } finally {
+        if (!cancelled) setLoadingSignature(false)
+      }
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [open, supabase, user])
+
+  const getCanvasPoint = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    const canvas = canvasRef.current
+    if (!canvas) return null
+    const rect = canvas.getBoundingClientRect()
+    const scaleX = canvas.width / rect.width
+    const scaleY = canvas.height / rect.height
+    return {
+      canvas,
+      x: (e.clientX - rect.left) * scaleX,
+      y: (e.clientY - rect.top) * scaleY,
+    }
+  }
+
+  const handleMouseDown = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    const point = getCanvasPoint(e)
+    if (!point) return
+    const ctx = point.canvas.getContext("2d")
+    if (!ctx) return
+    ctx.strokeStyle = "#000000"
+    ctx.lineWidth = 2
+    ctx.lineCap = "round"
+    ctx.beginPath()
+    ctx.moveTo(point.x, point.y)
+    isDrawingRef.current = true
+  }
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!isDrawingRef.current) return
+    const point = getCanvasPoint(e)
+    if (!point) return
+    const ctx = point.canvas.getContext("2d")
+    if (!ctx) return
+    ctx.lineTo(point.x, point.y)
+    ctx.stroke()
+  }
+
+  const handleMouseUp = () => {
+    isDrawingRef.current = false
+  }
+
+  const handleClearSignature = () => {
+    fillCanvasWhite()
+    setSignaturePath(null)
+  }
+
+  const uploadInvoice = async (): Promise<string | null> => {
+    if (!user || !invoiceFile) return null
+    const ext = invoiceFile.name.split(".").pop() ?? "pdf"
+    const path = `${user.id}/invoices/${Date.now()}.${ext}`
+    const { error } = await supabase.storage
+      .from(REIMBURSE_BUCKETS.invoices)
+      .upload(path, invoiceFile, {
+        cacheControl: "3600",
+        upsert: false,
+        contentType: "application/pdf",
+      })
+    if (error) {
+      console.error("[reimburse] upload invoice failed", error)
+      toast.error("上傳發票失敗")
+      return null
+    }
+    setInvoicePath(path)
+    return path
+  }
+
+  const uploadSignature = async (): Promise<string | null> => {
+    if (!user) return null
+    const canvas = canvasRef.current
+    if (!canvas) return null
+
+    const blob: Blob | null = await new Promise((resolve) =>
+      canvas.toBlob((b) => resolve(b), "image/png")
+    )
+    if (!blob) {
+      toast.error("簽名讀取失敗，請重試")
+      return null
+    }
+
+    const path = `signatures/${user.id}.png`
+    const { error } = await supabase.storage
+      .from(REIMBURSE_BUCKETS.signatures)
+      .upload(path, blob, {
+        cacheControl: "3600",
+        upsert: true,
+        contentType: "image/png",
+      })
+    if (error) {
+      console.error("[reimburse] upload signature failed", error)
+      toast.error("上傳簽名失敗")
+      return null
+    }
+    setSignaturePath(path)
+    return path
+  }
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    if (!user) {
+      toast.error("請先登入")
+      return
+    }
+    setLoading(true)
+    try {
+      const [invoiceStoragePath, signatureStoragePath] = await Promise.all([
+        invoicePath ? Promise.resolve(invoicePath) : uploadInvoice(),
+        signaturePath ? Promise.resolve(signaturePath) : uploadSignature(),
+      ])
+
+      if (!invoiceStoragePath || !signatureStoragePath) return
+
+      const res = await fetch("/api/reimburse/advance", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          applicant_name: formData.applicant_name,
+          item_name: formData.item_name,
+          item_amount: parseFloat(formData.item_amount),
+          item_comment: formData.item_comment || null,
+          invoice_date: formData.invoice_date,
+          invoice_path: invoiceStoragePath,
+          signature_path: signatureStoragePath,
+        }),
+      })
+
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as {
+          message?: string
+        } | null
+        toast.error(body?.message ?? "產生報帳 PDF 失敗")
+        return
+      }
+
+      toast.success("已產生並上傳報帳 PDF")
+      setOpen(false)
+      setFormData(EMPTY_FORM)
+      setInvoiceFile(null)
+      setInvoicePath(null)
+    } catch (err) {
+      console.error("[reimburse] submit failed", err)
+      toast.error("上傳報帳失敗")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline">
+          <Upload />
+          上傳報帳
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[600px]">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <DialogHeader>
+            <DialogTitle>上傳報帳</DialogTitle>
+            <DialogDescription>
+              上傳 PDF 電子發票，並於下方框框簽名，系統會自動產生支出證明單 PDF
+              並儲存。
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="applicant_name">
+                申請人 <span className="text-red-500">*</span>
+              </Label>
+              <Input
+                id="applicant_name"
+                value={formData.applicant_name}
+                onChange={(e) =>
+                  setFormData({
+                    ...formData,
+                    applicant_name: e.target.value,
+                  })
+                }
+                required
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="item_name">
+                支出事由 <span className="text-red-500">*</span>
+              </Label>
+              <Input
+                id="item_name"
+                value={formData.item_name}
+                onChange={(e) =>
+                  setFormData({ ...formData, item_name: e.target.value })
+                }
+                required
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="item_amount">
+                金額 <span className="text-red-500">*</span>
+              </Label>
+              <Input
+                id="item_amount"
+                type="number"
+                min="0"
+                step="1"
+                value={formData.item_amount}
+                onChange={(e) =>
+                  setFormData({ ...formData, item_amount: e.target.value })
+                }
+                required
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="invoice_date">
+                發票日期 <span className="text-red-500">*</span>
+              </Label>
+              <Input
+                id="invoice_date"
+                type="date"
+                value={formData.invoice_date}
+                onChange={(e) =>
+                  setFormData({ ...formData, invoice_date: e.target.value })
+                }
+                required
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="item_comment">備註</Label>
+            <Textarea
+              id="item_comment"
+              rows={3}
+              value={formData.item_comment}
+              onChange={(e) =>
+                setFormData({ ...formData, item_comment: e.target.value })
+              }
+              placeholder="可填寫不能取得單據原因等說明"
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="invoice_file">
+              電子發票（PDF） <span className="text-red-500">*</span>
+            </Label>
+            <Input
+              id="invoice_file"
+              type="file"
+              accept="application/pdf"
+              onChange={(e) => {
+                const file = e.target.files?.[0] ?? null
+                setInvoiceFile(file)
+                setInvoicePath(null)
+              }}
+              required={!invoiceFile}
+            />
+            {invoicePath && (
+              <p className="text-xs text-muted-foreground">
+                已上傳：{invoicePath}
+              </p>
+            )}
+          </div>
+
+          <div className="grid gap-2">
+            <Label>簽名</Label>
+            <div className="rounded-md border bg-muted/40 p-2">
+              <canvas
+                ref={canvasRef}
+                width={500}
+                height={200}
+                className="h-40 w-full cursor-crosshair rounded-sm border bg-white"
+                onMouseDown={handleMouseDown}
+                onMouseMove={handleMouseMove}
+                onMouseUp={handleMouseUp}
+                onMouseLeave={handleMouseUp}
+              />
+              <div className="mt-2 flex items-center justify-between text-xs text-muted-foreground">
+                <span>
+                  {loadingSignature
+                    ? "載入簽名中…"
+                    : signaturePath
+                      ? "已載入先前簽名，如需重簽可清除後重新簽名。"
+                      : "請於上方框框內以滑鼠簽名，簽名會自動保存供下次使用。"}
+                </span>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleClearSignature}
+                >
+                  清除簽名
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={loading}
+            >
+              取消
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? "處理中…" : "確認產生報帳 PDF"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/portal/app/reimburse/_components/data-view.tsx
+++ b/apps/portal/app/reimburse/_components/data-view.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import { useMemo } from "react"
+
+import { Badge } from "@workspace/ui/components/badge"
+
+import type { Ingress, Reimbursement, Transaction } from "@/lib/reimburse/types"
+
+import { AddEgressDialog } from "./add-egress-dialog"
+import { AddIngressDialog } from "./add-ingress-dialog"
+import { AddReimburseDialog } from "./add-reimburse-dialog"
+import { getUnifiedColumns } from "./unified-columns"
+import { UnifiedChart } from "./unified-chart"
+import { UnifiedTable } from "./unified-table"
+
+interface DataViewProps {
+  egressData: Reimbursement[]
+  ingressData: Ingress[]
+  isAdmin: boolean
+}
+
+const twd = new Intl.NumberFormat("zh-TW", {
+  style: "currency",
+  currency: "TWD",
+  minimumFractionDigits: 0,
+})
+
+export function DataView({ egressData, ingressData, isAdmin }: DataViewProps) {
+  const transactions = useMemo<Transaction[]>(() => {
+    return [
+      ...egressData.map((item): Transaction => ({ type: "egress", ...item })),
+      ...ingressData.map((item): Transaction => ({ type: "ingress", ...item })),
+    ].sort((a, b) => {
+      const dateA = a.type === "egress" ? a.invoiceDate : a.ingressDate
+      const dateB = b.type === "egress" ? b.invoiceDate : b.ingressDate
+      return dateB.localeCompare(dateA)
+    })
+  }, [egressData, ingressData])
+
+  const balance = useMemo(() => {
+    const totalIngress = ingressData.reduce(
+      (sum, item) => sum + item.ingressAmount,
+      0
+    )
+    const totalEgress = egressData.reduce(
+      (sum, item) => sum + item.itemAmount + (item.transferFee ?? 0),
+      0
+    )
+    return totalIngress - totalEgress
+  }, [egressData, ingressData])
+
+  const columns = useMemo(() => getUnifiedColumns(isAdmin), [isAdmin])
+
+  return (
+    <div className="flex w-full flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <Badge
+          variant={balance >= 0 ? "outline" : "destructive"}
+          className="text-base"
+        >
+          {twd.format(balance)}
+        </Badge>
+        {isAdmin && (
+          <div className="flex flex-wrap gap-2">
+            <AddReimburseDialog />
+            <AddEgressDialog />
+            <AddIngressDialog />
+          </div>
+        )}
+      </div>
+
+      <div className="h-64 w-full">
+        <UnifiedChart data={transactions} />
+      </div>
+
+      <UnifiedTable columns={columns} data={transactions} />
+    </div>
+  )
+}

--- a/apps/portal/app/reimburse/_components/delete-egress-button.tsx
+++ b/apps/portal/app/reimburse/_components/delete-egress-button.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import { Trash2 } from "lucide-react"
+import { useRouter } from "next/navigation"
+import { useState, useTransition } from "react"
+import { toast } from "sonner"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@workspace/ui/components/alert-dialog"
+import { Button } from "@workspace/ui/components/button"
+
+import { deleteEgressAction } from "../actions"
+
+interface DeleteEgressButtonProps {
+  id: string
+  itemName: string
+}
+
+export function DeleteEgressButton({ id, itemName }: DeleteEgressButtonProps) {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [isPending, startTransition] = useTransition()
+
+  const handleDelete = () => {
+    startTransition(async () => {
+      const result = await deleteEgressAction(id)
+      if (result.success) {
+        setOpen(false)
+        router.refresh()
+        toast.success("已刪除")
+        return
+      }
+      toast.error(result.error)
+    })
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 text-red-600 hover:text-red-700"
+          aria-label="刪除支出"
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>確認刪除此支出？</AlertDialogTitle>
+          <AlertDialogDescription>
+            「{itemName}」刪除後無法復原，請再次確認。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>取消</AlertDialogCancel>
+          <AlertDialogAction
+            type="button"
+            onClick={handleDelete}
+            disabled={isPending}
+            className="bg-red-600 hover:bg-red-700"
+          >
+            {isPending ? "刪除中…" : "確認刪除"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/apps/portal/app/reimburse/_components/edit-egress-dialog.tsx
+++ b/apps/portal/app/reimburse/_components/edit-egress-dialog.tsx
@@ -1,0 +1,255 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useEffect, useState } from "react"
+import { toast } from "sonner"
+
+import { Button } from "@workspace/ui/components/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@workspace/ui/components/dialog"
+import { Input } from "@workspace/ui/components/input"
+import { Label } from "@workspace/ui/components/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@workspace/ui/components/select"
+import { Textarea } from "@workspace/ui/components/textarea"
+
+import type { EgressStatus, Reimbursement } from "@/lib/reimburse/types"
+
+import { updateEgressAction } from "../actions"
+
+interface EditEgressDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  data: Reimbursement
+}
+
+function toFormData(data: Reimbursement) {
+  return {
+    applicant_name: data.applicantName,
+    item_name: data.itemName,
+    item_amount: data.itemAmount.toString(),
+    item_comment: data.itemComment ?? "",
+    invoice_date: data.invoiceDate,
+    transfer_date: data.transferDate ?? "",
+    transfer_fee: data.transferFee?.toString() ?? "",
+    status: data.status,
+  }
+}
+
+export function EditEgressDialog({
+  open,
+  onOpenChange,
+  data,
+}: EditEgressDialogProps) {
+  const router = useRouter()
+  const [loading, setLoading] = useState(false)
+  const [formData, setFormData] = useState(() => toFormData(data))
+
+  useEffect(() => {
+    setFormData(toFormData(data))
+  }, [data])
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setLoading(true)
+    try {
+      const result = await updateEgressAction(data.id, {
+        applicant_name: formData.applicant_name,
+        item_name: formData.item_name,
+        item_amount: parseFloat(formData.item_amount),
+        item_comment: formData.item_comment || null,
+        invoice_date: formData.invoice_date,
+        transfer_date: formData.transfer_date || null,
+        transfer_fee: formData.transfer_fee
+          ? parseFloat(formData.transfer_fee)
+          : null,
+        status: formData.status,
+      })
+
+      if (result.success) {
+        onOpenChange(false)
+        router.refresh()
+        toast.success("已更新")
+      } else {
+        toast.error(result.error)
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[600px]">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>編輯支出記錄</DialogTitle>
+            <DialogDescription>請修改以下資訊</DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="edit-applicant_name">
+                  申請人 <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="edit-applicant_name"
+                  value={formData.applicant_name}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      applicant_name: e.target.value,
+                    })
+                  }
+                  required
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="edit-item_name">
+                  項目名稱 <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="edit-item_name"
+                  value={formData.item_name}
+                  onChange={(e) =>
+                    setFormData({ ...formData, item_name: e.target.value })
+                  }
+                  required
+                />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="edit-item_amount">
+                  金額 <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="edit-item_amount"
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={formData.item_amount}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      item_amount: e.target.value,
+                    })
+                  }
+                  required
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="edit-invoice_date">
+                  發票日期 <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="edit-invoice_date"
+                  type="date"
+                  value={formData.invoice_date}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      invoice_date: e.target.value,
+                    })
+                  }
+                  required
+                />
+              </div>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="edit-item_comment">備註</Label>
+              <Textarea
+                id="edit-item_comment"
+                rows={3}
+                value={formData.item_comment}
+                onChange={(e) =>
+                  setFormData({
+                    ...formData,
+                    item_comment: e.target.value,
+                  })
+                }
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="edit-transfer_date">轉帳日期</Label>
+                <Input
+                  id="edit-transfer_date"
+                  type="date"
+                  value={formData.transfer_date}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      transfer_date: e.target.value,
+                    })
+                  }
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="edit-transfer_fee">轉帳手續費</Label>
+                <Input
+                  id="edit-transfer_fee"
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={formData.transfer_fee}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      transfer_fee: e.target.value,
+                    })
+                  }
+                />
+              </div>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="edit-status">狀態</Label>
+              <Select
+                value={formData.status}
+                onValueChange={(value) =>
+                  setFormData({
+                    ...formData,
+                    status: value as EgressStatus,
+                  })
+                }
+              >
+                <SelectTrigger id="edit-status" className="w-full">
+                  <SelectValue placeholder="選擇狀態" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="pending">待審核</SelectItem>
+                  <SelectItem value="approved">已審核</SelectItem>
+                  <SelectItem value="rejected">已拒絕</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={loading}
+            >
+              取消
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? "更新中…" : "更新"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/portal/app/reimburse/_components/edit-ingress-dialog.tsx
+++ b/apps/portal/app/reimburse/_components/edit-ingress-dialog.tsx
@@ -1,0 +1,153 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useEffect, useState } from "react"
+import { toast } from "sonner"
+
+import { Button } from "@workspace/ui/components/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@workspace/ui/components/dialog"
+import { Input } from "@workspace/ui/components/input"
+import { Label } from "@workspace/ui/components/label"
+import { Textarea } from "@workspace/ui/components/textarea"
+
+import type { Ingress } from "@/lib/reimburse/types"
+
+import { updateIngressAction } from "../actions"
+
+interface EditIngressDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  data: Ingress
+}
+
+function toFormData(data: Ingress) {
+  return {
+    ingress_date: data.ingressDate,
+    ingress_amount: data.ingressAmount.toString(),
+    ingress_comment: data.ingressComment ?? "",
+  }
+}
+
+export function EditIngressDialog({
+  open,
+  onOpenChange,
+  data,
+}: EditIngressDialogProps) {
+  const router = useRouter()
+  const [loading, setLoading] = useState(false)
+  const [formData, setFormData] = useState(() => toFormData(data))
+
+  useEffect(() => {
+    setFormData(toFormData(data))
+  }, [data])
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setLoading(true)
+    try {
+      const result = await updateIngressAction(data.id, {
+        ingress_date: formData.ingress_date,
+        ingress_amount: parseFloat(formData.ingress_amount),
+        ingress_comment: formData.ingress_comment || null,
+        ingress_files: [],
+      })
+
+      if (result.success) {
+        onOpenChange(false)
+        router.refresh()
+        toast.success("已更新")
+      } else {
+        toast.error(result.error)
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>編輯收入記錄</DialogTitle>
+            <DialogDescription>請修改以下資訊</DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="edit-ingress_date">
+                  日期 <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="edit-ingress_date"
+                  type="date"
+                  value={formData.ingress_date}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      ingress_date: e.target.value,
+                    })
+                  }
+                  required
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="edit-ingress_amount">
+                  金額 <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="edit-ingress_amount"
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={formData.ingress_amount}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      ingress_amount: e.target.value,
+                    })
+                  }
+                  required
+                />
+              </div>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="edit-ingress_comment">備註</Label>
+              <Textarea
+                id="edit-ingress_comment"
+                rows={3}
+                value={formData.ingress_comment}
+                onChange={(e) =>
+                  setFormData({
+                    ...formData,
+                    ingress_comment: e.target.value,
+                  })
+                }
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={loading}
+            >
+              取消
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? "更新中…" : "更新"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/portal/app/reimburse/_components/unified-chart.tsx
+++ b/apps/portal/app/reimburse/_components/unified-chart.tsx
@@ -1,0 +1,119 @@
+"use client"
+
+import { useMemo } from "react"
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+} from "recharts"
+
+import type { Transaction } from "@/lib/reimburse/types"
+
+const twd = new Intl.NumberFormat("zh-TW", {
+  style: "currency",
+  currency: "TWD",
+  minimumFractionDigits: 0,
+})
+
+// ISO week key (Monday-anchored) so the chart bins by calendar week.
+function weekKey(date: Date): string {
+  const d = new Date(
+    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())
+  )
+  const dayNum = d.getUTCDay() || 7
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum)
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1))
+  const weekNum = Math.ceil(
+    ((d.getTime() - yearStart.getTime()) / 86_400_000 + 1) / 7
+  )
+  return `${d.getUTCFullYear()}-W${String(weekNum).padStart(2, "0")}`
+}
+
+function buildChartData(transactions: Transaction[]) {
+  const ingress = new Map<string, number>()
+  const egress = new Map<string, number>()
+
+  for (const tx of transactions) {
+    if (tx.type === "ingress") {
+      const key = weekKey(new Date(tx.ingressDate))
+      ingress.set(key, (ingress.get(key) ?? 0) + tx.ingressAmount)
+    } else {
+      const key = weekKey(new Date(tx.invoiceDate))
+      const amount = tx.itemAmount + (tx.transferFee ?? 0)
+      egress.set(key, (egress.get(key) ?? 0) + amount)
+    }
+  }
+
+  const weeks = Array.from(new Set([...ingress.keys(), ...egress.keys()]))
+  return weeks.sort().map((week) => ({
+    week,
+    ingress: ingress.get(week) ?? 0,
+    egress: egress.get(week) ?? 0,
+  }))
+}
+
+interface UnifiedChartProps {
+  data: Transaction[]
+}
+
+export function UnifiedChart({ data }: UnifiedChartProps) {
+  const chartData = useMemo(() => buildChartData(data), [data])
+
+  return (
+    <div className="h-full w-full rounded-lg border p-4">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart
+          data={chartData}
+          margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+        >
+          <CartesianGrid
+            stroke="currentColor"
+            strokeOpacity={0.1}
+            vertical={false}
+          />
+          <XAxis
+            dataKey="week"
+            tickLine={false}
+            axisLine={false}
+            tick={{ fontSize: 11 }}
+            stroke="currentColor"
+            strokeOpacity={0.4}
+          />
+          <Tooltip
+            cursor={{ stroke: "currentColor", strokeOpacity: 0.2 }}
+            contentStyle={{
+              background: "var(--popover)",
+              border: "1px solid var(--border)",
+              borderRadius: 8,
+              color: "var(--popover-foreground)",
+              fontSize: 12,
+            }}
+            formatter={(value, name) => [
+              twd.format(Number(value)),
+              name === "ingress" ? "收入" : "支出",
+            ]}
+          />
+          <Line
+            type="monotone"
+            dataKey="ingress"
+            stroke="#22c55e"
+            strokeWidth={2}
+            dot={false}
+            activeDot={{ r: 5 }}
+          />
+          <Line
+            type="monotone"
+            dataKey="egress"
+            stroke="#ef4444"
+            strokeWidth={2}
+            dot={false}
+            activeDot={{ r: 5 }}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/apps/portal/app/reimburse/_components/unified-columns.tsx
+++ b/apps/portal/app/reimburse/_components/unified-columns.tsx
@@ -1,0 +1,198 @@
+"use client"
+
+import type { ColumnDef, Row } from "@tanstack/react-table"
+import { Pencil } from "lucide-react"
+import { useState } from "react"
+
+import { Button } from "@workspace/ui/components/button"
+
+import type { Ingress, Reimbursement, Transaction } from "@/lib/reimburse/types"
+
+import { DeleteEgressButton } from "./delete-egress-button"
+import { EditEgressDialog } from "./edit-egress-dialog"
+import { EditIngressDialog } from "./edit-ingress-dialog"
+
+const dateFmt = new Intl.DateTimeFormat("zh-TW", {
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+})
+
+const twd = new Intl.NumberFormat("zh-TW", {
+  style: "currency",
+  currency: "TWD",
+  minimumFractionDigits: 0,
+})
+
+const STATUS_LABEL: Record<Reimbursement["status"], string> = {
+  pending: "待審核",
+  approved: "已審核",
+  rejected: "已拒絕",
+}
+
+function EditActionCell({ row }: { row: Row<Transaction> }) {
+  const [open, setOpen] = useState(false)
+  const data = row.original
+
+  if (data.type === "egress") {
+    return (
+      <div className="flex items-center gap-1">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={() => setOpen(true)}
+          aria-label="編輯支出"
+        >
+          <Pencil className="h-4 w-4" />
+        </Button>
+        <EditEgressDialog
+          open={open}
+          onOpenChange={setOpen}
+          data={data as Reimbursement}
+        />
+        <DeleteEgressButton id={data.id} itemName={data.itemName} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8"
+        onClick={() => setOpen(true)}
+        aria-label="編輯收入"
+      >
+        <Pencil className="h-4 w-4" />
+      </Button>
+      <EditIngressDialog
+        open={open}
+        onOpenChange={setOpen}
+        data={data as Ingress}
+      />
+    </div>
+  )
+}
+
+export function getUnifiedColumns(isAdmin: boolean): ColumnDef<Transaction>[] {
+  const columns: ColumnDef<Transaction>[] = [
+    {
+      id: "date",
+      header: () => <span>日期</span>,
+      cell: ({ row }) => {
+        const data = row.original
+        const raw = data.type === "egress" ? data.invoiceDate : data.ingressDate
+        return <span>{dateFmt.format(new Date(raw))}</span>
+      },
+    },
+    {
+      id: "applicant",
+      header: () => <span>申請人</span>,
+      cell: ({ row }) => {
+        const data = row.original
+        return <span>{data.type === "egress" ? data.applicantName : "—"}</span>
+      },
+    },
+    {
+      id: "amount",
+      header: () => <span>金額</span>,
+      cell: ({ row }) => {
+        const data = row.original
+        const amount =
+          data.type === "egress" ? data.itemAmount : data.ingressAmount
+        const sign = data.type === "egress" ? "-" : "+"
+        return (
+          <span
+            className={
+              data.type === "egress" ? "text-red-500" : "text-green-500"
+            }
+          >
+            {sign}
+            {twd.format(amount)}
+          </span>
+        )
+      },
+    },
+    {
+      id: "name",
+      header: () => <span>名稱 / 備註</span>,
+      cell: ({ row }) => {
+        const data = row.original
+        if (data.type === "egress") {
+          return <span>{data.itemName}</span>
+        }
+        return (
+          <span className="text-muted-foreground">
+            {data.ingressComment ?? "—"}
+          </span>
+        )
+      },
+    },
+    {
+      id: "transferFee",
+      header: () => <span>轉帳手續費</span>,
+      cell: ({ row }) => {
+        const data = row.original
+        if (data.type === "egress" && data.transferFee !== null) {
+          return (
+            <span className="text-red-500">
+              -{twd.format(data.transferFee)}
+            </span>
+          )
+        }
+        return <span className="text-muted-foreground">—</span>
+      },
+    },
+    {
+      id: "comment",
+      header: () => <span>備註</span>,
+      cell: ({ row }) => {
+        const data = row.original
+        if (data.type === "egress") {
+          return (
+            <span className="text-muted-foreground">
+              {data.itemComment ?? "—"}
+            </span>
+          )
+        }
+        return <span className="text-muted-foreground">—</span>
+      },
+    },
+    {
+      id: "transferDate",
+      header: () => <span>轉帳日期</span>,
+      cell: ({ row }) => {
+        const data = row.original
+        if (data.type === "egress" && data.transferDate) {
+          return <span>{dateFmt.format(new Date(data.transferDate))}</span>
+        }
+        return <span className="text-muted-foreground">—</span>
+      },
+    },
+    {
+      id: "status",
+      header: () => <span>狀態</span>,
+      cell: ({ row }) => {
+        const data = row.original
+        if (data.type === "egress") {
+          return <span>{STATUS_LABEL[data.status]}</span>
+        }
+        return <span className="text-muted-foreground">—</span>
+      },
+    },
+  ]
+
+  if (isAdmin) {
+    columns.push({
+      id: "actions",
+      header: () => <span>操作</span>,
+      cell: ({ row }) => <EditActionCell row={row} />,
+      enableSorting: false,
+      enableHiding: false,
+    })
+  }
+
+  return columns
+}

--- a/apps/portal/app/reimburse/_components/unified-table.tsx
+++ b/apps/portal/app/reimburse/_components/unified-table.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+  type ColumnDef,
+} from "@tanstack/react-table"
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@workspace/ui/components/table"
+
+interface UnifiedTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[]
+  data: TData[]
+}
+
+export function UnifiedTable<TData, TValue>({
+  columns,
+  data,
+}: UnifiedTableProps<TData, TValue>) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  })
+
+  return (
+    <div className="w-full overflow-auto rounded-lg border">
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <TableHead key={header.id}>
+                  {header.isPlaceholder
+                    ? null
+                    : flexRender(
+                        header.column.columnDef.header,
+                        header.getContext()
+                      )}
+                </TableHead>
+              ))}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {table.getRowModel().rows.length ? (
+            table.getRowModel().rows.map((row) => (
+              <TableRow key={row.id}>
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell
+                colSpan={columns.length}
+                className="h-24 text-center text-muted-foreground"
+              >
+                沒有資料
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/apps/portal/app/reimburse/actions.ts
+++ b/apps/portal/app/reimburse/actions.ts
@@ -1,0 +1,94 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+
+import {
+  createEgress,
+  deleteEgress,
+  updateEgress,
+} from "@/lib/reimburse/egress"
+import { createIngress, updateIngress } from "@/lib/reimburse/ingress"
+import type {
+  InsertEgress,
+  InsertIngress,
+  UpdateEgress,
+  UpdateIngress,
+} from "@/lib/reimburse/types"
+
+type ActionResult = { success: true } | { success: false; error: string }
+
+function failure(error: unknown): ActionResult {
+  return {
+    success: false,
+    error: error instanceof Error ? error.message : "未知錯誤",
+  }
+}
+
+// Mutations rely on RLS for authorization (is_reimburse_admin() in RLS
+// policies). RLS rejecting the row is the source of truth — we surface the
+// error to the toast instead of duplicating role checks here.
+
+export async function addEgressAction(
+  data: InsertEgress
+): Promise<ActionResult> {
+  try {
+    await createEgress(data)
+    revalidatePath("/reimburse")
+    return { success: true }
+  } catch (error) {
+    console.error("[reimburse] addEgressAction failed", error)
+    return failure(error)
+  }
+}
+
+export async function updateEgressAction(
+  id: string,
+  data: UpdateEgress
+): Promise<ActionResult> {
+  try {
+    await updateEgress(id, data)
+    revalidatePath("/reimburse")
+    return { success: true }
+  } catch (error) {
+    console.error("[reimburse] updateEgressAction failed", error)
+    return failure(error)
+  }
+}
+
+export async function deleteEgressAction(id: string): Promise<ActionResult> {
+  try {
+    await deleteEgress(id)
+    revalidatePath("/reimburse")
+    return { success: true }
+  } catch (error) {
+    console.error("[reimburse] deleteEgressAction failed", error)
+    return failure(error)
+  }
+}
+
+export async function addIngressAction(
+  data: InsertIngress
+): Promise<ActionResult> {
+  try {
+    await createIngress(data)
+    revalidatePath("/reimburse")
+    return { success: true }
+  } catch (error) {
+    console.error("[reimburse] addIngressAction failed", error)
+    return failure(error)
+  }
+}
+
+export async function updateIngressAction(
+  id: string,
+  data: UpdateIngress
+): Promise<ActionResult> {
+  try {
+    await updateIngress(id, data)
+    revalidatePath("/reimburse")
+    return { success: true }
+  } catch (error) {
+    console.error("[reimburse] updateIngressAction failed", error)
+    return failure(error)
+  }
+}

--- a/apps/portal/app/reimburse/layout.tsx
+++ b/apps/portal/app/reimburse/layout.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+
+import { Toaster } from "@workspace/ui/components/sonner"
+
+import { PortalShell } from "@/components/portal-shell"
+
+export const metadata: Metadata = {
+  title: "Reimburse | Portal",
+  description: "WinLab cash-flow bookkeeping.",
+}
+
+export default function ReimburseLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <>
+      <PortalShell
+        appName="Reimburse"
+        appHref="/reimburse"
+        bottomLeft={
+          <Link href="/" className="transition-colors hover:text-foreground">
+            Portal
+          </Link>
+        }
+      >
+        {children}
+      </PortalShell>
+      <Toaster />
+    </>
+  )
+}

--- a/apps/portal/app/reimburse/page.tsx
+++ b/apps/portal/app/reimburse/page.tsx
@@ -1,0 +1,32 @@
+import { isReimburseAdmin } from "@/lib/reimburse/admin"
+import { getEgressList } from "@/lib/reimburse/egress"
+import { getIngressList } from "@/lib/reimburse/ingress"
+import { transformEgress, transformIngress } from "@/lib/reimburse/transformers"
+
+import { DataView } from "./_components/data-view"
+
+// /reimburse depends on the signed-in user's role + cookies. Skip static
+// rendering so the admin gate and data are always fresh.
+export const dynamic = "force-dynamic"
+
+export default async function ReimbursePage() {
+  const [egressRows, ingressRows, isAdmin] = await Promise.all([
+    getEgressList().catch((err) => {
+      console.error("[reimburse] failed to fetch egress", err)
+      return []
+    }),
+    getIngressList().catch((err) => {
+      console.error("[reimburse] failed to fetch ingress", err)
+      return []
+    }),
+    isReimburseAdmin(),
+  ])
+
+  return (
+    <DataView
+      egressData={egressRows.map(transformEgress)}
+      ingressData={ingressRows.map(transformIngress)}
+      isAdmin={isAdmin}
+    />
+  )
+}

--- a/apps/portal/lib/reimburse/admin.ts
+++ b/apps/portal/lib/reimburse/admin.ts
@@ -1,0 +1,13 @@
+import { createClient } from "@/lib/supabase/server"
+
+// Wraps the `is_reimburse_admin()` SQL helper. RPC keeps the role-resolution
+// logic on one side (DB), so JS callers can't drift out of sync with RLS.
+export async function isReimburseAdmin(): Promise<boolean> {
+  const supabase = await createClient()
+  const { data, error } = await supabase.rpc("is_reimburse_admin")
+  if (error) {
+    console.error("[reimburse] is_reimburse_admin rpc failed", error)
+    return false
+  }
+  return data === true
+}

--- a/apps/portal/lib/reimburse/egress.ts
+++ b/apps/portal/lib/reimburse/egress.ts
@@ -1,0 +1,63 @@
+import { createClient } from "@/lib/supabase/server"
+
+import type { DatabaseEgress, InsertEgress, UpdateEgress } from "./types"
+
+const TABLE = "reimburse_egress"
+
+export async function getEgressList() {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select("*")
+    .order("invoice_date", { ascending: false })
+
+  if (error) throw new Error(`Failed to fetch egress: ${error.message}`)
+  return (data ?? []) as DatabaseEgress[]
+}
+
+export async function getEgressById(id: string) {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select("*")
+    .eq("id", id)
+    .single()
+
+  if (error) throw new Error(`Failed to fetch egress: ${error.message}`)
+  return data as DatabaseEgress
+}
+
+export async function createEgress(payload: InsertEgress) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  const { data, error } = await supabase
+    .from(TABLE)
+    .insert({ ...payload, user_id: user?.id ?? null })
+    .select()
+    .single()
+
+  if (error) throw new Error(`Failed to create egress: ${error.message}`)
+  return data as DatabaseEgress
+}
+
+export async function updateEgress(id: string, updates: UpdateEgress) {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from(TABLE)
+    .update(updates)
+    .eq("id", id)
+    .select()
+    .single()
+
+  if (error) throw new Error(`Failed to update egress: ${error.message}`)
+  return data as DatabaseEgress
+}
+
+export async function deleteEgress(id: string) {
+  const supabase = await createClient()
+  const { error } = await supabase.from(TABLE).delete().eq("id", id)
+  if (error) throw new Error(`Failed to delete egress: ${error.message}`)
+}

--- a/apps/portal/lib/reimburse/ingress.ts
+++ b/apps/portal/lib/reimburse/ingress.ts
@@ -1,0 +1,63 @@
+import { createClient } from "@/lib/supabase/server"
+
+import type { DatabaseIngress, InsertIngress, UpdateIngress } from "./types"
+
+const TABLE = "reimburse_ingress"
+
+export async function getIngressList() {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select("*")
+    .order("ingress_date", { ascending: false })
+
+  if (error) throw new Error(`Failed to fetch ingress: ${error.message}`)
+  return (data ?? []) as DatabaseIngress[]
+}
+
+export async function getIngressById(id: string) {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select("*")
+    .eq("id", id)
+    .single()
+
+  if (error) throw new Error(`Failed to fetch ingress: ${error.message}`)
+  return data as DatabaseIngress
+}
+
+export async function createIngress(payload: InsertIngress) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  const { data, error } = await supabase
+    .from(TABLE)
+    .insert({ ...payload, user_id: user?.id ?? null })
+    .select()
+    .single()
+
+  if (error) throw new Error(`Failed to create ingress: ${error.message}`)
+  return data as DatabaseIngress
+}
+
+export async function updateIngress(id: string, updates: UpdateIngress) {
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from(TABLE)
+    .update(updates)
+    .eq("id", id)
+    .select()
+    .single()
+
+  if (error) throw new Error(`Failed to update ingress: ${error.message}`)
+  return data as DatabaseIngress
+}
+
+export async function deleteIngress(id: string) {
+  const supabase = await createClient()
+  const { error } = await supabase.from(TABLE).delete().eq("id", id)
+  if (error) throw new Error(`Failed to delete ingress: ${error.message}`)
+}

--- a/apps/portal/lib/reimburse/transformers.ts
+++ b/apps/portal/lib/reimburse/transformers.ts
@@ -1,0 +1,35 @@
+import type {
+  DatabaseEgress,
+  DatabaseIngress,
+  Ingress,
+  Reimbursement,
+} from "./types"
+
+export function transformEgress(row: DatabaseEgress): Reimbursement {
+  return {
+    id: row.id,
+    applicantName: row.applicant_name,
+    itemName: row.item_name,
+    itemAmount: Number(row.item_amount),
+    itemComment: row.item_comment,
+    invoiceDate: row.invoice_date,
+    invoiceFiles: row.invoice_files ?? [],
+    transferDate: row.transfer_date,
+    transferFee: row.transfer_fee !== null ? Number(row.transfer_fee) : null,
+    transferFiles:
+      row.transfer_files && row.transfer_files.length > 0
+        ? row.transfer_files
+        : null,
+    status: row.status,
+  }
+}
+
+export function transformIngress(row: DatabaseIngress): Ingress {
+  return {
+    id: row.id,
+    ingressDate: row.ingress_date,
+    ingressAmount: Number(row.ingress_amount),
+    ingressComment: row.ingress_comment,
+    ingressFiles: row.ingress_files ?? [],
+  }
+}

--- a/apps/portal/lib/reimburse/types.ts
+++ b/apps/portal/lib/reimburse/types.ts
@@ -1,0 +1,109 @@
+// Database row shapes (snake_case, mirrors public.reimburse_egress / reimburse_ingress).
+
+export type EgressStatus = "pending" | "approved" | "rejected"
+
+export interface DatabaseEgress {
+  id: string
+  applicant_name: string
+  item_name: string
+  item_amount: number
+  item_comment: string | null
+  invoice_date: string
+  invoice_files: string[]
+  transfer_date: string | null
+  transfer_fee: number | null
+  transfer_files: string[] | null
+  status: EgressStatus
+  user_id: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface DatabaseIngress {
+  id: string
+  ingress_date: string
+  ingress_amount: number
+  ingress_comment: string | null
+  ingress_files: string[]
+  user_id: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface InsertEgress {
+  applicant_name: string
+  item_name: string
+  item_amount: number
+  item_comment?: string | null
+  invoice_date: string
+  invoice_files?: string[]
+  transfer_date?: string | null
+  transfer_fee?: number | null
+  transfer_files?: string[] | null
+  status?: EgressStatus
+  user_id?: string | null
+}
+
+export interface InsertIngress {
+  ingress_date: string
+  ingress_amount: number
+  ingress_comment?: string | null
+  ingress_files?: string[]
+  user_id?: string | null
+}
+
+export interface UpdateEgress {
+  applicant_name?: string
+  item_name?: string
+  item_amount?: number
+  item_comment?: string | null
+  invoice_date?: string
+  invoice_files?: string[]
+  transfer_date?: string | null
+  transfer_fee?: number | null
+  transfer_files?: string[] | null
+  status?: EgressStatus
+}
+
+export interface UpdateIngress {
+  ingress_date?: string
+  ingress_amount?: number
+  ingress_comment?: string | null
+  ingress_files?: string[]
+}
+
+// Application shapes (camelCase, what UI consumes).
+
+export interface Reimbursement {
+  id: string
+  applicantName: string
+  itemName: string
+  itemAmount: number
+  itemComment: string | null
+  invoiceDate: string
+  invoiceFiles: string[]
+  transferDate: string | null
+  transferFee: number | null
+  transferFiles: string[] | null
+  status: EgressStatus
+}
+
+export interface Ingress {
+  id: string
+  ingressDate: string
+  ingressAmount: number
+  ingressComment: string | null
+  ingressFiles: string[]
+}
+
+// Unified transaction for the merged egress + ingress view.
+
+export type Transaction =
+  | ({ type: "egress" } & Reimbursement)
+  | ({ type: "ingress" } & Ingress)
+
+export const REIMBURSE_BUCKETS = {
+  invoices: "reimburse-invoices",
+  signatures: "reimburse-signatures",
+  advances: "reimburse-advances",
+} as const

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -17,6 +17,7 @@
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.104.0",
     "@tabler/icons-react": "^3.41.1",
+    "@tanstack/react-table": "^8.21.3",
     "@workspace/ui": "workspace:*",
     "client-zip": "^2.5.0",
     "next": "16.1.6",
@@ -27,6 +28,7 @@
     "react-pdf": "^9",
     "react-rnd": "^10.5.3",
     "react-signature-canvas": "^1",
+    "recharts": "^2.15.4",
     "resend": "^6.12.2"
   },
   "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -82,6 +82,7 @@
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.104.0",
         "@tabler/icons-react": "^3.41.1",
+        "@tanstack/react-table": "^8.21.3",
         "@workspace/ui": "workspace:*",
         "client-zip": "^2.5.0",
         "next": "16.1.6",
@@ -92,6 +93,7 @@
         "react-pdf": "^9",
         "react-rnd": "^10.5.3",
         "react-signature-canvas": "^1",
+        "recharts": "^2.15.4",
         "resend": "^6.12.2",
       },
       "devDependencies": {
@@ -219,6 +221,8 @@
     "@babel/plugin-transform-typescript": ["@babel/plugin-transform-typescript@7.28.6", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.27.3", "@babel/helper-create-class-features-plugin": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6", "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw=="],
 
     "@babel/preset-typescript": ["@babel/preset-typescript@7.28.5", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-validator-option": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-transform-modules-commonjs": "^7.27.1", "@babel/plugin-transform-typescript": "^7.28.5" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
 
@@ -726,6 +730,10 @@
 
     "@tanstack/react-query": ["@tanstack/react-query@5.99.2", "", { "dependencies": { "@tanstack/query-core": "5.99.2" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA=="],
 
+    "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
+
+    "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
+
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 
     "@turbo/darwin-64": ["@turbo/darwin-64@2.9.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg=="],
@@ -741,6 +749,24 @@
     "@turbo/windows-64": ["@turbo/windows-64@2.9.6", "", { "os": "win32", "cpu": "x64" }, "sha512-wVdQjvnBI15wB6JrA+43CtUtagjIMmX6XYO758oZHAsCNSxqRlJtdyujih0D8OCnwCRWiGWGI63zAxR0hO6s9g=="],
 
     "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -936,6 +962,28 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "data-view-buffer": ["data-view-buffer@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ=="],
@@ -947,6 +995,8 @@
     "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
 
@@ -979,6 +1029,8 @@
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
+
+    "dom-helpers": ["dom-helpers@5.2.1", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^3.0.2" } }, "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -1070,7 +1122,7 @@
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
-    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+    "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
@@ -1085,6 +1137,8 @@
     "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-equals": ["fast-equals@5.4.0", "", {}, "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw=="],
 
     "fast-glob": ["fast-glob@3.3.1", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.4" } }, "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg=="],
 
@@ -1235,6 +1289,8 @@
     "ini": ["ini@4.1.1", "", {}, "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
@@ -1389,6 +1445,8 @@
     "listr2": ["listr2@9.0.5", "", { "dependencies": { "cli-truncate": "^5.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
 
@@ -1614,7 +1672,7 @@
 
     "react-draggable": ["react-draggable@4.5.0", "", { "dependencies": { "clsx": "^2.1.1", "prop-types": "^15.8.1" }, "peerDependencies": { "react": ">= 16.3.0", "react-dom": ">= 16.3.0" } }, "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw=="],
 
-    "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+    "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "react-pdf": ["react-pdf@9.2.1", "", { "dependencies": { "clsx": "^2.0.0", "dequal": "^2.0.3", "make-cancellable-promise": "^1.3.1", "make-event-props": "^1.6.0", "merge-refs": "^1.3.0", "pdfjs-dist": "4.8.69", "tiny-invariant": "^1.0.0", "warning": "^4.0.0" }, "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-AJt0lAIkItWEZRA5d/mO+Om4nPCuTiQ0saA+qItO967DTjmGjnhmF+Bi2tL286mOTfBlF5CyLzJ35KTMaDoH+A=="],
 
@@ -1626,11 +1684,19 @@
 
     "react-signature-canvas": ["react-signature-canvas@1.0.7", "", { "dependencies": { "signature_pad": "^2.3.2", "trim-canvas": "^0.1.0" }, "peerDependencies": { "prop-types": "^15.5.8", "react": "0.14 - 19", "react-dom": "0.14 - 19" } }, "sha512-yo0x0uTMVmcClaqryuQu6F8xEVapk5zdM9/nuQ7GalDJWccoVNZPMmCFGK7U5r3I0mrEHPB9E5/rFSYUgZcfmA=="],
 
+    "react-smooth": ["react-smooth@4.0.4", "", { "dependencies": { "fast-equals": "^5.0.1", "prop-types": "^15.8.1", "react-transition-group": "^4.4.5" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q=="],
+
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
+
+    "react-transition-group": ["react-transition-group@4.4.5", "", { "dependencies": { "@babel/runtime": "^7.5.5", "dom-helpers": "^5.0.1", "loose-envify": "^1.4.0", "prop-types": "^15.6.2" }, "peerDependencies": { "react": ">=16.6.0", "react-dom": ">=16.6.0" } }, "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g=="],
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
+
+    "recharts": ["recharts@2.15.4", "", { "dependencies": { "clsx": "^2.0.0", "eventemitter3": "^4.0.1", "lodash": "^4.17.21", "react-is": "^18.3.1", "react-smooth": "^4.0.4", "recharts-scale": "^0.4.4", "tiny-invariant": "^1.3.1", "victory-vendor": "^36.6.8" }, "peerDependencies": { "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw=="],
+
+    "recharts-scale": ["recharts-scale@0.4.5", "", { "dependencies": { "decimal.js-light": "^2.4.1" } }, "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
@@ -1860,6 +1926,8 @@
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
+    "victory-vendor": ["victory-vendor@36.9.2", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ=="],
+
     "warning": ["warning@4.0.3", "", { "dependencies": { "loose-envify": "^1.0.0" } }, "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
@@ -1996,6 +2064,8 @@
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
+    "listr2/eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
     "log-symbols/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
@@ -2017,6 +2087,8 @@
     "ora/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 

--- a/supabase/migrations/2026-05-02-reimburse-app.sql
+++ b/supabase/migrations/2026-05-02-reimburse-app.sql
@@ -1,0 +1,167 @@
+-- reimburse app: lab cash-flow bookkeeping (migrated from reimburse.winlab.tw).
+-- Tracks egress (expenses with optional invoice/transfer-fee) and ingress
+-- (income), with admin-managed CRUD and lab-wide read visibility.
+--
+-- Schema mirrors the legacy `egress` / `ingress` tables but renamed to
+-- `reimburse_*` to align with the app namespace. Storage buckets keep their
+-- existing names (already prefixed: reimburse-invoices, reimburse-signatures,
+-- reimburse-advances). A follow-up migration drops `egress` / `ingress` once
+-- portal /reimburse is verified stable.
+
+-- =============================================================================
+-- Tables
+-- =============================================================================
+
+create table public.reimburse_egress (
+  id              uuid primary key default gen_random_uuid(),
+  applicant_name  text not null,
+  item_name       text not null,
+  item_amount     numeric not null check (item_amount >= 0),
+  item_comment    text,
+  invoice_date    date not null,
+  invoice_files   text[] not null default '{}',
+  transfer_date   date,
+  transfer_fee    numeric check (transfer_fee is null or transfer_fee >= 0),
+  transfer_files  text[],
+  status          text not null default 'pending'
+                    check (status in ('pending', 'approved', 'rejected')),
+  user_id         uuid references public.user_profiles(id) on delete set null,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now()
+);
+
+create index reimburse_egress_invoice_date
+  on public.reimburse_egress (invoice_date desc);
+create index reimburse_egress_user_id
+  on public.reimburse_egress (user_id);
+
+create table public.reimburse_ingress (
+  id              uuid primary key default gen_random_uuid(),
+  ingress_date    date not null,
+  ingress_amount  numeric not null check (ingress_amount >= 0),
+  ingress_comment text,
+  ingress_files   text[] not null default '{}',
+  user_id         uuid references public.user_profiles(id) on delete set null,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now()
+);
+
+create index reimburse_ingress_ingress_date
+  on public.reimburse_ingress (ingress_date desc);
+create index reimburse_ingress_user_id
+  on public.reimburse_ingress (user_id);
+
+-- =============================================================================
+-- updated_at trigger (mirrors original reimburse table behavior)
+-- =============================================================================
+
+create or replace function public.reimburse_set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger trg_reimburse_egress_updated_at
+before update on public.reimburse_egress
+for each row execute function public.reimburse_set_updated_at();
+
+create trigger trg_reimburse_ingress_updated_at
+before update on public.reimburse_ingress
+for each row execute function public.reimburse_set_updated_at();
+
+-- =============================================================================
+-- Admin helper: roles.reimburse contains "admin"
+-- (security definer to avoid recursive RLS evaluation on user_profiles)
+-- =============================================================================
+
+create or replace function public.is_reimburse_admin()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.user_profiles up
+    where up.id = auth.uid()
+      and (
+        up.is_admin = true
+        or (up.roles ? 'reimburse' and up.roles -> 'reimburse' ? 'admin')
+      )
+  );
+$$;
+
+-- =============================================================================
+-- RLS — lab-wide visibility, admin-only writes
+-- =============================================================================
+
+alter table public.reimburse_egress  enable row level security;
+alter table public.reimburse_ingress enable row level security;
+
+-- Any signed-in user can list (lab-wide bookkeeping is shared knowledge).
+create policy "reimburse_egress_select"
+on public.reimburse_egress for select
+using (auth.uid() is not null);
+
+create policy "reimburse_ingress_select"
+on public.reimburse_ingress for select
+using (auth.uid() is not null);
+
+-- Only reimburse admins (or global is_admin) may mutate.
+create policy "reimburse_egress_insert"
+on public.reimburse_egress for insert
+with check (public.is_reimburse_admin());
+
+create policy "reimburse_egress_update"
+on public.reimburse_egress for update
+using (public.is_reimburse_admin())
+with check (public.is_reimburse_admin());
+
+create policy "reimburse_egress_delete"
+on public.reimburse_egress for delete
+using (public.is_reimburse_admin());
+
+create policy "reimburse_ingress_insert"
+on public.reimburse_ingress for insert
+with check (public.is_reimburse_admin());
+
+create policy "reimburse_ingress_update"
+on public.reimburse_ingress for update
+using (public.is_reimburse_admin())
+with check (public.is_reimburse_admin());
+
+create policy "reimburse_ingress_delete"
+on public.reimburse_ingress for delete
+using (public.is_reimburse_admin());
+
+-- =============================================================================
+-- Data migration: copy existing egress / ingress rows into reimburse_*
+-- (preserves IDs so existing storage paths and external references stay valid)
+-- =============================================================================
+
+insert into public.reimburse_egress (
+  id, applicant_name, item_name, item_amount, item_comment,
+  invoice_date, invoice_files, transfer_date, transfer_fee, transfer_files,
+  status, user_id, created_at, updated_at
+)
+select
+  id, applicant_name, item_name, item_amount, item_comment,
+  invoice_date, coalesce(invoice_files, '{}'),
+  transfer_date, transfer_fee, transfer_files,
+  status, user_id, created_at, updated_at
+from public.egress;
+
+insert into public.reimburse_ingress (
+  id, ingress_date, ingress_amount, ingress_comment, ingress_files,
+  user_id, created_at, updated_at
+)
+select
+  id, ingress_date, ingress_amount, ingress_comment,
+  coalesce(ingress_files, '{}'),
+  user_id, created_at, updated_at
+from public.ingress;


### PR DESCRIPTION
## Summary

Mirrors what we did for `/debt` (#40): the standalone `reimburse.winlab.tw` app moves into portal as `/reimburse`, sharing the same Supabase project, auth, and `<PortalShell>` skeleton.

- Tables `egress` / `ingress` → `reimburse_egress` / `reimburse_ingress` (legacy tables left in place for rollback; follow-up will drop them)
- `is_reimburse_admin()` SQL helper drives RLS — admins write, all signed-in users read
- UI re-skinned to portal's `@workspace/ui` shadcn primitives; charts dropped the shadcn wrapper for plain Recharts
- Server Actions + Server Component for data; no QueryProvider needed
- New entry on portal home between `Debt` and `Profile`

## What ships

- `supabase/migrations/2026-05-02-reimburse-app.sql` — new tables, RLS, helper fn, data copy from old tables (preserves IDs)
- `apps/portal/app/reimburse/` — page / layout / actions + 10 client components
- `apps/portal/app/api/reimburse/advance/route.ts` — PDF synthesis endpoint (template + invoice + signature)
- `apps/portal/lib/reimburse/` — types, transformers, queries, admin RPC wrapper
- `apps/portal/package.json` — `recharts`, `@tanstack/react-table`

## Migration plan

1. Apply `2026-05-02-reimburse-app.sql` against `yissfqcdmzsxwfnzrflz` (Dashboard SQL editor or `supabase db push --linked` once linked)
2. Smoke-test `/reimburse` — read-only for non-admins, full CRUD for `roles.reimburse=[\"admin\"]`
3. Verify row count parity vs legacy `egress` / `ingress`
4. After ~2 weeks of stable use, follow-up migration drops `egress` / `ingress`

## Heads-up — needs the lab's PDF template

`/api/reimburse/advance` reads `apps/portal/public/reimburse/advance.pdf` (the lab's pre-printed expense form). The original repo never committed it (gitignored or production-only). Drop the file in before this lands, or we can rip out `AddReimburseDialog` + the API route if the auto-PDF feature isn't worth carrying.

Storage buckets (`reimburse-invoices`, `reimburse-signatures`, `reimburse-advances`) keep their existing names and data — no bucket migration needed.

## Test plan

- [ ] Apply migration; check `select count(*) from reimburse_egress` matches legacy `egress`
- [ ] Visit `/reimburse` as non-admin → balance + table render, no Add buttons
- [ ] Visit `/reimburse` as admin → Add/Edit/Delete works, toasts show, table refreshes
- [ ] Drop `advance.pdf` template, click 上傳報帳 → produces merged PDF in `reimburse-advances/`
- [ ] Build / typecheck / lint clean (verified locally)