### PR TITLE
feat(portal): add /receipts — admin-only receipt review wall

### DIFF
--- a/apps/portal/app/receipts/_components/image-preview-dialog.tsx
+++ b/apps/portal/app/receipts/_components/image-preview-dialog.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { Skeleton } from "@workspace/ui/components/skeleton"
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "@workspace/ui/components/dialog"
+
+import { useReceiptSignedUrl } from "@/hooks/receipts/use-receipts"
+
+export function ImagePreviewDialog({
+  path,
+  name,
+}: {
+  path: string
+  name: string
+}) {
+  const { data: url, isLoading } = useReceiptSignedUrl(path)
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className="size-12 overflow-hidden rounded-md border border-border transition-opacity hover:opacity-80 disabled:cursor-wait"
+          disabled={!url}
+          aria-label={`預覽 ${name}`}
+        >
+          {isLoading || !url ? (
+            <Skeleton className="size-full" />
+          ) : (
+            // signed urls are remote; using <img> keeps Next config out of it
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={url}
+              alt={name}
+              className="size-full object-cover"
+              loading="lazy"
+            />
+          )}
+        </button>
+      </DialogTrigger>
+      <DialogContent
+        showCloseButton
+        className="max-w-3xl border-none bg-transparent p-0 shadow-none ring-0 sm:max-w-3xl"
+      >
+        <DialogTitle className="sr-only">{name}</DialogTitle>
+        {url ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={url}
+            alt={name}
+            className="max-h-[85vh] w-full rounded-2xl object-contain"
+          />
+        ) : (
+          <Skeleton className="aspect-square w-full" />
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/portal/app/receipts/_components/query-provider.tsx
+++ b/apps/portal/app/receipts/_components/query-provider.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { useState, type ReactNode } from "react"
+
+export function QueryProvider({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 1000 * 60,
+            refetchOnWindowFocus: false,
+          },
+        },
+      })
+  )
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}

--- a/apps/portal/app/receipts/_components/receipts-view.tsx
+++ b/apps/portal/app/receipts/_components/receipts-view.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import { Skeleton } from "@workspace/ui/components/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@workspace/ui/components/table"
+
+import { useReceipts } from "@/hooks/receipts/use-receipts"
+
+import { ImagePreviewDialog } from "./image-preview-dialog"
+import { StatusSelect } from "./status-select"
+import { UploadDialog } from "./upload-dialog"
+
+export function ReceiptsView() {
+  const { data: receipts, isLoading, error } = useReceipts()
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between gap-4">
+        <h1 className="text-2xl font-medium">收據</h1>
+        <UploadDialog />
+      </div>
+
+      <div className="rounded-2xl border border-border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>名稱</TableHead>
+              <TableHead className="w-20">圖片</TableHead>
+              <TableHead className="w-40">狀態</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              <SkeletonRows />
+            ) : error ? (
+              <TableRow>
+                <TableCell
+                  colSpan={3}
+                  className="py-10 text-center text-sm text-destructive"
+                >
+                  讀取失敗：{error.message}
+                </TableCell>
+              </TableRow>
+            ) : !receipts || receipts.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={3}
+                  className="py-10 text-center text-sm text-muted-foreground"
+                >
+                  還沒有收據，按右上角上傳一張。
+                </TableCell>
+              </TableRow>
+            ) : (
+              receipts.map((r) => (
+                <TableRow key={r.id}>
+                  <TableCell className="font-medium">{r.name}</TableCell>
+                  <TableCell>
+                    <ImagePreviewDialog path={r.imagePath} name={r.name} />
+                  </TableCell>
+                  <TableCell>
+                    <StatusSelect id={r.id} value={r.status} />
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  )
+}
+
+function SkeletonRows() {
+  return (
+    <>
+      {Array.from({ length: 3 }).map((_, i) => (
+        <TableRow key={i}>
+          <TableCell>
+            <Skeleton className="h-4 w-32" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="size-12 rounded-md" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-9 w-32" />
+          </TableCell>
+        </TableRow>
+      ))}
+    </>
+  )
+}

--- a/apps/portal/app/receipts/_components/status-select.tsx
+++ b/apps/portal/app/receipts/_components/status-select.tsx
@@ -1,0 +1,73 @@
+"use client"
+
+import { toast } from "sonner"
+
+import { Badge } from "@workspace/ui/components/badge"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@workspace/ui/components/select"
+
+import { useUpdateReceiptStatus } from "@/hooks/receipts/use-receipts"
+import type { ReceiptStatus } from "@/lib/receipts/types"
+
+const LABELS: Record<ReceiptStatus, string> = {
+  pending: "審核中",
+  approved: "審核完成",
+  rejected: "已拒絕",
+}
+
+const VARIANTS: Record<ReceiptStatus, "secondary" | "default" | "destructive"> =
+  {
+    pending: "secondary",
+    approved: "default",
+    rejected: "destructive",
+  }
+
+export function ReceiptStatusBadge({ status }: { status: ReceiptStatus }) {
+  return <Badge variant={VARIANTS[status]}>{LABELS[status]}</Badge>
+}
+
+export function StatusSelect({
+  id,
+  value,
+}: {
+  id: string
+  value: ReceiptStatus
+}) {
+  const update = useUpdateReceiptStatus()
+
+  const handleChange = (next: string) => {
+    if (next === value) return
+    update.mutate(
+      { id, status: next as ReceiptStatus },
+      {
+        onSuccess: () =>
+          toast.success(`狀態改為「${LABELS[next as ReceiptStatus]}」`),
+        onError: (err) => toast.error(`改狀態失敗：${err.message}`),
+      }
+    )
+  }
+
+  return (
+    <Select
+      value={value}
+      onValueChange={handleChange}
+      disabled={update.isPending}
+    >
+      <SelectTrigger className="w-32">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {(["pending", "approved", "rejected"] as ReceiptStatus[]).map((s) => (
+          <SelectItem key={s} value={s}>
+            {LABELS[s]}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/apps/portal/app/receipts/_components/upload-dialog.tsx
+++ b/apps/portal/app/receipts/_components/upload-dialog.tsx
@@ -1,0 +1,118 @@
+"use client"
+
+import { Plus } from "lucide-react"
+import { useState } from "react"
+import { toast } from "sonner"
+
+import { Button } from "@workspace/ui/components/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@workspace/ui/components/dialog"
+import { Input } from "@workspace/ui/components/input"
+import { Label } from "@workspace/ui/components/label"
+
+import { useUploadReceipt } from "@/hooks/receipts/use-receipts"
+
+export function UploadDialog() {
+  const [open, setOpen] = useState(false)
+  const [name, setName] = useState("")
+  const [file, setFile] = useState<File | null>(null)
+  const upload = useUploadReceipt()
+
+  const reset = () => {
+    setName("")
+    setFile(null)
+  }
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    if (!file) {
+      toast.error("請選一張收據圖片")
+      return
+    }
+
+    upload.mutate(
+      { name: name.trim(), file },
+      {
+        onSuccess: () => {
+          toast.success("已上傳")
+          setOpen(false)
+          reset()
+        },
+        onError: (err) => toast.error(`上傳失敗：${err.message}`),
+      }
+    )
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next)
+        if (!next) reset()
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button>
+          <Plus />
+          上傳收據
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>上傳收據</DialogTitle>
+            <DialogDescription>
+              新增一筆收據記錄，預設狀態為「審核中」。
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <div className="grid gap-2">
+              <Label htmlFor="receipt-name">
+                名稱 <span className="text-destructive">*</span>
+              </Label>
+              <Input
+                id="receipt-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="例：Amazon 鍵盤"
+                required
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="receipt-file">
+                收據圖片 <span className="text-destructive">*</span>
+              </Label>
+              <Input
+                id="receipt-file"
+                type="file"
+                accept="image/*"
+                onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+                required
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setOpen(false)}
+              disabled={upload.isPending}
+            >
+              取消
+            </Button>
+            <Button type="submit" disabled={upload.isPending}>
+              {upload.isPending ? "上傳中…" : "上傳"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/portal/app/receipts/layout.tsx
+++ b/apps/portal/app/receipts/layout.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+
+import { Toaster } from "@workspace/ui/components/sonner"
+
+import { PortalShell } from "@/components/portal-shell"
+
+import { QueryProvider } from "./_components/query-provider"
+
+export const metadata: Metadata = {
+  title: "Receipts | Portal",
+  description: "Receipt review for WinLab.",
+}
+
+export default function ReceiptsLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <QueryProvider>
+      <PortalShell
+        appName="Receipts"
+        appHref="/receipts"
+        bottomLeft={
+          <Link href="/" className="transition-colors hover:text-foreground">
+            Portal
+          </Link>
+        }
+      >
+        {children}
+      </PortalShell>
+      <Toaster />
+    </QueryProvider>
+  )
+}

--- a/apps/portal/app/receipts/page.tsx
+++ b/apps/portal/app/receipts/page.tsx
@@ -1,0 +1,15 @@
+import { notFound } from "next/navigation"
+
+import { isReceiptsAdmin } from "@/lib/receipts/admin"
+
+import { ReceiptsView } from "./_components/receipts-view"
+
+// /receipts is admin-only; the listing is sensitive (incoming reimbursement
+// claims). Skip static rendering so the gate runs per request.
+export const dynamic = "force-dynamic"
+
+export default async function ReceiptsPage() {
+  const isAdmin = await isReceiptsAdmin()
+  if (!isAdmin) notFound()
+  return <ReceiptsView />
+}

--- a/apps/portal/hooks/receipts/query-keys.ts
+++ b/apps/portal/hooks/receipts/query-keys.ts
@@ -1,0 +1,9 @@
+export const queryKeys = {
+  receipts: {
+    all: ["receipts", "list"] as const,
+  },
+  admin: {
+    status: ["receipts", "admin"] as const,
+  },
+  signedUrl: (path: string) => ["receipts", "signed-url", path] as const,
+}

--- a/apps/portal/hooks/receipts/use-admin.ts
+++ b/apps/portal/hooks/receipts/use-admin.ts
@@ -1,0 +1,35 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+
+import { useAuth } from "@/hooks/use-auth"
+import { createClient } from "@/lib/supabase/client"
+
+import { queryKeys } from "./query-keys"
+
+export function useReceiptsAdmin() {
+  const { user } = useAuth()
+  const supabase = createClient()
+
+  const { data, isLoading } = useQuery({
+    queryKey: queryKeys.admin.status,
+    queryFn: async () => {
+      if (!user) return null
+      const { data: profile } = await supabase
+        .from("user_profiles")
+        .select("roles, is_admin")
+        .eq("id", user.id)
+        .single()
+      return profile
+    },
+    enabled: !!user,
+  })
+
+  const roles = data?.roles as Record<string, string[]> | undefined
+  const receiptRoles = roles?.receipts
+  const isAdmin =
+    data?.is_admin === true ||
+    (Array.isArray(receiptRoles) && receiptRoles.includes("admin"))
+
+  return { isAdmin, isLoading }
+}

--- a/apps/portal/hooks/receipts/use-receipts.ts
+++ b/apps/portal/hooks/receipts/use-receipts.ts
@@ -1,0 +1,114 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { createClient } from "@/lib/supabase/client"
+
+import {
+  RECEIPTS_BUCKET,
+  toReceipt,
+  type DatabaseReceipt,
+  type Receipt,
+  type ReceiptStatus,
+} from "@/lib/receipts/types"
+
+import { queryKeys } from "./query-keys"
+
+const TABLE = "receipts"
+const SIGNED_URL_TTL = 60 * 60 // one hour — long enough that a tab open all
+// afternoon doesn't go stale
+
+export function useReceipts() {
+  const supabase = createClient()
+  return useQuery({
+    queryKey: queryKeys.receipts.all,
+    queryFn: async (): Promise<Receipt[]> => {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select("*")
+        .order("created_at", { ascending: false })
+      if (error) throw error
+      return (data as DatabaseReceipt[]).map(toReceipt)
+    },
+  })
+}
+
+export function useReceiptSignedUrl(path: string | null) {
+  const supabase = createClient()
+  return useQuery({
+    queryKey: path ? queryKeys.signedUrl(path) : ["receipts", "signed-url", ""],
+    queryFn: async () => {
+      if (!path) return null
+      const { data, error } = await supabase.storage
+        .from(RECEIPTS_BUCKET)
+        .createSignedUrl(path, SIGNED_URL_TTL)
+      if (error) throw error
+      return data.signedUrl
+    },
+    enabled: !!path,
+    staleTime: (SIGNED_URL_TTL - 60) * 1000,
+  })
+}
+
+export function useUploadReceipt() {
+  const supabase = createClient()
+  const qc = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ name, file }: { name: string; file: File }) => {
+      const ext = file.name.split(".").pop()?.toLowerCase() ?? "bin"
+      const id = crypto.randomUUID()
+      const path = `${id}/${id}.${ext}`
+
+      const { error: uploadError } = await supabase.storage
+        .from(RECEIPTS_BUCKET)
+        .upload(path, file, {
+          contentType: file.type || "application/octet-stream",
+          upsert: false,
+        })
+      if (uploadError) throw uploadError
+
+      const { data, error } = await supabase
+        .from(TABLE)
+        .insert({ id, name, image_path: path })
+        .select()
+        .single()
+      if (error) {
+        // best-effort cleanup; orphaned object is preferable to a half-row
+        await supabase.storage.from(RECEIPTS_BUCKET).remove([path])
+        throw error
+      }
+      return toReceipt(data as DatabaseReceipt)
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.receipts.all })
+    },
+  })
+}
+
+export function useUpdateReceiptStatus() {
+  const supabase = createClient()
+  const qc = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      id,
+      status,
+    }: {
+      id: string
+      status: ReceiptStatus
+    }) => {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .update({ status })
+        .eq("id", id)
+        .select()
+        .single()
+      if (error) throw error
+      return toReceipt(data as DatabaseReceipt)
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.receipts.all })
+    },
+  })
+}

--- a/apps/portal/lib/receipts/admin.ts
+++ b/apps/portal/lib/receipts/admin.ts
@@ -1,0 +1,11 @@
+import { createClient } from "@/lib/supabase/server"
+
+export async function isReceiptsAdmin(): Promise<boolean> {
+  const supabase = await createClient()
+  const { data, error } = await supabase.rpc("is_receipts_admin")
+  if (error) {
+    console.error("[receipts] is_receipts_admin rpc failed", error)
+    return false
+  }
+  return data === true
+}

--- a/apps/portal/lib/receipts/types.ts
+++ b/apps/portal/lib/receipts/types.ts
@@ -1,0 +1,42 @@
+export type ReceiptStatus = "pending" | "approved" | "rejected"
+
+export interface DatabaseReceipt {
+  id: string
+  name: string
+  image_path: string
+  status: ReceiptStatus
+  created_by: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface InsertReceipt {
+  name: string
+  image_path: string
+  status?: ReceiptStatus
+}
+
+export interface UpdateReceipt {
+  name?: string
+  status?: ReceiptStatus
+}
+
+export interface Receipt {
+  id: string
+  name: string
+  imagePath: string
+  status: ReceiptStatus
+  createdAt: string
+}
+
+export function toReceipt(row: DatabaseReceipt): Receipt {
+  return {
+    id: row.id,
+    name: row.name,
+    imagePath: row.image_path,
+    status: row.status,
+    createdAt: row.created_at,
+  }
+}
+
+export const RECEIPTS_BUCKET = "receipts"

--- a/supabase/migrations/2026-05-04-receipts-app.sql
+++ b/supabase/migrations/2026-05-04-receipts-app.sql
@@ -1,0 +1,112 @@
+-- receipts app: admin-only receipt review workflow.
+-- Each row is one receipt: a name + uploaded image + status (pending /
+-- approved / rejected). Only receipts admins can see, upload, or change
+-- status — this is the upstream stage before reimburse bookkeeping.
+
+-- =============================================================================
+-- Table
+-- =============================================================================
+
+create table public.receipts (
+  id          uuid primary key default gen_random_uuid(),
+  name        text not null,
+  image_path  text not null,
+  status      text not null default 'pending'
+                check (status in ('pending', 'approved', 'rejected')),
+  created_by  uuid references public.user_profiles(id) on delete set null,
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now()
+);
+
+create index receipts_created_at on public.receipts (created_at desc);
+create index receipts_status     on public.receipts (status);
+
+-- =============================================================================
+-- updated_at trigger
+-- =============================================================================
+
+create or replace function public.receipts_set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger trg_receipts_updated_at
+before update on public.receipts
+for each row execute function public.receipts_set_updated_at();
+
+-- =============================================================================
+-- Admin helper: roles.receipts contains "admin"
+-- (security definer to avoid recursive RLS on user_profiles)
+-- =============================================================================
+
+create or replace function public.is_receipts_admin()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.user_profiles up
+    where up.id = auth.uid()
+      and (
+        up.is_admin = true
+        or (up.roles ? 'receipts' and up.roles -> 'receipts' ? 'admin')
+      )
+  );
+$$;
+
+-- =============================================================================
+-- RLS — admin-only across the board (table is for the receipts admin's eyes)
+-- =============================================================================
+
+alter table public.receipts enable row level security;
+
+create policy "receipts_select"
+on public.receipts for select
+using (public.is_receipts_admin());
+
+create policy "receipts_insert"
+on public.receipts for insert
+with check (public.is_receipts_admin());
+
+create policy "receipts_update"
+on public.receipts for update
+using (public.is_receipts_admin())
+with check (public.is_receipts_admin());
+
+create policy "receipts_delete"
+on public.receipts for delete
+using (public.is_receipts_admin());
+
+-- =============================================================================
+-- Storage — private bucket, admin-only read/write
+-- Path layout: <receipt_id>/<filename>
+-- =============================================================================
+
+insert into storage.buckets (id, name, public)
+values ('receipts', 'receipts', false)
+on conflict (id) do nothing;
+
+create policy "receipts_storage_select"
+on storage.objects for select
+using (bucket_id = 'receipts' and public.is_receipts_admin());
+
+create policy "receipts_storage_insert"
+on storage.objects for insert
+with check (bucket_id = 'receipts' and public.is_receipts_admin());
+
+create policy "receipts_storage_update"
+on storage.objects for update
+using (bucket_id = 'receipts' and public.is_receipts_admin())
+with check (bucket_id = 'receipts' and public.is_receipts_admin());
+
+create policy "receipts_storage_delete"
+on storage.objects for delete
+using (bucket_id = 'receipts' and public.is_receipts_admin());


### PR DESCRIPTION
## Summary
- 新增 `/receipts` app（在 `apps/portal/app/receipts/` 底下，照 bento 範本起骨架）
- 一張表三欄：**名稱 / 圖片 / 狀態**（`pending` / `approved` / `rejected`，中文 label：審核中 / 審核完成 / 已拒絕）
- Admin 才看得到（`page.tsx` 用 `isReceiptsAdmin()` server gate，不是 admin 直接 `notFound()`）
- 點圖開大圖：`<ImagePreviewDialog>` 用 1 小時 signed URL（避免每秒 re-sign）
- 上傳：`<UploadDialog>` → Supabase Storage `receipts` bucket（私有），path layout `<receipt_id>/<receipt_id>.<ext>`
- 改狀態：行內 `<StatusSelect>`，TanStack Query 樂觀 invalidate

## Schema
`receipts` table + `is_receipts_admin()` SQL helper + 私有 storage bucket，RLS **admin-only 全 CRUD**（沒有 `using (true)`、沒有 "for simplicity" 偷懶）

## Test plan
- [x] `bun run typecheck` 全綠
- [x] `bun run lint --filter=portal` 0 errors
- [x] `bunx turbo run build --filter=portal` 成功，`/receipts` 進 route 列表為 ƒ (Dynamic)
- [ ] **Merge 後手動步驟（owner 自己跑）：**
  - [ ] 在 Supabase Dashboard SQL Editor 執行 `supabase/migrations/2026-05-04-receipts-app.sql`
  - [ ] 在 `user_profiles` 表把自己的 `roles` 設成 `{"receipts": ["admin"]}`（merge 既有 roles 用 jsonb 操作）或者 `is_admin = true`
  - [ ] 訪問 `/receipts`、上傳一張圖、切狀態、點圖看大圖

## 邊界
這個 app 是 **報銷申請的 review 階段**；通過後該怎麼接 `/reimburse` 落帳，等實際用起來再規劃 — 先不做 over-engineering。