### PR TITLE
feat(portal): show receipts link on home only to receipts admins

### DIFF
--- a/apps/portal/app/page.tsx
+++ b/apps/portal/app/page.tsx
@@ -6,9 +6,10 @@ import { PortalShell } from "@/components/portal-shell"
 import { SignOutButton } from "@/components/sign-out-button"
 import { ThemeToggle } from "@/components/theme-toggle"
 import { UserCard } from "@/components/user-card"
+import { isReceiptsAdmin } from "@/lib/receipts/admin"
 import { getCurrentUser } from "@/lib/user"
 
-const apps = [
+const baseApps = [
   { href: "/bento", label: "Bento", note: "便當訂購" },
   { href: "/leave", label: "Leave", note: "請假登記" },
   { href: "/meetings", label: "Meetings", note: "組會排班" },
@@ -21,7 +22,19 @@ const apps = [
 ]
 
 export default async function Page() {
-  const user = (await getCurrentUser())!
+  const [user, showReceipts] = await Promise.all([
+    getCurrentUser(),
+    isReceiptsAdmin(),
+  ])
+  const currentUser = user!
+
+  const apps = showReceipts
+    ? [
+        ...baseApps.slice(0, 7),
+        { href: "/receipts", label: "Receipts", note: "收據審核" },
+        ...baseApps.slice(7),
+      ]
+    : baseApps
 
   return (
     <PortalShell appName="Portal" bottomLeft={<ThemeToggle />}>
@@ -33,9 +46,9 @@ export default async function Page() {
           </p>
         </div>
         <UserCard
-          name={user.name}
-          email={user.email}
-          avatarUrl={user.avatarUrl}
+          name={currentUser.name}
+          email={currentUser.email}
+          avatarUrl={currentUser.avatarUrl}
         />
         <nav className="flex flex-col gap-3">
           {apps.map((app) => (


### PR DESCRIPTION
## Summary
- Portal 首頁 nav 加 **Receipts** 入口，只給 `roles.receipts` 含 `admin`（或 super admin）的人看到
- Server-side 用 `isReceiptsAdmin()` RPC 判斷，未通過直接從 apps array 拿掉，HTML 不會帶到 client
- 排在 Reimburse 後面 — receipts 是 reimburse 上游 review，順序對齊上下游 mental model

## Test plan
- [x] `bun run typecheck`、`bunx turbo run build --filter=portal` 全綠
- [ ] 用 admin 帳號看首頁 → Receipts 出現在 Reimburse 跟 Profile 中間
- [ ] 用非 admin 帳號 → 看不到 Receipts