### PR TITLE
chore(portal): trim reimburse label to four chars — line up with the rest

### DIFF
--- a/apps/portal/app/page.tsx
+++ b/apps/portal/app/page.tsx
@@ -14,7 +14,7 @@ const apps = [
   { href: "/approve", label: "Approve", note: "文件簽核" },
   { href: "/trip", label: "Trip", note: "出差文件" },
   { href: "/debt", label: "Debt", note: "分帳記帳" },
-  { href: "/reimburse", label: "Reimburse", note: "實驗室帳本" },
+  { href: "/reimburse", label: "Reimburse", note: "收支記帳" },
   { href: "/profile", label: "Profile", note: "個人帳號" },
   { href: "https://gallery.winlab.tw", label: "Gallery", note: "藝術畫廊" },
 ]


### PR DESCRIPTION
## Summary

`/reimburse` 的 note 從 5 字 `實驗室帳本` 改成 4 字 `收支記帳`，跟 Debt 的 `分帳記帳` 對齊節奏，整列入口卡片終於齊頭。

```
Bento     便當訂購
Leave     請假登記
Approve   文件簽核
Trip      出差文件
Debt      分帳記帳
Reimburse 收支記帳   ← was 實驗室帳本
Profile   個人帳號
Gallery   藝術畫廊
```

字面意思也更精準：reimburse 模組就是 ingress (收) 跟 egress (支) 兩個 entity 的記帳。

## Test plan

- [x] `/` 入口列表所有 note 都 4 字