### PR TITLE
fix(portal): receipts preview fills the dialog, drop the redundant download column

### DIFF
--- a/apps/portal/app/receipts/_components/receipt-preview-dialog.tsx
+++ b/apps/portal/app/receipts/_components/receipt-preview-dialog.tsx
@@ -21,17 +21,22 @@ export function ReceiptPreviewDialog({
 }) {
   const { data: url, isLoading } = useReceiptSignedUrl(path)
 
+  // #view=FitH tells the browser PDF viewer to fit the page width — without
+  // it landscape pages float at the bottom of the iframe with a tall black bar
+  // above them.
+  const iframeSrc = url ? `${url}#view=FitH` : null
+
   return (
     <Dialog>
       <DialogTrigger asChild>
         <button
           type="button"
           className="inline-flex size-9 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-wait disabled:opacity-50"
-          disabled={!url}
+          disabled={!iframeSrc}
           aria-label={`預覽 ${name}`}
           title={`預覽 ${name}`}
         >
-          {isLoading || !url ? (
+          {isLoading || !iframeSrc ? (
             <Skeleton className="size-4" />
           ) : (
             <FileText className="size-4" />
@@ -40,13 +45,17 @@ export function ReceiptPreviewDialog({
       </DialogTrigger>
       <DialogContent
         showCloseButton
-        className="h-[85vh] max-w-4xl gap-0 overflow-hidden p-0 sm:max-w-4xl"
+        className="grid h-[85vh] max-w-4xl grid-rows-[auto_1fr] gap-0 overflow-hidden p-0 sm:max-w-4xl"
       >
         <DialogTitle className="border-b border-border px-6 py-3 text-sm font-medium">
           {name}
         </DialogTitle>
-        {url ? (
-          <iframe src={url} title={name} className="size-full border-0" />
+        {iframeSrc ? (
+          <iframe
+            src={iframeSrc}
+            title={name}
+            className="size-full min-h-0 border-0"
+          />
         ) : (
           <Skeleton className="size-full" />
         )}

--- a/apps/portal/app/receipts/_components/receipts-view.tsx
+++ b/apps/portal/app/receipts/_components/receipts-view.tsx
@@ -1,8 +1,5 @@
 "use client"
 
-import { Download } from "lucide-react"
-import { toast } from "sonner"
-
 import { Skeleton } from "@workspace/ui/components/skeleton"
 import {
   Table,
@@ -13,7 +10,7 @@ import {
   TableRow,
 } from "@workspace/ui/components/table"
 
-import { useDownloadReceipt, useReceipts } from "@/hooks/receipts/use-receipts"
+import { useReceipts } from "@/hooks/receipts/use-receipts"
 
 import { ReceiptPreviewDialog } from "./receipt-preview-dialog"
 import { StatusSelect } from "./status-select"
@@ -27,16 +24,6 @@ export function ReceiptsView() {
     refetch,
     isRefetching,
   } = useReceipts()
-  const download = useDownloadReceipt()
-
-  const handleDownload = (id: string, name: string, path: string) => {
-    download.mutate(
-      { name, path },
-      {
-        onError: (err) => toast.error(`下載失敗：${err.message}`),
-      }
-    )
-  }
 
   return (
     <div className="flex flex-col gap-6">
@@ -52,7 +39,6 @@ export function ReceiptsView() {
               <TableHead>名稱</TableHead>
               <TableHead className="w-20">檔案</TableHead>
               <TableHead className="w-40">狀態</TableHead>
-              <TableHead className="w-16 text-right">下載</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -61,7 +47,7 @@ export function ReceiptsView() {
             ) : !receipts || receipts.length === 0 ? (
               <TableRow>
                 <TableCell
-                  colSpan={4}
+                  colSpan={3}
                   className="py-10 text-center text-sm text-muted-foreground"
                 >
                   {error ? (
@@ -88,18 +74,6 @@ export function ReceiptsView() {
                   <TableCell>
                     <StatusSelect id={r.id} value={r.status} />
                   </TableCell>
-                  <TableCell className="text-right">
-                    <button
-                      type="button"
-                      onClick={() => handleDownload(r.id, r.name, r.imagePath)}
-                      disabled={download.isPending}
-                      className="inline-flex size-9 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
-                      aria-label={`下載 ${r.name}`}
-                      title={`下載 ${r.name}.pdf`}
-                    >
-                      <Download className="size-4" />
-                    </button>
-                  </TableCell>
                 </TableRow>
               ))
             )}
@@ -123,9 +97,6 @@ function SkeletonRows() {
           </TableCell>
           <TableCell>
             <Skeleton className="h-9 w-32" />
-          </TableCell>
-          <TableCell className="text-right">
-            <Skeleton className="ml-auto size-9 rounded-md" />
           </TableCell>
         </TableRow>
       ))}

--- a/apps/portal/hooks/receipts/use-receipts.ts
+++ b/apps/portal/hooks/receipts/use-receipts.ts
@@ -7,7 +7,6 @@ import {
   RECEIPT_FILE_EXT,
   RECEIPT_MIME_PDF,
   fileToReceiptPdf,
-  sanitizeFilename,
 } from "@/lib/receipts/file"
 import {
   RECEIPTS_BUCKET,
@@ -117,27 +116,6 @@ export function useUpdateReceiptStatus() {
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: queryKeys.receipts.all })
-    },
-  })
-}
-
-export function useDownloadReceipt() {
-  const supabase = createClient()
-
-  return useMutation({
-    mutationFn: async ({ name, path }: { name: string; path: string }) => {
-      const { data, error } = await supabase.storage
-        .from(RECEIPTS_BUCKET)
-        .download(path)
-      if (error) throw error
-      const url = URL.createObjectURL(data)
-      const a = document.createElement("a")
-      a.href = url
-      a.download = `${sanitizeFilename(name)}.${RECEIPT_FILE_EXT}`
-      document.body.appendChild(a)
-      a.click()
-      a.remove()
-      URL.revokeObjectURL(url)
     },
   })
 }

--- a/apps/portal/lib/receipts/file.ts
+++ b/apps/portal/lib/receipts/file.ts
@@ -71,15 +71,3 @@ function loadImage(src: string): Promise<HTMLImageElement> {
     img.src = src
   })
 }
-
-// Strip characters that NTFS / HFS / common shells dislike, so the downloaded
-// filename actually opens in the user's OS.
-export function sanitizeFilename(name: string): string {
-  // Strip control bytes (\x00-\x1f) and shell-hostile punctuation.
-  // eslint-disable-next-line no-control-regex
-  const cleaned = name
-    .replace(/[\\/:*?"<>|\x00-\x1f]/g, "")
-    .replace(/\s+/g, " ")
-    .trim()
-  return cleaned.length > 0 ? cleaned : "receipt"
-}


### PR DESCRIPTION
## Summary
- Dialog 從預設 grid auto-rows 改成 `grid-rows-[auto_1fr]`，iframe 加 `min-h-0` 撐滿剩餘空間 — 不會再看到上方一大塊黑
- iframe URL 加 `#view=FitH`，瀏覽器 PDF viewer 會 fit page width，landscape 收據不再縮在底部
- 拿掉「下載」欄 + `useDownloadReceipt` hook + `sanitizeFilename` helper（沒人 import 了）
- 下載靠瀏覽器 PDF viewer toolbar 自帶（檔名是 storage 上的 `<id>.pdf` —— 不對齊 row name，但維護成本低）

## Test plan
- [x] typecheck / lint / build 全綠
- [ ] 上傳 landscape PDF 後預覽自動 fit width，沒有上方黑色空白