### PR TITLE
feat(portal): row actions on /receipts — edit name and delete

### DIFF
--- a/apps/portal/app/receipts/_components/delete-receipt-dialog.tsx
+++ b/apps/portal/app/receipts/_components/delete-receipt-dialog.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import { toast } from "sonner"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@workspace/ui/components/alert-dialog"
+
+import { useDeleteReceipt } from "@/hooks/receipts/use-receipts"
+
+export function DeleteReceiptDialog({
+  id,
+  name,
+  path,
+  open,
+  onOpenChange,
+}: {
+  id: string
+  name: string
+  path: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const del = useDeleteReceipt()
+
+  const handleConfirm = () => {
+    del.mutate(
+      { id, path },
+      {
+        onSuccess: () => {
+          toast.success(`已刪除「${name}」`)
+          onOpenChange(false)
+        },
+        onError: (err) => toast.error(`刪除失敗：${err.message}`),
+      }
+    )
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>刪除「{name}」？</AlertDialogTitle>
+          <AlertDialogDescription>
+            這會把資料列跟原始檔案一起刪掉，沒辦法救回。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={del.isPending}>取消</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleConfirm}
+            disabled={del.isPending}
+            className="text-destructive-foreground bg-destructive hover:bg-destructive/90"
+          >
+            {del.isPending ? "刪除中…" : "確認刪除"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/apps/portal/app/receipts/_components/edit-receipt-dialog.tsx
+++ b/apps/portal/app/receipts/_components/edit-receipt-dialog.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { useState } from "react"
+import { toast } from "sonner"
+
+import { Button } from "@workspace/ui/components/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@workspace/ui/components/dialog"
+import { Input } from "@workspace/ui/components/input"
+import { Label } from "@workspace/ui/components/label"
+
+import { useUpdateReceiptName } from "@/hooks/receipts/use-receipts"
+
+export function EditReceiptDialog({
+  id,
+  name,
+  onClose,
+}: {
+  id: string
+  name: string
+  onClose: () => void
+}) {
+  const [draft, setDraft] = useState(name)
+  const update = useUpdateReceiptName()
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    update.mutate(
+      { id, name: draft },
+      {
+        onSuccess: () => {
+          toast.success("已更名")
+          onClose()
+        },
+        onError: (err) => toast.error(`更名失敗：${err.message}`),
+      }
+    )
+  }
+
+  return (
+    <Dialog open onOpenChange={(next) => !next && onClose()}>
+      <DialogContent>
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>編輯名稱</DialogTitle>
+            <DialogDescription>
+              改的是顯示用的名稱；檔案不會動到。
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-2 py-4">
+            <Label htmlFor="receipt-name-edit">
+              名稱 <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="receipt-name-edit"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              disabled={update.isPending}
+              required
+              autoFocus
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onClose}
+              disabled={update.isPending}
+            >
+              取消
+            </Button>
+            <Button type="submit" disabled={update.isPending}>
+              {update.isPending ? "儲存中…" : "儲存"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/portal/app/receipts/_components/receipts-view.tsx
+++ b/apps/portal/app/receipts/_components/receipts-view.tsx
@@ -13,6 +13,7 @@ import {
 import { useReceipts } from "@/hooks/receipts/use-receipts"
 
 import { ReceiptPreviewDialog } from "./receipt-preview-dialog"
+import { ReceiptRowActions } from "./row-actions"
 import { StatusSelect } from "./status-select"
 import { UploadDialog } from "./upload-dialog"
 
@@ -39,6 +40,7 @@ export function ReceiptsView() {
               <TableHead>名稱</TableHead>
               <TableHead className="w-20">檔案</TableHead>
               <TableHead className="w-40">狀態</TableHead>
+              <TableHead className="w-12 text-right">動作</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -47,7 +49,7 @@ export function ReceiptsView() {
             ) : !receipts || receipts.length === 0 ? (
               <TableRow>
                 <TableCell
-                  colSpan={3}
+                  colSpan={4}
                   className="py-10 text-center text-sm text-muted-foreground"
                 >
                   {error ? (
@@ -74,6 +76,13 @@ export function ReceiptsView() {
                   <TableCell>
                     <StatusSelect id={r.id} value={r.status} />
                   </TableCell>
+                  <TableCell className="text-right">
+                    <ReceiptRowActions
+                      id={r.id}
+                      name={r.name}
+                      path={r.imagePath}
+                    />
+                  </TableCell>
                 </TableRow>
               ))
             )}
@@ -97,6 +106,9 @@ function SkeletonRows() {
           </TableCell>
           <TableCell>
             <Skeleton className="h-9 w-32" />
+          </TableCell>
+          <TableCell className="text-right">
+            <Skeleton className="ml-auto size-9 rounded-md" />
           </TableCell>
         </TableRow>
       ))}

--- a/apps/portal/app/receipts/_components/row-actions.tsx
+++ b/apps/portal/app/receipts/_components/row-actions.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import { MoreHorizontal, Pencil, Trash2 } from "lucide-react"
+import { useState } from "react"
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@workspace/ui/components/dropdown-menu"
+
+import { DeleteReceiptDialog } from "./delete-receipt-dialog"
+import { EditReceiptDialog } from "./edit-receipt-dialog"
+
+export function ReceiptRowActions({
+  id,
+  name,
+  path,
+}: {
+  id: string
+  name: string
+  path: string
+}) {
+  const [editOpen, setEditOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="inline-flex size-9 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            aria-label={`動作 — ${name}`}
+          >
+            <MoreHorizontal className="size-4" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onSelect={() => setEditOpen(true)}>
+            <Pencil className="size-4" />
+            編輯名稱
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => setDeleteOpen(true)}
+            className="text-destructive focus:text-destructive"
+          >
+            <Trash2 className="size-4" />
+            刪除
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {editOpen && (
+        <EditReceiptDialog
+          id={id}
+          name={name}
+          onClose={() => setEditOpen(false)}
+        />
+      )}
+      <DeleteReceiptDialog
+        id={id}
+        name={name}
+        path={path}
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+      />
+    </>
+  )
+}

--- a/apps/portal/hooks/receipts/use-receipts.ts
+++ b/apps/portal/hooks/receipts/use-receipts.ts
@@ -93,6 +93,48 @@ export function useUploadReceipt() {
   })
 }
 
+export function useUpdateReceiptName() {
+  const supabase = createClient()
+  const qc = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ id, name }: { id: string; name: string }) => {
+      const trimmed = name.trim()
+      if (!trimmed) throw new Error("名稱不能空白")
+      const { data, error } = await supabase
+        .from(TABLE)
+        .update({ name: trimmed })
+        .eq("id", id)
+        .select()
+        .single()
+      if (error) throw error
+      return toReceipt(data as DatabaseReceipt)
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.receipts.all })
+    },
+  })
+}
+
+export function useDeleteReceipt() {
+  const supabase = createClient()
+  const qc = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ id, path }: { id: string; path: string }) => {
+      // Drop the row first — storage cleanup is best-effort because an orphan
+      // PDF beats a half-deleted record (RLS blocks reads anyway once the row
+      // is gone, so the orphan stays invisible to users).
+      const { error } = await supabase.from(TABLE).delete().eq("id", id)
+      if (error) throw error
+      await supabase.storage.from(RECEIPTS_BUCKET).remove([path])
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.receipts.all })
+    },
+  })
+}
+
 export function useUpdateReceiptStatus() {
   const supabase = createClient()
   const qc = useQueryClient()


### PR DESCRIPTION
## Summary
- 每列加 kebab menu（**編輯名稱** / **刪除**），對齊 bento / reimburse 的 row-action pattern
- 編輯：dialog 改 `name`（其他欄位不動），用 conditional render 避開 `useEffect` setState 警告
- 刪除：`AlertDialog` 確認後拔 row + best-effort 拔 storage object（孤兒檔案被 RLS 蓋掉，視覺上看不到）
- 新 hooks：`useUpdateReceiptName`、`useDeleteReceipt`，繼續走 TanStack Query invalidate

## Test plan
- [x] `bun run typecheck`、`bun run lint --filter=portal`（0 errors）、`bunx turbo run build --filter=portal` 全綠
- [ ] 上傳一筆 → 用 kebab 改名 → 確認列表更新
- [ ] 刪除 → 確認列表消失 + Supabase storage 該檔不見