### PR TITLE
feat(meetings): searchable presenter select + nav alpha sort + fix info links

### DIFF
--- a/apps/portal/app/meetings/_components/add-meeting-dialog.tsx
+++ b/apps/portal/app/meetings/_components/add-meeting-dialog.tsx
@@ -13,16 +13,10 @@ import {
 } from "@workspace/ui/components/dialog"
 import { Input } from "@workspace/ui/components/input"
 import { Label } from "@workspace/ui/components/label"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@workspace/ui/components/select"
-
 import { useAddMeeting } from "@/hooks/meetings/use-meetings"
 import { useLabUsers } from "@/hooks/meetings/use-lab-users"
+
+import { PresenterSelect } from "./presenter-select"
 
 interface Props {
   year: number
@@ -106,22 +100,11 @@ export function AddMeetingDialog({ year, open, onOpenChange }: Props) {
           {!isHoliday && (
             <div className="flex flex-col gap-1.5">
               <Label>報告人</Label>
-              <Select
+              <PresenterSelect
+                users={users}
                 value={presenterUserId}
-                onValueChange={setPresenterUserId}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="選擇報告人" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none__">（未指定）</SelectItem>
-                  {users.map((u) => (
-                    <SelectItem key={u.id} value={u.id}>
-                      {u.name ?? u.id}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                onSelect={setPresenterUserId}
+              />
             </div>
           )}
         </div>

--- a/apps/portal/app/meetings/_components/info-tab.tsx
+++ b/apps/portal/app/meetings/_components/info-tab.tsx
@@ -13,17 +13,17 @@ const INFO = [
   {
     label: "NextCloud",
     value: "開啟 NextCloud",
-    href: "https://nextcloud.winfra.cs.nycu.edu.tw/apps/files/files?dir=/winlab/meeting/2026",
+    href: "https://nextcloud.winlab.tw/apps/files/files/318788?dir=/winlab/Meeting/2026",
   },
   {
     label: "請假系統",
     value: "leave.winlab.tw",
-    href: "https://leave.winlab.tw",
+    href: "https://portal.winlab.tw/leave",
   },
   {
     label: "便當系統",
     value: "bento.winlab.tw",
-    href: "https://bento.winlab.tw",
+    href: "https://portal.winlab.tw/bento",
   },
 ]
 

--- a/apps/portal/app/meetings/_components/meeting-edit-dialog.tsx
+++ b/apps/portal/app/meetings/_components/meeting-edit-dialog.tsx
@@ -13,13 +13,7 @@ import {
 } from "@workspace/ui/components/dialog"
 import { Input } from "@workspace/ui/components/input"
 import { Label } from "@workspace/ui/components/label"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@workspace/ui/components/select"
+import { PresenterSelect } from "./presenter-select"
 
 import {
   useAdminUpdateMeeting,
@@ -156,22 +150,11 @@ export function MeetingEditDialog({
           {!isHoliday && (
             <div className="flex flex-col gap-1.5">
               <Label>報告人</Label>
-              <Select
+              <PresenterSelect
+                users={users}
                 value={presenterUserId}
-                onValueChange={setPresenterUserId}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="選擇報告人" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none__">（未指定）</SelectItem>
-                  {users.map((u) => (
-                    <SelectItem key={u.id} value={u.id}>
-                      {u.name ?? u.id}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                onSelect={setPresenterUserId}
+              />
             </div>
           )}
 

--- a/apps/portal/app/meetings/_components/presenter-select.tsx
+++ b/apps/portal/app/meetings/_components/presenter-select.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import { IconChevronDown } from "@tabler/icons-react"
+import { useState } from "react"
+
+import { Button } from "@workspace/ui/components/button"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@workspace/ui/components/command"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@workspace/ui/components/popover"
+
+interface PresenterSelectProps {
+  users: { id: string; name: string | null }[]
+  value: string
+  onSelect: (userId: string) => void
+}
+
+export function PresenterSelect({ users, value, onSelect }: PresenterSelectProps) {
+  const [open, setOpen] = useState(false)
+  const selected = users.find((u) => u.id === value) ?? null
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className="w-full justify-between font-normal"
+        >
+          <span className={selected ? "" : "text-muted-foreground"}>
+            {selected?.name ?? "（未指定）"}
+          </span>
+          <IconChevronDown data-icon="inline-end" className="opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-(--radix-popover-trigger-width) p-0">
+        <Command>
+          <CommandInput placeholder="搜尋報告人" />
+          <CommandList>
+            <CommandEmpty>找不到成員</CommandEmpty>
+            <CommandGroup>
+              <CommandItem
+                value="__none__"
+                onSelect={() => {
+                  onSelect("__none__")
+                  setOpen(false)
+                }}
+              >
+                （未指定）
+              </CommandItem>
+              {users.map((u) => (
+                <CommandItem
+                  key={u.id}
+                  value={u.name ?? u.id}
+                  onSelect={() => {
+                    onSelect(u.id)
+                    setOpen(false)
+                  }}
+                >
+                  {u.name ?? u.id}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/portal/app/page.tsx
+++ b/apps/portal/app/page.tsx
@@ -10,15 +10,15 @@ import { isReceiptsAdmin } from "@/lib/receipts/admin"
 import { getCurrentUser } from "@/lib/user"
 
 const baseApps = [
+  { href: "/approve", label: "Approve", note: "文件簽核" },
   { href: "/bento", label: "Bento", note: "便當訂購" },
+  { href: "/debt", label: "Debt", note: "分帳記帳" },
+  { href: "https://gallery.winlab.tw", label: "Gallery", note: "藝術畫廊" },
   { href: "/leave", label: "Leave", note: "請假登記" },
   { href: "/meetings", label: "Meetings", note: "組會排班" },
-  { href: "/approve", label: "Approve", note: "文件簽核" },
-  { href: "/trip", label: "Trip", note: "出差文件" },
-  { href: "/debt", label: "Debt", note: "分帳記帳" },
-  { href: "/reimburse", label: "Reimburse", note: "收支記帳" },
   { href: "/profile", label: "Profile", note: "個人帳號" },
-  { href: "https://gallery.winlab.tw", label: "Gallery", note: "藝術畫廊" },
+  { href: "/reimburse", label: "Reimburse", note: "收支記帳" },
+  { href: "/trip", label: "Trip", note: "出差文件" },
 ]
 
 export default async function Page() {
@@ -28,13 +28,12 @@ export default async function Page() {
   ])
   const currentUser = user!
 
-  const apps = showReceipts
-    ? [
-        ...baseApps.slice(0, 7),
-        { href: "/receipts", label: "Receipts", note: "收據審核" },
-        ...baseApps.slice(7),
-      ]
-    : baseApps
+  const apps = [
+    ...baseApps,
+    ...(showReceipts
+      ? [{ href: "/receipts", label: "Receipts", note: "收據審核" }]
+      : []),
+  ].sort((a, b) => a.label.localeCompare(b.label))
 
   return (
     <PortalShell appName="Portal" bottomLeft={<ThemeToggle />}>


### PR DESCRIPTION
## Summary

- **Searchable presenter select**: Replace plain `<Select>` in add/edit meeting dialogs with a `Popover + Command` combobox — same pattern as `debt/member-select`. Admins and presenters can now type a name to filter the list instead of scrolling through all lab members.
- **Nav alphabetical sort**: Portal home nav is now sorted A→Z. `Receipts` (admin-only) is spread into the array before sorting, replacing the fragile `slice(0,7)...slice(7)` insertion.
- **Info tab links fixed**: NextCloud → `nextcloud.winlab.tw` (with correct folder path), 請假/便當 → `portal.winlab.tw/leave` and `/bento`.

## Test plan

- [ ] Open `/meetings` → click 編輯 on any row → 報告人 field shows a searchable combobox, typing filters members
- [ ] Admin: click 新增週次 → 報告人 field also searchable
- [ ] Open `/` → nav order is Approve, Bento, Debt, Gallery, Leave, Meetings, Profile, Reimburse, Trip (Receipts appears between Profile and Reimburse for admins)
- [ ] Open `/meetings` → Info tab → NextCloud / 請假 / 便當 links go to correct URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)