### PR TITLE
chore: hand fallback ownership to portal-maintainers team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,10 @@
 # 每個 PR 會自動 request 對應 owner 的 review。
 # 規則從下往上匹配，越下面越具體。
 #
-# 等團隊長大再按 app / 模組拆分。現在單人 repo 先全部 fallback。
+# Fallback 走 portal-maintainers team；team 成員可互審。
+# 敏感路徑（shared infra / CI / repo 設定）仍鎖個人 owner。
 
-*                                         @zyx1121
+*                                         @NYCU-WinLab/portal-maintainers
 
 # === Shared infra（改動需特別小心，會影響所有 app） ===
 /apps/portal/middleware.ts                @zyx1121


### PR DESCRIPTION
## Summary

- Fallback CODEOWNERS rule (`*`) shifts from `@zyx1121` to `@NYCU-WinLab/portal-maintainers` team
- Team members (currently @zyx1121, @JaeggerJose) can mutually review fallback paths
- Sensitive paths (shared infra, CI, root configs) keep individual owner — no change there

## Why

PRs from non-owner team members were getting wedged on a single reviewer. Spreading the fallback to a team unblocks the bus factor without dropping the moat on shared infra.

## Test plan

- [ ] CI green
- [ ] After merge: confirm a JaeggerJose-authored PR on `apps/portal/app/meetings/**` gets reviewer routing to the team, not just @zyx1121