### PR TITLE
fix(meetings): mobile RWD + member claim/reassign slots

### DIFF
--- a/apps/portal/app/meetings/_components/meeting-edit-dialog.tsx
+++ b/apps/portal/app/meetings/_components/meeting-edit-dialog.tsx
@@ -95,9 +95,16 @@ export function MeetingEditDialog({
         { onSuccess: () => onOpenChange(false) }
       )
     } else {
+      const selectedUser =
+        presenterUserId === "__none__"
+          ? null
+          : users.find((u) => u.id === presenterUserId)
       updateOwn.mutate(
         {
           id: meeting.id,
+          presenter: selectedUser?.name ?? null,
+          presenterUserId:
+            presenterUserId === "__none__" ? null : presenterUserId,
           paperTitle: paperTitle || null,
           paperLink: paperLink || null,
           pptUploaded: ppt,
@@ -144,28 +151,28 @@ export function MeetingEditDialog({
                 />
                 假日 / 暫停（不需要報告人）
               </label>
-              {!isHoliday && (
-                <div className="flex flex-col gap-1.5">
-                  <Label>報告人</Label>
-                  <Select
-                    value={presenterUserId}
-                    onValueChange={setPresenterUserId}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="選擇報告人" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__none__">（未指定）</SelectItem>
-                      {users.map((u) => (
-                        <SelectItem key={u.id} value={u.id}>
-                          {u.name ?? u.id}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              )}
             </>
+          )}
+          {!isHoliday && (
+            <div className="flex flex-col gap-1.5">
+              <Label>報告人</Label>
+              <Select
+                value={presenterUserId}
+                onValueChange={setPresenterUserId}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="選擇報告人" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__none__">（未指定）</SelectItem>
+                  {users.map((u) => (
+                    <SelectItem key={u.id} value={u.id}>
+                      {u.name ?? u.id}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
           )}
 
           <div className="flex flex-col gap-1.5">

--- a/apps/portal/app/meetings/_components/papers-tab.tsx
+++ b/apps/portal/app/meetings/_components/papers-tab.tsx
@@ -43,7 +43,7 @@ export function PapersTab() {
       {papers.length === 0 ? (
         <p className="text-sm text-muted-foreground">尚無老師提供的 papers。</p>
       ) : (
-        <div className="rounded-md border">
+        <div className="overflow-x-auto rounded-md border">
           <Table>
             <TableHeader>
               <TableRow>

--- a/apps/portal/app/meetings/_components/schedule-tab.tsx
+++ b/apps/portal/app/meetings/_components/schedule-tab.tsx
@@ -14,8 +14,13 @@ import {
 } from "@workspace/ui/components/table"
 
 import { useAuth } from "@/hooks/use-auth"
-import { useMeetings, useDeleteMeeting } from "@/hooks/meetings/use-meetings"
+import {
+  useMeetings,
+  useDeleteMeeting,
+  useClaimMeeting,
+} from "@/hooks/meetings/use-meetings"
 import { useMeetingsAdmin } from "@/hooks/meetings/use-meetings-admin"
+import { useLabUsers } from "@/hooks/meetings/use-lab-users"
 import type { Meeting } from "@/lib/meetings/types"
 
 import { AddMeetingDialog } from "./add-meeting-dialog"
@@ -35,7 +40,9 @@ export function ScheduleTab({ year }: { year: number }) {
   const { user } = useAuth()
   const { isAdmin } = useMeetingsAdmin()
   const { data: meetings = [], isLoading } = useMeetings(year)
+  const { data: labUsers = [] } = useLabUsers()
   const deleteMeeting = useDeleteMeeting()
+  const claimMeeting = useClaimMeeting()
 
   const [addOpen, setAddOpen] = useState(false)
   const [editTarget, setEditTarget] = useState<Meeting | null>(null)
@@ -106,7 +113,7 @@ export function ScheduleTab({ year }: { year: number }) {
                   <TableCell className="text-center">
                     <Checkbox checked={m.videoUploaded} disabled />
                   </TableCell>
-                  <TableCell className="max-w-xs">
+                  <TableCell className="max-w-xs overflow-hidden">
                     {m.paperLink ? (
                       <a
                         href={m.paperLink}
@@ -117,7 +124,7 @@ export function ScheduleTab({ year }: { year: number }) {
                         {m.paperTitle ?? m.paperLink}
                       </a>
                     ) : (
-                      <span className="text-xs text-muted-foreground">
+                      <span className="line-clamp-2 text-xs text-muted-foreground">
                         {m.paperTitle ?? "—"}
                       </span>
                     )}
@@ -127,6 +134,24 @@ export function ScheduleTab({ year }: { year: number }) {
                   </TableCell>
                   <TableCell>
                     <div className="flex gap-1">
+                      {user && !m.isHoliday && !m.presenterUserId && (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="h-7 px-2 text-xs"
+                          disabled={claimMeeting.isPending}
+                          onClick={() => {
+                            const me = labUsers.find((u) => u.id === user.id)
+                            claimMeeting.mutate({
+                              id: m.id,
+                              presenter: me?.name ?? user.email ?? user.id,
+                              presenterUserId: user.id,
+                            })
+                          }}
+                        >
+                          認領
+                        </Button>
+                      )}
                       {(isAdmin || isOwn) && !m.isHoliday && (
                         <Button
                           size="sm"

--- a/apps/portal/app/meetings/_components/schedule-tab.tsx
+++ b/apps/portal/app/meetings/_components/schedule-tab.tsx
@@ -56,7 +56,7 @@ export function ScheduleTab({ year }: { year: number }) {
         </div>
       )}
 
-      <div className="rounded-md border">
+      <div className="overflow-x-auto rounded-md border">
         <Table>
           <TableHeader>
             <TableRow>

--- a/apps/portal/hooks/meetings/use-meetings.ts
+++ b/apps/portal/hooks/meetings/use-meetings.ts
@@ -34,6 +34,8 @@ export function useUpdateOwnMeeting() {
   return useMutation({
     mutationFn: async ({
       id,
+      presenter,
+      presenterUserId,
       paperTitle,
       paperLink,
       pptUploaded,
@@ -41,6 +43,8 @@ export function useUpdateOwnMeeting() {
       notes,
     }: {
       id: string
+      presenter: string | null
+      presenterUserId: string | null
       paperTitle: string | null
       paperLink: string | null
       pptUploaded: boolean
@@ -50,6 +54,8 @@ export function useUpdateOwnMeeting() {
       const { error } = await supabase
         .from(TABLE)
         .update({
+          presenter,
+          presenter_user_id: presenterUserId,
           paper_title: paperTitle,
           paper_link: paperLink,
           ppt_uploaded: pptUploaded,
@@ -62,6 +68,34 @@ export function useUpdateOwnMeeting() {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: queryKeys.meetings.all })
       toast.success("已儲存")
+    },
+    onError: (e: Error) => toast.error(e.message),
+  })
+}
+
+export function useClaimMeeting() {
+  const supabase = createClient()
+  const qc = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      id,
+      presenter,
+      presenterUserId,
+    }: {
+      id: string
+      presenter: string
+      presenterUserId: string
+    }) => {
+      const { error } = await supabase
+        .from(TABLE)
+        .update({ presenter, presenter_user_id: presenterUserId })
+        .eq("id", id)
+      if (error) throw new Error(error.message || "認領失敗")
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.meetings.all })
+      toast.success("已認領")
     },
     onError: (e: Error) => toast.error(e.message),
   })


### PR DESCRIPTION
## Summary

- Add `overflow-x-auto` to schedule and papers table wrappers so tables scroll horizontally on mobile instead of breaking layout (320px / 375px / 768px verified)
- Fix Paper column: add `overflow-hidden` to cell and `line-clamp-2` to plain-text span so long paper titles don't overflow into adjacent columns
- Allow any logged-in member to **claim** an empty meeting slot with one click
- Allow the current presenter to **reassign** their slot to another lab member via the edit dialog (presenter Select is now shown for all users, not just admins)

## Test plan

- [ ] Open `/meetings` at 320px, 375px, 768px — table should scroll horizontally, no overflow
- [ ] Long paper titles (e.g. "A CI/CD Framework...") should be clamped to 2 lines
- [ ] Empty non-holiday rows show a "認領" button; clicking sets current user as presenter
- [ ] Own rows show "編輯"; inside dialog, 報告人 Select is visible and can be changed to another member
- [ ] Admin still has full edit access (week label, date, holiday toggle, presenter)