### PR TITLE
docs: translate to english and sync with current apps and conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,51 @@
 # Changelog
 
-All notable changes to this project will be documented here.
-
-Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/).
+All notable changes are recorded here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
 ### Added
 
-- Initial Turborepo monorepo（Bun + Next.js 16 + React 19 + Tailwind v4 + shadcn/ui）
-- Supabase Auth 走 Keycloak OIDC provider
-- Root-level `AuthProvider`，跨 app 共用 user state
-- Middleware 路由級 auth gating — 未登入自動導回 `/auth/login`
-- `/bento` 訂餐系統 — orders、menus、ratings（後移除）、realtime、admin 權限
-- `/profile` — Supabase user 全資料顯示
-- `PortalShell` chrome — TL/TR/BL/BR 四角 slot 架構
-- Design system baseline — `rounded-xl`、`gap-10/4/3`、`border + bg-card` 無 shadow
-- Dev system — CI、PR / Issue template、CODEOWNERS、Dependabot、commitlint、husky
+- `/admin` super-admin panel for managing user roles, gated by `user_profiles.is_admin`
+- `/receipts` admin-only receipt review wall — uploads any image or PDF, archives it as a single PDF per row, status workflow (pending / approved / rejected), preview dialog, row actions for renaming and deleting
+- `/meetings` lab-meeting scheduler — weekly schedule, presenter sign-up, teacher-paper sharing
+- `/trip` travel-document app — file uploads, admin folder export, dynamic signature stamping at view time
+- `/debt` bill-splitting app with monthly-settlement Vercel Cron
+- `/reimburse` lab cash-flow bookkeeping (egress + ingress, schema migrated from the legacy `egress` / `ingress` tables)
+- `/approve` document signing with PDF field placement and Resend email outbox via Vercel Cron
+- `/leave` Monday-meeting attendance sign-ups
+- `/profile` lab stats card aggregating bento / leave / approve / trip activity (replaced the old auth dump)
+- `apps/gallery` — the lab's art wall on `gallery.winlab.tw`, with renamable works and MIME-resilient uploads
+- `apps/mcp` — MCP server with OAuth 2.1, exposing bento and leave tools over `mcp.winlab.tw`
+- Theme toggle on portal home, defaulting to dark
+- Portal home receipts link, only visible to receipts admins
+
+### Changed
+
+- Renamed `middleware.ts` → `proxy.ts` to follow the Next.js 16 file-convention rename, with the function exported as `proxy()` instead of `middleware()`
+- Widened `<PortalShell>` content container from `max-w-2xl` (672px) to `max-w-4xl` (896px) so forms and lists breathe
+- Bumped Next.js to 16.2.4, react-pdf to 10.4.1, @eslint/js to 10.x, actions/checkout to v6
+- Receipts archive everything as PDF — phone photos get wrapped into a single-page PDF, real PDFs pass through untouched, downloads name the file by the row's title
+
+### Fixed
+
+- Self-healing in `AuthProvider` when the local Supabase state goes stale
+- Cross-subdomain cookie cleanup on auth callback failure (keeps stale `sb-*` cookies and PKCE code-verifier from sticking)
+- Dialog scroll behaviour when the content overflows the viewport
+- Mobile uploads for gallery — raised the 1 MB cap and accepted HEIC / HEIF
+- Reimburse PDF auto-generation removed; the app is bookkeeping-only now
+- `next-env.d.ts` no longer fights prettier — added to `.prettierignore` so dev mode and build mode can disagree about the types path without making the working tree dirty
+
+## [0.1.0] — Initial cut
+
+### Added
+
+- Initial Turborepo monorepo (Bun + Next.js 16 + React 19 + Tailwind v4 + shadcn/ui)
+- Supabase Auth via Keycloak OIDC provider
+- Root-level `AuthProvider` sharing user state across apps
+- Middleware-driven auth gating — unauthenticated requests redirect to `/auth/login`
+- `/bento` lunch-ordering system — orders, menus, realtime, admin scope
+- `/profile` initial Supabase user dump
+- `<PortalShell>` chrome — TL/TR/BL/BR slot architecture
+- Design system baseline — `rounded-xl`, `gap-10/4/3` rhythm, `border + bg-card` with no shadows
+- Dev system — CI workflow, PR / Issue templates, CODEOWNERS, Dependabot, commitlint, husky

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,80 +1,82 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file briefs Claude Code (claude.ai/code) when working in this repository.
 
 ## Product
 
-**portal.winlab.tw** — WinLab 的內部 Portal。根域名 `portal.winlab.tw` 下掛多個業務 app（`/bento`、`/invoice`、`/approval`…），每個 app 由不同人維護、業務邏輯獨立，但共用：
+**portal.winlab.tw** — WinLab's internal portal. The root domain hosts business apps (`/bento`, `/leave`, `/meetings`, `/approve`, `/trip`, `/debt`, `/reimburse`, `/receipts`, `/profile`, `/admin`), each owned by different people but sharing:
 
-- **Auth**：Supabase Auth，OIDC provider 為 Keycloak
-- **Profile / session**：跨所有 app 一份
-- **Coding style、元件庫、架構骨架**
+- **Auth** — Supabase Auth, Keycloak as the OIDC provider
+- **Profile / session** — one user state across the portal
+- **Coding style, component library, layout chrome**
 
-業務 app = `apps/portal/app/<name>/` 底下的 route segment，**不是** 獨立的 Turborepo workspace。要新增 app 就在 `apps/portal/app/` 下開資料夾，別去 `apps/*` 開新 Next.js。
+A business app is `apps/portal/app/<name>/` — a route segment, **not** a separate Turborepo workspace. To add one, drop a folder under `apps/portal/app/`. Don't open a new `apps/*` Next.js project.
 
-**例外**：若該 app 的 design system 跟 portal **明顯不同**（不同字體、不同版面 metaphor），才允許獨立 subdomain workspace。目前唯一一個是 `apps/gallery`（`gallery.winlab.tw`，Instrument Serif、拍立得錯落 layout）。新建獨立 workspace 前先問 maintainer，不要因為怕碰共用骨架就直接開新 workspace 偷懶 —— 這是 owner 意識問題。
+**Exception**: when an app's design system genuinely diverges from portal (different fonts, different layout metaphor), break it out into a subdomain workspace. Today that's `apps/gallery` (`gallery.winlab.tw`, Instrument Serif, polaroid scatter) and `apps/mcp` (`mcp.winlab.tw`, MCP server). Ask the maintainer before opening a new workspace — don't open one just to dodge the shared shell. That's an owner-mindset issue.
 
-## 技術棧
+## Stack
 
-- **Bun** 1.3+（`packageManager` 鎖定）— 一律 `bun` / `bunx`，不要 `npm` / `pnpm`
-- **Turborepo** 2.x — 所有指令從 root 跑
+- **Bun** 1.3+ (`packageManager` is pinned) — always `bun` / `bunx`, never `npm` / `pnpm`
+- **Turborepo** 2.x — run commands from the repo root
 - **Next.js 16** App Router + React 19 + Turbopack dev
-- **Tailwind v4** + **shadcn/ui**（radix-luma style、neutral base、tabler icons）
-- **Supabase** JS SDK + `@supabase/ssr`（browser / server / middleware 三分）
-- **Keycloak** 作為 Supabase 的 OIDC provider（在 Supabase Dashboard 配置，不在 code）
+- **Tailwind v4** + **shadcn/ui** (radix-luma style, neutral base, tabler icons)
+- **Supabase** JS SDK + `@supabase/ssr` (browser / server / proxy split)
+- **Keycloak** as Supabase's OIDC provider (configured in dashboards, never in code)
+- **TanStack Query** v5 for client-side data fetching where it's needed
+- **pdf-lib** for receipt-archive PDF generation in the browser
 
 ## Commands
 
 ```bash
-bun install                      # 會跑 `prepare` 自動裝 husky hooks
-bun run dev                      # 所有 dev（web 跑 next dev --turbopack on :3000）
-bun run build                    # turbo build（尊重 ^build 相依）
+bun install                      # `prepare` script installs husky hooks
+bun run dev                      # all dev servers (portal on :3000)
+bun run build                    # turbo build (respects ^build deps)
 bun run lint                     # eslint
 bun run typecheck                # tsc --noEmit
 bun run format                   # prettier --write
 
-bun run dev --filter=portal         # 只跑 portal
-turbo run typecheck --filter=portal # 繞過 bun wrapper 直接下 turbo
+bun run dev --filter=portal         # portal only
+turbo run typecheck --filter=portal # bypass the bun wrapper, call turbo directly
 ```
 
-無 test runner，別亂裝，要加先問。
+No test runner. Don't add one without asking.
 
-### Git hooks（husky）
+### Git hooks (husky)
 
-`bun install` 後 hooks 自動 active：
+`bun install` activates the hooks:
 
-- **pre-commit** → `lint-staged`：對 staged 檔跑 `prettier --write` + `eslint --fix --max-warnings=0`。`.ts/.tsx/.js/.mjs/.cjs` 會跑全套，`.json/.md/.yml/.yaml/.css` 只跑 prettier
-- **commit-msg** → `commitlint`：擋下不符 Conventional Commits 的 message（`feat:` / `fix:` / `chore:` / `docs:` / `refactor:` / `test:` / `perf:` / `style:`），上限 100 字
+- **pre-commit** → `lint-staged`: runs `prettier --write` and `eslint --fix --max-warnings=0` on staged files. `.ts/.tsx/.js/.mjs/.cjs` get the full pipeline; `.json/.md/.yml/.yaml/.css` only get prettier.
+- **commit-msg** → `commitlint`: rejects messages that don't match Conventional Commits (`feat:` / `fix:` / `chore:` / `docs:` / `refactor:` / `test:` / `perf:` / `style:`), 100-character header limit.
 
-寫 commit message 時照 `<type>: description` 就好，`description` 用英文、有人味。完整 branch / PR / review 規範在 `CONTRIBUTING.md`。
+Write commits as `<type>: description`, English, written like a person. Full branch / PR / review rules live in `CONTRIBUTING.md`.
 
-## 架構
+## Architecture
 
-### Monorepo 拓撲
+### Monorepo topology
 
-- `apps/portal` — 主消費端 Next.js app（workspace 名稱就叫 `portal`，跑 :3000）。多數業務 route（`/bento`、`/approve`、`/leave`、`/profile`…）都進這裡。
-- `apps/gallery` — `gallery.winlab.tw`，獨立 subdomain workspace（跑 :3001）。Design system 跟 portal 不同（Instrument Serif、拍立得錯落 layout），但共用 `@workspace/ui` 的 `<PortalShell>` 四角骨架。
-- `apps/mcp` — MCP server，對外暴露 portal 資料的 MCP 介面。
-- `packages/ui` — 設計系統 + shadcn 元件的**唯一真實源**，所有 app 共用。`<PortalShell containerClassName=...>` 在這裡，gallery 與 portal 都從這裡 import。
-- `packages/eslint-config` — flat config 三個 preset：`base` / `next-js` / `react-internal`
-- `packages/typescript-config` — `base.json` / `nextjs.json` / `react-library.json`
+- `apps/portal` — the main Next.js app on `portal.winlab.tw` (workspace name `portal`, runs on :3000). Most business routes (`/bento`, `/approve`, `/leave`, `/meetings`, `/trip`, `/debt`, `/reimburse`, `/receipts`, `/profile`, `/admin`) live here.
+- `apps/gallery` — `gallery.winlab.tw`, an independent subdomain workspace (runs on :3001). Different design system (Instrument Serif, polaroid layout) but still uses `<PortalShell>` from `@workspace/ui`.
+- `apps/mcp` — `mcp.winlab.tw`, an MCP server exposing portal data over OAuth 2.1.
+- `packages/ui` — the single source of truth for the design system and shadcn primitives. `<PortalShell>` lives here; both portal and gallery import it.
+- `packages/eslint-config` — flat-config presets: `base` / `next-js` / `react-internal`.
+- `packages/typescript-config` — `base.json` / `nextjs.json` / `react-library.json`.
 
 ### Path aliases
 
-- `@/*` → 各 app 自己的 root（在 `apps/portal/tsconfig.json` 與 `apps/gallery/tsconfig.json` 各自指）
-- `@workspace/ui/*` → `packages/ui/src/*`（跨 workspace）
+- `@/*` → each app's own root (configured in `apps/portal/tsconfig.json` and `apps/gallery/tsconfig.json` separately)
+- `@workspace/ui/*` → `packages/ui/src/*` (cross-workspace)
 
-### Supabase 分層（住在 `apps/portal/lib/supabase/`）
+### Supabase layering (lives in `apps/portal/lib/supabase/`)
 
-| File                                | 用途                                                       | 可以 import 的地方                                |
+| File                                | Purpose                                                    | Where to import it                                |
 | ----------------------------------- | ---------------------------------------------------------- | ------------------------------------------------- |
-| `client.ts` → `createClient()`      | browser client                                             | Client Components（`"use client"`）、hooks        |
-| `server.ts` → `createClient()`      | server client，讀 `next/headers` cookies                   | Server Components、Route Handlers、Server Actions |
-| `middleware.ts` → `updateSession()` | request-level session refresh + 未登入時導向 `/auth/login` | 只給 root `proxy.ts` 使用                         |
+| `client.ts` → `createClient()`      | browser client                                             | Client Components (`"use client"`), hooks         |
+| `server.ts` → `createClient()`      | server client, reads `next/headers` cookies                | Server Components, Route Handlers, Server Actions |
+| `middleware.ts` → `updateSession()` | request-level session refresh + redirects to `/auth/login` | only the root `proxy.ts` should use this          |
 
-> Fluid compute 警告（寫在 `server.ts` / `middleware.ts` 的註解）：**不要** 把 Supabase client 放全域變數，每次請求要新建一個。
+> Fluid-compute caveat (also commented in `server.ts` / `middleware.ts`): never store the Supabase client in a global variable. Build a fresh one per request.
 
-**路由級 auth gating 已啟用** — `apps/portal/proxy.ts`（Next.js 16 把 `middleware.ts` convention 改名為 `proxy.ts`）呼叫 `updateSession()`，未登入自動導向 `/auth/login`。白名單走 pathname 前綴：`/login` 與 `/auth/*`（login、callback、auth-code-error）不擋。
+**Route-level auth gating is on** — `apps/portal/proxy.ts` (Next.js 16 renamed the `middleware.ts` convention to `proxy.ts`) calls `updateSession()` and redirects unauthenticated requests to `/auth/login`. The allow-list is pathname-prefix based: `/login` and `/auth/*` (login, callback, auth-code-error) skip the gate.
 
 ```ts
 // apps/portal/proxy.ts
@@ -92,20 +94,20 @@ export const config = {
 }
 ```
 
-因此 protected page 不用再自己 `redirect("/auth/login")` — proxy 擋下。Server Component 可以直接 `const user = (await getCurrentUser())!` 信任 non-null。例外：`/auth/login` 自己需要 `if (user) redirect("/")` 當「已登入就離開 login 頁」的 UX，這是業務邏輯不是 protection。
+Because the proxy already gates protected pages, individual pages don't need their own `redirect("/auth/login")`. Server Components can do `const user = (await getCurrentUser())!` and trust the non-null. The exception is `/auth/login` itself, which uses `if (user) redirect("/")` to bounce already-authenticated users away — that's UX, not protection.
 
-### Auth（Keycloak via Supabase OIDC）
+### Auth (Keycloak via Supabase OIDC)
 
-**Dashboard 配置清單**（全在 Supabase + Keycloak 控制台做，不進 repo）：
+Dashboard checklist (lives entirely in Supabase + Keycloak consoles, never in code):
 
-1. Keycloak realm → 建一個 client，"Client Protocol" = `openid-connect`，"Access Type" = `confidential`
-2. Keycloak client → "Valid Redirect URIs" 加 `https://yissfqcdmzsxwfnzrflz.supabase.co/auth/v1/callback`
-3. Keycloak client → 抄下 `Client ID`（Settings 分頁）與 `Client Secret`（Credentials 分頁）
-4. Keycloak realm settings → OpenID Endpoint Configuration → 抄下 `issuer`（這個是 `Keycloak URL`）
-5. Supabase Dashboard → Authentication → Providers → Keycloak → 填 Client ID / Secret / Keycloak URL
-6. Supabase Dashboard → Authentication → URL Configuration → Redirect URLs 加本地 `http://localhost:3000/auth/callback` 與 production `https://portal.winlab.tw/auth/callback`
+1. Keycloak realm → create a client, "Client Protocol" = `openid-connect`, "Access Type" = `confidential`.
+2. Keycloak client → "Valid Redirect URIs" = `https://yissfqcdmzsxwfnzrflz.supabase.co/auth/v1/callback`.
+3. Keycloak client → copy `Client ID` (Settings tab) and `Client Secret` (Credentials tab).
+4. Keycloak realm settings → OpenID Endpoint Configuration → copy the `issuer` value (this is the Keycloak URL).
+5. Supabase Dashboard → Authentication → Providers → Keycloak → fill in Client ID / Secret / Keycloak URL.
+6. Supabase Dashboard → Authentication → URL Configuration → add `http://localhost:3000/auth/callback` and `https://portal.winlab.tw/auth/callback` to the Redirect URLs.
 
-**Sign in**：
+**Sign in**:
 
 ```ts
 // client component
@@ -113,64 +115,73 @@ const supabase = createClient()
 await supabase.auth.signInWithOAuth({
   provider: "keycloak",
   options: {
-    scopes: "openid", // Keycloak 22+ 硬性要求，只給 openid
-    redirectTo: `${location.origin}/auth/callback`, // PKCE flow 的回跳點
+    scopes: "openid", // Keycloak 22+ rejects more
+    redirectTo: `${location.origin}/auth/callback`, // PKCE flow callback
   },
 })
 ```
 
-> ⚠️ scope 只給 `"openid"`，不要加 `profile email`。Keycloak 22+ 對 scope 很嚴，多塞會拒絕。profile / email claims 在 `openid` scope 下就會帶回來。
+> Scope is `"openid"` only. Don't add `profile email`. Keycloak 22+ is strict about scopes; profile and email claims come back inside `openid` anyway.
 
-**Callback（PKCE code → session exchange）**：已實作於 `apps/portal/app/auth/callback/route.ts`，負責 `exchangeCodeForSession` 並處理 `x-forwarded-host`（reverse proxy 後方也能跑）。錯誤時導到 `/auth/auth-code-error`，那頁需要你自己做。
+**Callback (PKCE code → session exchange)**: implemented in `apps/portal/app/auth/callback/route.ts`, which calls `exchangeCodeForSession` and handles `x-forwarded-host` so it works behind reverse proxies. On error it redirects to `/auth/auth-code-error`.
 
-**Sign out**：
+**Sign out**:
 
 ```ts
 await supabase.auth.signOut()
 ```
 
-**讀當前使用者**：middleware 與 server 端優先用 `supabase.auth.getClaims()`（claims 在 JWT 裡，免打 Auth API）；只有要同步新鮮 profile 時才用 `getUser()`。
+**Reading the current user**: prefer `supabase.auth.getClaims()` in middleware and on the server (claims live in the JWT, no Auth API call needed). Use `getUser()` only when you need the freshest profile.
 
-### SDK-first 原則（重要）
+### Permission model
 
-**非必要不寫 Next.js API route / Route Handler。** 優先順序：
+Two layers:
 
-1. **Server Component + `server.ts` 的 `createClient()`** — 讀資料的主場
-2. **Server Action** — 寫入 / mutation
-3. **Client Component + `client.ts`** — 需要即時互動（realtime subscribe、optimistic UI）
-4. **Route Handler** — 只有在下列情境才開：Webhook 接收、第三方 OAuth callback、需要非 Supabase cookie/header 操作、檔案 streaming
+- **Super admin** — `user_profiles.is_admin = true`. Only super admins can manage roles via the `/admin` panel. The `prevent_role_escalation` BEFORE UPDATE trigger blocks direct writes to `roles` / `is_admin` from anyone but `service_role`, which is why the admin RPCs elevate role inside `SECURITY DEFINER` functions before mutating.
+- **App-scoped roles** — `user_profiles.roles` is `jsonb` shaped like `{ "<app>": ["admin", ...] }`. Each app has a SQL helper such as `is_bento_admin()` / `is_meetings_admin()` / `is_receipts_admin()` returning `true` if the caller has the relevant role. Apps RLS-gate themselves with these helpers; `useAdmin()` hooks read the same data on the client.
 
-RLS 是資料層防線，不要為了安全在 API route 包一層。RLS policy 寫清楚比 API route 可靠。
+When adding a new admin-controlled action, write the SECURITY DEFINER RPC + helper first, then the hook. Don't gate writes purely on the client.
 
-## Coding Style（跟 https://supabase.com/ui 對齊）
+### SDK-first principle (important)
 
-把一個 feature 的東西**分開放**，不要全部塞一個檔案：
+**Don't write a Next.js API route or Route Handler unless you have to.** Order of preference:
+
+1. **Server Component + `server.ts`'s `createClient()`** — reads
+2. **Server Action** — writes / mutations
+3. **Client Component + `client.ts`** — when interactivity is needed (realtime subscribe, optimistic UI)
+4. **Route Handler** — only for: webhook receivers, third-party OAuth callbacks, non-Supabase cookie/header work, file streaming
+
+RLS is the data-layer line of defense. Don't wrap a Supabase call in an API route to "make it secure" — write the RLS policy correctly instead.
+
+## Coding style (aligned with https://supabase.com/ui)
+
+Split a feature across files, don't dump everything into one:
 
 ```
 apps/portal/
 ├─ app/<feature>/
-│  ├─ page.tsx              # 純頁面組裝
-│  └─ _components/          # 只在這個 feature 用的 UI 片段
-├─ components/<feature>-*.tsx   # 跨 feature 共用的組合元件
-├─ hooks/use-<feature>.ts       # stateful 行為 / side effect
-└─ lib/<feature>/              # 純邏輯、data access、schema
+│  ├─ page.tsx              # composition only
+│  └─ _components/          # UI fragments scoped to this feature
+├─ components/<feature>-*.tsx   # shared composite components across features
+├─ hooks/<feature>/use-<thing>.ts # stateful behaviour / side effects
+└─ lib/<feature>/                # pure logic, data access, schema
 
 packages/ui/src/
-├─ components/*.tsx         # shadcn primitives（Button、Input…）
-├─ lib/*.ts                 # cn、utils
-└─ hooks/*.ts               # 純 UI 狀態 hook
+├─ components/*.tsx         # shadcn primitives (Button, Input, …)
+├─ lib/*.ts                 # cn, utils
+└─ hooks/*.ts               # pure UI state hooks
 ```
 
-規則：
+Rules:
 
-- **components** 吃 props 渲染 UI；不直接呼 Supabase
-- **hooks** 管 state 與 side effect；Supabase client 在這層被呼叫
-- **lib** 放 pure function、schema、query builder；不依賴 React
-- **Server Component** 直接 call `createClient()` 取資料，把結果 prop 傳給 Client Component
+- **components** take props, render UI. They don't call Supabase directly.
+- **hooks** own state and side effects. The Supabase client is called here.
+- **lib** holds pure functions, schemas, query builders. No React.
+- **Server Components** call `createClient()` directly to fetch and pass props down to client components.
 
-### Reference: `bento` app（多層業務 app 範本）
+### Reference: the `bento` app (multi-route business app template)
 
-`apps/portal/app/bento/` 是目前最完整的業務 app，新 app 照這個版型做即可：
+`apps/portal/app/bento/` is the most complete business app today. New apps should follow this layout:
 
 ```
 apps/portal/
@@ -179,77 +190,77 @@ apps/portal/
 │  ├─ page.tsx                            # /bento — orders list
 │  ├─ menus/page.tsx                      # /bento/menus — restaurant CRUD
 │  ├─ orders/[id]/page.tsx                # /bento/orders/[id] — order detail
-│  └─ _components/                        # 只有 bento 用的 UI（order-card、restaurant-card、…）
-├─ hooks/bento/                           # bento-only data hooks（use-orders、use-menus、…）
-│  └─ query-keys.ts                       # TanStack Query keys，全以 ["bento", …] 開頭 namespace 隔離
-└─ lib/bento/                             # bento 型別與純工具（types.ts、date.ts、menu.ts）
+│  └─ _components/                        # bento-only UI (order-card, restaurant-card, …)
+├─ hooks/bento/                           # bento-only data hooks (use-orders, use-menus, …)
+│  └─ query-keys.ts                       # TanStack Query keys, all namespaced under ["bento", …]
+└─ lib/bento/                             # bento types and pure helpers (types.ts, date.ts, menu.ts)
 ```
 
-- **TanStack Query 只在 bento 用**：所以 `QueryProvider` 留在 `bento/layout.tsx`，不上提到 root
-- **Toaster 也在 bento layout**：其他 app 要用 toast 時再提到 root layout（目前 YAGNI 不上提）
-- **AuthProvider 在 root layout**（跨 app 共用 user state），bento hooks 用 `@/hooks/use-auth`
-- **Admin 是 app-scoped**：`useAdmin()` 讀 `user_profiles.roles.bento = ["admin"]`，權限範圍不跨 app
+- **TanStack Query is bento-only** today — `QueryProvider` lives in `bento/layout.tsx`, not in root layout.
+- **`<Toaster />` lives in bento's layout** too. Other apps that need toasts hoist it into their own layouts when needed (YAGNI for now).
+- **`AuthProvider` lives in root layout** because user state is shared. Bento hooks consume `@/hooks/use-auth`.
+- **Admin is app-scoped** — `useAdmin()` reads `user_profiles.roles.bento = ["admin"]`. The receipts and meetings apps follow the same pattern with their own `useReceiptsAdmin()` / `useMeetingsAdmin()`.
 
-### Feedback UX 規範
+### Feedback UX
 
-- **Notification**（成功/失敗訊息）一律用 `sonner` 的 `toast.success()` / `toast.error()`，不要用 `alert()`
-- **Destructive 確認**（刪除、不可逆操作）用 `_components/confirm-dialog.tsx`（shadcn `AlertDialog`），不要用 `confirm()`
-- `<Toaster />` 放在需要的 app layout 內（例：`bento/layout.tsx`），不重複掛
+- **Notifications** — always `toast.success()` / `toast.error()` from sonner. Never `alert()`.
+- **Destructive confirmations** — use the shadcn `AlertDialog` (or each app's local `ConfirmDialog` if it has one). Never `confirm()`.
+- `<Toaster />` is mounted per-app in the layout that needs it. Don't double-mount.
 
-### 加 shadcn 元件
+### Adding shadcn components
 
-**root 目錄**下：
+From the **repo root**:
 
 ```bash
 bunx shadcn@latest add <component> -c apps/portal
 ```
 
-儘管帶 `-c apps/portal`，檔案會因 `apps/portal/components.json` alias 寫入 `packages/ui/src/components/`。別手動往 `apps/portal/components/` 丟原始 shadcn primitive。
+Even with `-c apps/portal`, the file is written to `packages/ui/src/components/` because of `apps/portal/components.json`'s alias config. Don't drop raw shadcn primitives into `apps/portal/components/` by hand.
 
-### 加 Supabase UI（註冊過 `@supabase` namespace）
+### Adding Supabase UI (registered under `@supabase` namespace)
 
 ```bash
 bunx shadcn@latest add @supabase/<item>
-# 例：@supabase/password-based-auth-nextjs、@supabase/realtime-cursor…
+# e.g. @supabase/password-based-auth-nextjs, @supabase/realtime-cursor…
 ```
 
-registry 定義在 `apps/portal/components.json` 的 `registries."@supabase"` 欄位。
+The registry is configured under `apps/portal/components.json`'s `registries."@supabase"` field.
 
-## Design System
+## Design system
 
-Layout 統一由 `apps/portal/components/portal-shell.tsx` 的 `<PortalShell>` 負責。骨架是**中央內容 + 四角 fixed** —— 靈感對齊 [www.winlab.tw](https://github.com/NYCU-WinLab/www.winlab.tw)。
+Layout is owned by `apps/portal/components/portal-shell.tsx`'s `<PortalShell>`. The chrome is **central content + four fixed corners** — inspired by [www.winlab.tw](https://github.com/NYCU-WinLab/www.winlab.tw).
 
 ```tsx
 <PortalShell appName="Profile">{children}</PortalShell>
 ```
 
-| 角落 | 內容                                                         | 狀態 |
-| ---- | ------------------------------------------------------------ | ---- |
-| 左上 | appName，連結 `appHref`（預設 `/`），通常指向該 app 自己首頁 | 實作 |
-| 右下 | `© {new Date().getFullYear()}`                               | 實作 |
-| 右上 | `topRight?: ReactNode` slot — app 內 nav                     | slot |
-| 左下 | `bottomLeft?: ReactNode` slot — 返回 portal 首頁入口         | slot |
+| Corner | Content                                                           | Status |
+| ------ | ----------------------------------------------------------------- | ------ |
+| TL     | `appName`, links to `appHref` (defaults to `/`), usually app home | filled |
+| BR     | `© {new Date().getFullYear()}`                                    | filled |
+| TR     | `topRight?: ReactNode` slot — in-app nav                          | slot   |
+| BL     | `bottomLeft?: ReactNode` slot — back to portal home               | slot   |
 
-Corner 容器樣式鎖死：`fixed z-50 p-6 text-muted-foreground text-xs`。TR/BL 為 **optional slot props**（`topRight?` / `bottomLeft?`），app 只傳內容不傳樣式，一致性由 shell 保障。TL 的 `appHref` 預設 `/`（給 portal / 單層 app 如 profile 用）；多層 app（如 bento）應傳 `appHref="/bento"` 讓 TL 作為 app home，並用 BL 放 `<Link href="/">Portal</Link>` 當回主頁入口。
+Corner styling is locked: `fixed z-50 p-6 text-muted-foreground text-xs`. TR / BL are **optional slot props** (`topRight?` / `bottomLeft?`) — apps pass content, not classes; consistency stays in the shell. TL's `appHref` defaults to `/` (good for portal home and single-route apps like `/profile`); multi-route apps (e.g. bento) should pass `appHref="/bento"` so TL becomes the app's home, and use BL for `<Link href="/">Portal</Link>`.
 
-中央內容容器：`mx-auto w-full max-w-4xl px-6 py-20`。寬度 4xl（56rem / 896px）、上下各 5rem 確保 corner 不覆蓋內容。短頁要視覺置中在自己內容上加 `min-h-[60vh] flex-col justify-center`。
+Central content container: `mx-auto w-full max-w-4xl px-6 py-20`. Width is 4xl (56rem / 896px), 5rem of vertical padding so corners never overlap content. For short pages that should feel centred, add `min-h-[60vh] flex-col justify-center` to the content.
 
-**每個 route 自己決定 `appName`**（Portal、Profile、Bento…）。不在 root `layout.tsx` 統一設，避免全 app 綁死同一名字；多層 sub-route 的 app 則在該 app 的 `layout.tsx` 包一次 shell。
+**Each route picks its own `appName`** (Portal, Profile, Bento, …). Don't set it once in the root `layout.tsx` — that would freeze every app to the same name. Multi-route apps wrap `<PortalShell>` in their own `layout.tsx`.
 
-## 風格約定
+## Style conventions
 
-- **Prettier**：無分號、雙引號、2-space、`printWidth: 80`、`trailingComma: "es5"`。`prettier-plugin-tailwindcss` 自動排 class；`cn` / `cva` 已註冊為 Tailwind function。
-- **ESLint**：root `.eslintrc.js` 只設 `ignorePatterns`，真規則在各 workspace 透過 `@workspace/eslint-config` 載入。
-- **Theme**：`apps/portal/components/theme-provider.tsx` 包 `next-themes`，註冊了全域 `d` 鍵切 dark mode（輸入框時停用）。不要重複這段邏輯。
-- **Commit**：Conventional Commits，description 用英文、有人味；不加 Co-Authored-By。
+- **Prettier** — no semicolons, double quotes, 2-space indent, `printWidth: 80`, `trailingComma: "es5"`. `prettier-plugin-tailwindcss` sorts classes; `cn` and `cva` are registered as Tailwind functions.
+- **ESLint** — root `.eslintrc.js` only sets `ignorePatterns`; the real rules come from `@workspace/eslint-config`, loaded per workspace.
+- **Theme** — `apps/portal/components/theme-provider.tsx` wraps `next-themes` and registers a global `d` key for toggling dark mode (disabled inside inputs). Don't duplicate that logic.
+- **Commits** — Conventional Commits, English description, with personality. No `Co-Authored-By` lines.
 
 ## Env
 
-`apps/portal/.env.local`（已 gitignore）：
+`apps/portal/.env.local` (gitignored):
 
 ```
 NEXT_PUBLIC_SUPABASE_URL=...
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=...
 ```
 
-範本 `apps/portal/.env.example` 會進 repo。新 env key 一律兩邊同步加。
+`apps/portal/.env.example` is the template and is checked in. Whenever a new env key gets added, update both at once.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,18 @@
 # Contributing
 
-歡迎來改 portal.winlab.tw。這份文件只講 how。設計規範與架構看 [`CLAUDE.md`](./CLAUDE.md)，環境變數與上手看 [`README.md`](./README.md)。
+Welcome — this file is the _how_. Architecture and design rules live in [`CLAUDE.md`](./CLAUDE.md); environment setup lives in [`README.md`](./README.md).
 
-## 工作流程
+## Workflow
 
-1. **從 `main` 開 branch** — `main` 被鎖，不能直推
-2. **寫 code + 自己跑過** — `bun run typecheck`、`bun run lint`、`bun run build`，dev server 實際點一遍
-3. **開 PR** — 走 PR template，填 why / what / test plan / screenshot
-4. **等 CI 綠 + reviewer pass** — 不綠不能 merge，CODEOWNERS 會自動指派
-5. **Squash merge** — 保持 main 線性、一個 PR 一個 commit
+1. **Branch off `main`** — `main` is locked, direct pushes are rejected.
+2. **Write code and run it locally** — `bun run typecheck`, `bun run lint`, `bun run build`, plus a real click-through in dev. CI does not check what your eyes catch.
+3. **Open a pull request** — fill in the template (why / what / test plan / screenshots).
+4. **Wait for CI green and a code-owner review** — CODEOWNERS auto-assigns the right reviewer.
+5. **Squash merge** — keep `main` linear, one commit per PR.
 
-### Branch 命名
+### Branch naming
 
-`<type>/<short-description>` — type 跟 Conventional Commits 對齊：
+`<type>/<short-description>`, where `<type>` follows Conventional Commits:
 
 ```
 feat/profile-avatar-upload
@@ -22,9 +22,9 @@ docs/clarify-portal-shell-slots
 refactor/extract-menu-items-editor
 ```
 
-### Commit message
+### Commit messages
 
-Conventional Commits + 英文 description，有人味，不要機器人風格：
+Conventional Commits, English description, written like a person not a robot:
 
 ```
 feat: add bento order auto-close timer
@@ -33,54 +33,57 @@ chore: feed dependencies their latest treats
 refactor: untangle the spaghetti in auth middleware
 ```
 
-commitlint hook 會擋掉不對格式的 message，放心寫不用怕手滑。
+A commitlint hook (`commit-msg`) blocks anything else, so a malformed header cannot land. Header limit is 100 characters.
 
-### PR 標題
+### Pull-request title and body
 
-跟 commit 格式一樣。Squash merge 時這個會變成最終 commit message。
+- Title follows the same Conventional Commits format. With squash-merge, this becomes the final commit on `main`.
+- Body explains **why** and **what changed**. Reviewers send back PRs that just paste commit messages.
 
-### PR body
+### About CI and Vercel preview deploys
 
-走 template — 沒填 **why** 跟 **what changed** 的會被 reviewer 退。
+- The required check is `typecheck · lint · build`. Anything else is informational.
+- Vercel preview deploys require owner authorization when the commit author is outside the Vercel team — fork PRs and contributions from non-members will show "Authorization required to deploy". This is expected and does not block merges; the maintainer can either click the per-commit authorize link to see a preview, or merge directly and let the production deploy run on `main`.
+- First-time contributors will see GitHub Actions stuck on "action required" until a maintainer clicks **Approve and run workflows**. After that, the contributor's later PRs run automatically.
 
 ## Code conventions
 
-- **TS**：別 `any`、別 `@ts-ignore`。真的要 escape hatch 用 `as unknown as X` + 註解
-- **React**：Server Component 優先，Client 只在需要互動時用；Supabase call 只在 `hooks/` 層
-- **Comment**：沒必要不寫。寫就寫 why（非直覺的決策、workaround、約束），不要寫 what（code 自解釋）
-- **Feedback UX**：`toast` 不 `alert`，`ConfirmDialog` 不 `confirm()`
-- **Design system**：顆粒度（gap、padding、rounded）照 CLAUDE.md Design System 段走，別自己發明
+- **TypeScript** — no `any`, no `@ts-ignore`. If you genuinely need an escape hatch, use `as unknown as X` and leave a comment explaining why.
+- **React** — Server Components first; reach for `"use client"` only when interactivity is needed. Supabase calls live in the `hooks/` layer, not inside components.
+- **Comments** — write none by default. If you do, write the _why_ (a non-obvious decision, a workaround, an invariant) — never the _what_. Code is self-explanatory; comments aren't.
+- **Feedback UX** — `toast` from sonner instead of `alert`; `AlertDialog` (or local `ConfirmDialog`) instead of `confirm()`.
+- **Design system** — spacing, padding, and rounding follow the rhythm in CLAUDE.md's Design System section. Don't invent local rules.
 
-## 加依賴
+## Adding dependencies
 
-- `bun add <pkg> --filter=portal` — 只給 portal 用
-- `bun add <pkg>` — root / 跨 workspace
-- 加新 dep 在 PR body 解釋 why（特別是大或小眾的套件）
+- `bun add <pkg> --filter=portal` — only for portal
+- `bun add <pkg>` — root or shared across workspaces
+- Justify new dependencies in the PR body, especially when the package is large or niche
 
-## 加 shadcn 元件
+## Adding shadcn components
 
 ```bash
 bunx shadcn@latest add <name> -c apps/portal
 ```
 
-進 `packages/ui/src/components/`，別手動放 `apps/portal/components/`。
+The file lands in `packages/ui/src/components/`. Don't manually copy primitives into `apps/portal/components/`.
 
-## Review guidelines
+## Reviewing pull requests
 
-**自己的 PR**：
+**On your own PR**:
 
-- 先自己 review 一遍再請人看
-- 每條 reviewer comment 要嘛修、要嘛回覆為什麼不修
-- 改完 mark resolved
+- Self-review once before requesting one
+- Resolve every comment — either fix it or explain why you won't
+- Mark conversations resolved as you go
 
-**看別人的 PR**：
+**On someone else's PR**:
 
-- 優先看 **why** 通不通，再看實作細節
-- 找得到更簡單的做法要講出來
-- 雞毛蒜皮先忍住，除非真的重要（nitpick 可以標 `nit:` prefix）
+- Look at the _why_ before the implementation details
+- If you can see a simpler approach, say so
+- Hold back on nitpicks unless they really matter; prefix true nitpicks with `nit:`
 
-## 遇到問題
+## Getting unstuck
 
-- **不確定是不是 bug** — 開 Question issue
-- **找 maintainer** — @zyx1121（Loki）
-- **急的** — 直接敲 Loki
+- **Not sure if it's a bug** — open a Question issue
+- **Need a maintainer** — `@zyx1121` (Loki)
+- **Urgent** — ping Loki directly

--- a/README.md
+++ b/README.md
@@ -1,98 +1,115 @@
 # portal.winlab.tw
 
-NYCU [WinLab](https://winlab.tw) 的內部入口。根域名 `portal.winlab.tw` 下掛多個業務 app（`/bento`、`/invoice`、`/approval`…），每個 app 由不同人維護、業務邏輯獨立，但共用：
+The internal portal for NYCU [WinLab](https://winlab.tw). The root domain hosts a handful of business apps under `portal.winlab.tw/<name>`, each owned by different people but sharing the same:
 
-- **Auth** — Supabase Auth + Keycloak OIDC
-- **Profile / session** — 一份 user state 跨整個 portal
-- **Design system** — 元件庫、顆粒度、feedback UX 規範
+- **Auth** — Supabase Auth fronted by Keycloak (OIDC)
+- **Profile / session** — one user state across the whole portal
+- **Design system** — components, spacing, feedback UX
 
-## 技術棧
+## Stack
 
-Bun 1.3 · Turborepo · Next.js 16（App Router + Turbopack）· React 19 · Tailwind v4 · shadcn/ui · Supabase（SSR cookies）· TanStack Query v5 · Keycloak（Supabase OIDC provider）
+Bun 1.3 · Turborepo 2 · Next.js 16 (App Router + Turbopack) · React 19 · Tailwind v4 · shadcn/ui · Supabase (`@supabase/ssr`) · TanStack Query v5 · Keycloak (Supabase OIDC provider) · pdf-lib
 
-## 上手
+## Apps
+
+| Path         | What it is                                                      |
+| ------------ | --------------------------------------------------------------- |
+| `/`          | Home — welcome card + nav to every app                          |
+| `/admin`     | Super-admin role management (gated by `user_profiles.is_admin`) |
+| `/approve`   | Document signing with PDF field placement + email outbox        |
+| `/bento`     | Lunch-ordering for the lab — orders, menus, realtime            |
+| `/debt`      | Bill-splitting + monthly settlement cron                        |
+| `/leave`     | Monday-meeting attendance sign-ups                              |
+| `/meetings`  | Lab-meeting weekly schedule + teacher papers                    |
+| `/profile`   | Personal account + bento / leave / approve / trip stats         |
+| `/receipts`  | Admin-only receipt review (PDF archive workflow)                |
+| `/reimburse` | Lab cash-flow bookkeeping (egress + ingress)                    |
+| `/trip`      | Travel-document uploads with admin folder export                |
+
+Two apps live on their own subdomains because their design system diverges from portal:
+
+- [`apps/gallery`](./apps/gallery) — `gallery.winlab.tw`, the lab's art wall (Instrument Serif, polaroid layout)
+- [`apps/mcp`](./apps/mcp) — `mcp.winlab.tw`, an MCP server exposing portal data over OAuth 2.1
+
+## Get started
 
 ```bash
 bun install
-cp apps/portal/.env.example apps/portal/.env.local  # 填 Supabase 兩把 key
+cp apps/portal/.env.example apps/portal/.env.local   # fill the two Supabase keys
 bun run dev                                          # http://localhost:3000
 ```
 
-`.env.local` 需要的值找 [@zyx1121](https://github.com/zyx1121)。Keycloak 相關設定全在 Supabase / Keycloak Dashboard，不進 repo。
+`.env.local` values live with [@zyx1121](https://github.com/zyx1121). Keycloak setup happens entirely in the Supabase + Keycloak dashboards — never in code.
 
-## 常用指令
+## Common commands
 
 ```bash
-bun run dev                       # 全棧 dev
-bun run dev --filter=portal       # 只跑 portal
+bun run dev                       # everything (portal :3000)
+bun run dev --filter=portal       # just portal
 bun run build                     # turbo build
 bun run typecheck                 # tsc --noEmit
 bun run lint                      # eslint
 bun run format                    # prettier --write
 ```
 
-沒裝 test runner — 要加先討論。
+No test runner yet — bring it up in an issue before adding one.
 
-## 怎麼加新的 app
+## Adding a new app
 
-業務 app = `apps/portal/app/<name>/` 底下的 route segment，**不是** 獨立 Turborepo workspace。要新增 app 就在 `apps/portal/app/` 下開資料夾，包一層 `<PortalShell appName="..." appHref="/<name>">` 就有 portal 骨架了。
+A business app is a `apps/portal/app/<name>/` route segment, **not** a separate Turborepo workspace. To start a new one, drop a folder under `apps/portal/app/`, wrap it with `<PortalShell appName="..." appHref="/<name>">`, and you've got the chrome for free.
 
-目前最完整的範例是 [`apps/portal/app/bento/`](./apps/portal/app/bento)，新 app 照它的版型做即可。
+The most complete reference today is [`apps/portal/app/bento/`](./apps/portal/app/bento) — copy that layout for the next app.
 
-### 例外：獨立 subdomain workspace
+### When to break out into a subdomain workspace
 
-當 app 的 design system 跟 portal **明顯不同**（字體、版面 metaphor），才開新 workspace 在 `apps/<name>/`，跑 subdomain（如 `gallery.winlab.tw`）。骨架還是 `<PortalShell>`（住在 `@workspace/ui`），但字體、容器寬度、互動可以自己玩。
+Only when the app's design system genuinely diverges from portal — different fonts, different layout metaphor. Otherwise, keep it inside `apps/portal/app/`. Ask a maintainer before opening a new workspace; do not create one just to dodge the shared shell.
 
-目前的範例是 [`apps/gallery/`](./apps/gallery)（Instrument Serif、拍立得錯落 layout）。**先問 maintainer 才開新 workspace**，避免重複造輪子。
+The lone example is [`apps/gallery`](./apps/gallery), which earned its own subdomain because it uses Instrument Serif and a polaroid scatter layout.
 
-## 怎麼加 shadcn 元件
+## Adding shadcn components
 
 ```bash
 bunx shadcn@latest add <component> -c apps/portal
 ```
 
-儘管帶 `-c apps/portal`，檔案會寫到 `packages/ui/src/components/`（跨 workspace 共用）。別手動往 `apps/portal/components/` 丟原始 shadcn primitive。
+Even though the flag points at `apps/portal`, the file lands in `packages/ui/src/components/` (workspace-shared). Do not drop raw shadcn primitives directly into `apps/portal/components/`.
 
-## Design system 規範（重點摘要）
+## Design system at a glance
 
-- **Layout** 統一用 `<PortalShell>`：TL 當前 app、TR app 內 nav、BL 回 portal 首頁、BR ©
-- **Card 殼** `border + rounded-xl + bg-card`，無 shadow、無 ring
-- **間距顆粒度**：section 間 `gap-10`、section 內 `gap-4`、card list 間 `gap-3`、list card padding `p-4`
-- **Feedback**：notification 用 `toast`（sonner）、destructive 確認用 `ConfirmDialog`，**不要** `alert()` / `confirm()`
-- **SDK-first**：Server Component → Server Action → Client Component → Route Handler（最後才開）；非必要不寫 API route
+- **Layout** — every app uses `<PortalShell>`: TL = current app, TR = in-app nav, BL = back to portal home, BR = ©
+- **Cards** — `border + rounded-xl + bg-card`, no shadow, no ring
+- **Spacing rhythm** — `gap-10` between sections, `gap-4` inside a section, `gap-3` between list cards, `p-4` for list-card padding
+- **Feedback** — `toast` from sonner for messages; `AlertDialog` (or local `ConfirmDialog`) for destructive confirms. **No** `alert()`, **no** `confirm()`
+- **SDK-first** — Server Component → Server Action → Client Component → Route Handler (last resort). Avoid wrapping Supabase in API routes; trust RLS
 
-完整規範與架構細節：[`CLAUDE.md`](./CLAUDE.md)（給 Claude Code 讀的，但人類也看得懂）。
+The full spec lives in [`CLAUDE.md`](./CLAUDE.md). Written for Claude Code, but humans read it fine.
 
-## 開發流程
+## Workflow
 
-### Branch
+### Branches
 
-- 從 `main` 開 branch
-- 命名：`<type>/<short-description>`，例：`feat/profile-avatar-upload`、`fix/bento-order-close-race`
-- `main` 被鎖，不能直推
+- Branch off `main`. `main` is locked — direct pushes are rejected.
+- Naming: `<type>/<short-description>`, e.g. `feat/profile-avatar-upload`, `fix/bento-order-close-race`.
 
-### Commit
+### Commits
 
-Conventional Commits — description 用英文、有人味：
+Conventional Commits, English description, with personality:
 
 ```
 feat: add bento order auto-close timer
 fix: stop the infinite loop from eating all the RAM
 chore: feed dependencies their latest treats
-docs: ...
-refactor: ...
-test: ...
-perf: ...
-style: ...
 ```
 
-### PR
+A commit-msg hook rejects malformed messages, so you cannot land a bad header by accident.
 
-- 標題照 commit 風格
-- Body 講 **why** 和 **what changed**，別只貼 commit messages
-- 等 CI 綠 + review pass 才 merge
-- 自己先把 PR 走一遍再請人看，改完 conversation mark resolved
+### Pull requests
+
+- PR title follows the same Conventional Commits format
+- Body explains the **why** and **what changed** — not a copy of commit messages
+- Self-review before requesting one; resolve conversations as you address them
+- Wait for CI green; deployments to Vercel may need owner authorization for outside contributors (see `CONTRIBUTING.md`)
 
 ## Contributors
 
-- [@zyx1121](https://github.com/zyx1121)（Loki）— maintainer
+- [@zyx1121](https://github.com/zyx1121) — maintainer


### PR DESCRIPTION
## Summary
四份文件原本是中文 + 內容跟現實 drift（少了 receipts / meetings / admin / trip / approve / debt 等 app，middleware 沒改 proxy，max-w 還寫 2xl）。整批：

- **README.md** — 重寫成英文，補完整 apps 表格、技術棧加 TanStack Query / pdf-lib，subdomain workspace 例外規則更明確
- **CHANGELOG.md** — 把這幾週的改動拆成 Unreleased section（admin / receipts / meetings / trip / debt / reimburse / approve / leave / profile / gallery / mcp + middleware→proxy + Next 16.2 + max-w-4xl + react-pdf 10）；保留原本 0.1.0 initial cut
- **CONTRIBUTING.md** — 翻譯成英文，加上 first-time contributor workflow 批准、Vercel preview deploy 對 outside contributor 的 authorization 限制
- **CLAUDE.md** — 翻成英文，補上 admin app + super admin / app-scoped role 的 permission model 段落，apps 列表完整化，receipts / meetings 的 useAdmin pattern 註明

無 code 變動，純文件。

## Test plan
- [x] markdown 編譯沒問題（GitHub render 預覽）
- [ ] 走一遍 README → CONTRIBUTING → CLAUDE → CHANGELOG，確認連結都對