### PR TITLE
feat(gallery): allow renaming uploaded works on upload page

### DIFF
--- a/apps/gallery/app/upload/_components/rename-button.tsx
+++ b/apps/gallery/app/upload/_components/rename-button.tsx
@@ -1,0 +1,93 @@
+"use client"
+
+import { useEffect, useState, useTransition } from "react"
+import { toast } from "sonner"
+
+import { Button } from "@workspace/ui/components/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@workspace/ui/components/dialog"
+import { Input } from "@workspace/ui/components/input"
+
+import { renameGalleryImage } from "@/app/upload/actions"
+
+export function RenameButton({ id, name }: { id: string; name: string }) {
+  const [open, setOpen] = useState(false)
+  const [draft, setDraft] = useState(name)
+  const [pending, startTransition] = useTransition()
+
+  useEffect(() => {
+    if (open) setDraft(name)
+  }, [open, name])
+
+  function onSave() {
+    startTransition(async () => {
+      const result = await renameGalleryImage(id, draft)
+      if (result.ok) {
+        toast.success("Name updated")
+        setOpen(false)
+      } else {
+        toast.error(result.error)
+      }
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <Button
+        type="button"
+        variant="ghost"
+        onClick={() => setOpen(true)}
+        className="!text-lg text-muted-foreground italic hover:bg-transparent hover:text-foreground"
+      >
+        Rename
+      </Button>
+      <DialogContent className="gap-6">
+        <DialogHeader>
+          <DialogTitle className="font-serif text-2xl italic">
+            Rename work
+          </DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-2">
+          <label
+            className="text-sm text-muted-foreground"
+            htmlFor="rename-name"
+          >
+            Name
+          </label>
+          <Input
+            id="rename-name"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault()
+                onSave()
+              }
+            }}
+            disabled={pending}
+            className="text-base"
+            autoComplete="off"
+          />
+        </div>
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setOpen(false)}
+            disabled={pending}
+          >
+            Cancel
+          </Button>
+          <Button type="button" onClick={onSave} disabled={pending}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/gallery/app/upload/actions.ts
+++ b/apps/gallery/app/upload/actions.ts
@@ -104,6 +104,34 @@ export async function deleteGalleryImage(
   return { ok: true }
 }
 
+export async function renameGalleryImage(
+  id: string,
+  newName: string
+): Promise<ActionResult> {
+  const trimmed = newName.trim()
+  if (!trimmed) {
+    return { ok: false, error: "Name is required." }
+  }
+
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from("gallery_images")
+    .update({ name: trimmed })
+    .eq("id", id)
+    .select("id")
+
+  if (error) {
+    return { ok: false, error: `Rename failed: ${error.message}` }
+  }
+  if (!data?.length) {
+    return { ok: false, error: "Could not update this work." }
+  }
+
+  revalidatePath("/")
+  revalidatePath("/upload")
+  return { ok: true }
+}
+
 function guessExtension(mime: string, filename: string): string {
   const fromName = filename.split(".").pop()?.toLowerCase()
   if (fromName && /^[a-z0-9]{2,5}$/.test(fromName)) return fromName

--- a/apps/gallery/app/upload/page.tsx
+++ b/apps/gallery/app/upload/page.tsx
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation"
 import { PortalShell } from "@workspace/ui/components/portal-shell"
 
 import { DeleteButton } from "@/app/upload/_components/delete-button"
+import { RenameButton } from "@/app/upload/_components/rename-button"
 import { UploadForm } from "@/app/upload/_components/upload-form"
 import { createClient } from "@/lib/supabase/server"
 import type { GalleryImage } from "@/lib/gallery/types"
@@ -44,7 +45,7 @@ export default async function UploadPage() {
             Your works
           </h1>
           <p className="text-lg text-muted-foreground md:text-xl">
-            Upload your own. Delete what no longer fits.
+            Upload your own. Rename or delete what no longer fits.
           </p>
         </div>
 
@@ -80,11 +81,14 @@ export default async function UploadPage() {
                       {new Date(image.created_at).toLocaleDateString()}
                     </p>
                   </div>
-                  <DeleteButton
-                    id={image.id}
-                    imagePath={image.image_path}
-                    name={image.name}
-                  />
+                  <div className="flex shrink-0 items-center gap-1">
+                    <RenameButton id={image.id} name={image.name} />
+                    <DeleteButton
+                      id={image.id}
+                      imagePath={image.image_path}
+                      name={image.name}
+                    />
+                  </div>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Summary

讓使用者在 `/upload` 上傳作品後，仍可透過 **Rename** 修改顯示標題（`gallery_images.name`）。

## Why

原本只能刪除，無法更正取錯的標題；補上更名，避免為了小錯字或改題名而重新上傳整張圖。

## What changed

- 新增 `renameGalleryImage` server action：更新 `name`，並 `revalidatePath` `/` 與 `/upload`。
- 新增 `RenameButton`（Dialog），與 **Delete** 並列在「Uploaded by you」列表。
- 上傳頁說明文字略調（rename / delete）。
- 無 schema、env、或公開 API 變更；沿用既有 RLS `gallery_images_update`。

## Test plan

- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] Dev server：`/upload` → Rename → 確認首頁列表標題更新
- [ ] （選）附 UI 截圖

## Screenshots

<!-- 若有 Rename 按鈕或 Dialog 截圖可貼在此 -->

## Breaking changes

無。