### PR TITLE
chore: stop next-env.d.ts from getting into a slap fight with prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ node_modules/
 coverage/
 pnpm-lock.yaml
 .pnpm-store/
+next-env.d.ts

--- a/apps/portal/next-env.d.ts
+++ b/apps/portal/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts"
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- Next.js 16 dev mode 把 `next-env.d.ts` 的 import 路徑從 `.next/types/` 改到 `.next/dev/types/` 並補了行尾分號 → pre-commit prettier 又把分號刪掉 → 下次起 dev 又補回來 → 永久 dirty
- 加 `next-env.d.ts` 進 `.prettierignore`（Next.js 官方就標明此檔不該手動編輯），同步 commit 當前 Next 16 生成的內容
- gallery / mcp 還沒跑過 dev 所以舊格式留著，下次他們起 dev 會自動 sync，prettier 不會再吃它

## Test plan
- [x] commit 過程中 prettier hook 沒動到 `next-env.d.ts`（只改 `.prettierignore`）
- [ ] 重啟 portal dev，working tree 維持乾淨