### PR TITLE
Feat/new feature

### DIFF
--- a/apps/gallery/app/_components/gallery-card.tsx
+++ b/apps/gallery/app/_components/gallery-card.tsx
@@ -19,9 +19,11 @@ import { getGalleryImageUrl } from "@/lib/gallery/url"
 export function GalleryCard({
   image,
   isSignedIn,
+  viewerName,
 }: {
   image: GalleryImage
   isSignedIn: boolean
+  viewerName: string
 }) {
   const rotation = getRotation(image.id)
   const url = getGalleryImageUrl(image.image_path)
@@ -30,6 +32,7 @@ export function GalleryCard({
   const [isPending, startTransition] = useTransition()
   const [votedByMe, setVotedByMe] = useState(image.voted_by_me)
   const [voteCount, setVoteCount] = useState(image.vote_count)
+  const [voterNames, setVoterNames] = useState(image.voter_names)
 
   const canToggleVote = isSignedIn && !isPending
 
@@ -50,14 +53,21 @@ export function GalleryCard({
       if (votedByMe) {
         setVotedByMe(false)
         setVoteCount((n) => Math.max(0, n - 1))
+        setVoterNames((names) => names.filter((name) => name !== viewerName))
         toast.success("Vote removed.")
       } else {
         setVotedByMe(true)
         setVoteCount((n) => n + 1)
+        setVoterNames((names) =>
+          names.includes(viewerName) ? names : [...names, viewerName]
+        )
         toast.success("Vote counted.")
       }
     })
   }
+
+  const votersPreview = voterNames.slice(0, 3).join(", ")
+  const votersExtra = voterNames.length > 3 ? ` +${voterNames.length - 3}` : ""
 
   return (
     <figure
@@ -125,6 +135,14 @@ export function GalleryCard({
           <p className="text-base text-white/70 italic md:text-lg">
             by {image.uploader_name}
           </p>
+          {voterNames.length > 0 ? (
+            <p className="text-sm text-white/70">
+              Liked by {votersPreview}
+              {votersExtra}
+            </p>
+          ) : (
+            <p className="text-sm text-white/60">No likes yet</p>
+          )}
         </DialogContent>
       </Dialog>
       <figcaption
@@ -138,6 +156,16 @@ export function GalleryCard({
           <p className="mt-1 truncate text-sm text-muted-foreground md:text-base">
             by {image.uploader_name}
           </p>
+          {voterNames.length > 0 ? (
+            <p className="mt-1 truncate text-xs text-muted-foreground not-italic md:text-sm">
+              Liked by {votersPreview}
+              {votersExtra}
+            </p>
+          ) : (
+            <p className="mt-1 truncate text-xs text-muted-foreground/70 not-italic md:text-sm">
+              No likes yet
+            </p>
+          )}
         </div>
         <button
           type="button"

--- a/apps/gallery/app/_components/gallery-card.tsx
+++ b/apps/gallery/app/_components/gallery-card.tsx
@@ -122,6 +122,9 @@ export function GalleryCard({
           <p className="text-3xl text-white/90 italic md:text-4xl">
             {image.name}
           </p>
+          <p className="text-base text-white/70 italic md:text-lg">
+            by {image.uploader_name}
+          </p>
         </DialogContent>
       </Dialog>
       <figcaption
@@ -130,7 +133,12 @@ export function GalleryCard({
           "italic md:text-3xl"
         )}
       >
-        <span className="truncate">{image.name}</span>
+        <div className="min-w-0">
+          <p className="truncate">{image.name}</p>
+          <p className="mt-1 truncate text-sm text-muted-foreground md:text-base">
+            by {image.uploader_name}
+          </p>
+        </div>
         <button
           type="button"
           onClick={onVote}

--- a/apps/gallery/app/_components/gallery-card.tsx
+++ b/apps/gallery/app/_components/gallery-card.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useTransition } from "react"
 
 import {
   Dialog,
@@ -9,36 +9,75 @@ import {
   DialogTrigger,
 } from "@workspace/ui/components/dialog"
 import { cn } from "@workspace/ui/lib/utils"
+import { toast } from "sonner"
 
+import { unvoteGalleryImage, voteGalleryImage } from "@/app/actions"
 import { getRotation } from "@/lib/gallery/rotation"
 import type { GalleryImage } from "@/lib/gallery/types"
 import { getGalleryImageUrl } from "@/lib/gallery/url"
 
-export function GalleryCard({ image }: { image: GalleryImage }) {
+export function GalleryCard({
+  image,
+  isSignedIn,
+}: {
+  image: GalleryImage
+  isSignedIn: boolean
+}) {
   const rotation = getRotation(image.id)
   const url = getGalleryImageUrl(image.image_path)
   const [thumbFailed, setThumbFailed] = useState(false)
   const [lightboxFailed, setLightboxFailed] = useState(false)
+  const [isPending, startTransition] = useTransition()
+  const [votedByMe, setVotedByMe] = useState(image.voted_by_me)
+  const [voteCount, setVoteCount] = useState(image.vote_count)
+
+  const canToggleVote = isSignedIn && !isPending
+
+  const onVote = () => {
+    if (!isSignedIn) {
+      toast.error("Please sign in before voting.")
+      return
+    }
+
+    startTransition(async () => {
+      const result = votedByMe
+        ? await unvoteGalleryImage(image.id)
+        : await voteGalleryImage(image.id)
+      if (!result.ok) {
+        toast.error(result.error)
+        return
+      }
+      if (votedByMe) {
+        setVotedByMe(false)
+        setVoteCount((n) => Math.max(0, n - 1))
+        toast.success("Vote removed.")
+      } else {
+        setVotedByMe(true)
+        setVoteCount((n) => n + 1)
+        toast.success("Vote counted.")
+      }
+    })
+  }
 
   return (
-    <Dialog>
-      <DialogTrigger asChild>
-        <figure
-          className={cn(
-            "group relative block w-full cursor-pointer",
-            "transition-transform duration-500 ease-out will-change-transform",
-            "[transform:rotate(var(--gallery-rot))]",
-            "hover:[transform:rotate(0deg)_scale(1.02)]"
-          )}
-          style={
-            {
-              "--gallery-rot": `${rotation}deg`,
-            } as React.CSSProperties
-          }
-        >
+    <figure
+      className={cn(
+        "group relative block w-full",
+        "transition-transform duration-500 ease-out will-change-transform",
+        "[transform:rotate(var(--gallery-rot))]",
+        "hover:[transform:rotate(0deg)_scale(1.02)]"
+      )}
+      style={
+        {
+          "--gallery-rot": `${rotation}deg`,
+        } as React.CSSProperties
+      }
+    >
+      <Dialog>
+        <DialogTrigger asChild>
           <div
             className={cn(
-              "relative w-full overflow-hidden bg-white",
+              "relative w-full cursor-pointer overflow-hidden bg-white",
               "border border-black/5 shadow-[0_1px_2px_rgba(0,0,0,0.06),0_8px_24px_-12px_rgba(0,0,0,0.18)]"
             )}
           >
@@ -59,40 +98,56 @@ export function GalleryCard({ image }: { image: GalleryImage }) {
               />
             )}
           </div>
-          <figcaption
-            className={cn(
-              "mt-4 text-center text-2xl leading-snug tracking-wide text-foreground/70",
-              "italic md:text-3xl"
-            )}
-          >
+        </DialogTrigger>
+        <DialogContent
+          showCloseButton={false}
+          className={cn(
+            "flex max-h-[95vh] w-auto max-w-[95vw] flex-col items-center justify-center gap-6 overflow-visible !rounded-none border-0 bg-transparent p-0 shadow-none ring-0 sm:max-w-[95vw]"
+          )}
+        >
+          <DialogTitle className="sr-only">{image.name}</DialogTitle>
+          {lightboxFailed ? (
+            <div className="max-w-[95vw] rounded-sm bg-muted px-8 py-16 text-center text-muted-foreground italic shadow-2xl">
+              This image cannot be previewed in your browser (common with HEIC).
+              Export as JPEG/PNG or open this page in Safari.
+            </div>
+          ) : (
+            <img
+              src={url}
+              alt={image.name}
+              className="block h-auto max-h-[85vh] w-auto max-w-[95vw] bg-white object-contain shadow-2xl"
+              onError={() => setLightboxFailed(true)}
+            />
+          )}
+          <p className="text-3xl text-white/90 italic md:text-4xl">
             {image.name}
-          </figcaption>
-        </figure>
-      </DialogTrigger>
-      <DialogContent
-        showCloseButton={false}
+          </p>
+        </DialogContent>
+      </Dialog>
+      <figcaption
         className={cn(
-          "flex max-h-[95vh] w-auto max-w-[95vw] flex-col items-center justify-center gap-6 overflow-visible !rounded-none border-0 bg-transparent p-0 shadow-none ring-0 sm:max-w-[95vw]"
+          "mt-4 flex items-center justify-between gap-4 text-2xl leading-snug tracking-wide text-foreground/70",
+          "italic md:text-3xl"
         )}
       >
-        <DialogTitle className="sr-only">{image.name}</DialogTitle>
-        {lightboxFailed ? (
-          <div className="max-w-[95vw] rounded-sm bg-muted px-8 py-16 text-center text-muted-foreground italic shadow-2xl">
-            This image cannot be previewed in your browser (common with HEIC).
-            Export as JPEG/PNG or open this page in Safari.
-          </div>
-        ) : (
-          <img
-            src={url}
-            alt={image.name}
-            className="block h-auto max-h-[85vh] w-auto max-w-[95vw] bg-white object-contain shadow-2xl"
-            onError={() => setLightboxFailed(true)}
-          />
-        )}
-        <p className="text-3xl text-white/90 italic md:text-4xl">
-          {image.name}
-        </p>
-      </DialogContent>
-    </Dialog>
+        <span className="truncate">{image.name}</span>
+        <button
+          type="button"
+          onClick={onVote}
+          disabled={!canToggleVote}
+          aria-label={votedByMe ? "Remove vote" : "Vote for this work"}
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-base not-italic transition-colors md:text-lg",
+            votedByMe
+              ? "border-foreground/20 bg-foreground/10 text-foreground"
+              : "border-foreground/20 bg-background/80 text-foreground hover:bg-foreground/10",
+            !canToggleVote && "cursor-not-allowed opacity-70"
+          )}
+        >
+          <span aria-hidden>{votedByMe ? "✓" : "👍"}</span>
+          <span>{voteCount}</span>
+        </button>
+      </figcaption>
+    </figure>
   )
 }

--- a/apps/gallery/app/_components/gallery-grid.tsx
+++ b/apps/gallery/app/_components/gallery-grid.tsx
@@ -19,9 +19,11 @@ function pickCols(width: number): number {
 export function GalleryGrid({
   images,
   isSignedIn,
+  viewerName,
 }: {
   images: GalleryImage[]
   isSignedIn: boolean
+  viewerName: string
 }) {
   // SSR seeds with 3-col layout (desktop default). useEffect rebuckets on
   // mount and on resize. The seed shape stays stable so React doesn't blow
@@ -57,7 +59,12 @@ export function GalleryGrid({
       {buckets.map((bucket, i) => (
         <div key={i} className="flex min-w-0 flex-1 flex-col gap-12">
           {bucket.map((image) => (
-            <GalleryCard key={image.id} image={image} isSignedIn={isSignedIn} />
+            <GalleryCard
+              key={image.id}
+              image={image}
+              isSignedIn={isSignedIn}
+              viewerName={viewerName}
+            />
           ))}
         </div>
       ))}

--- a/apps/gallery/app/_components/gallery-grid.tsx
+++ b/apps/gallery/app/_components/gallery-grid.tsx
@@ -16,7 +16,13 @@ function pickCols(width: number): number {
   return 1
 }
 
-export function GalleryGrid({ images }: { images: GalleryImage[] }) {
+export function GalleryGrid({
+  images,
+  isSignedIn,
+}: {
+  images: GalleryImage[]
+  isSignedIn: boolean
+}) {
   // SSR seeds with 3-col layout (desktop default). useEffect rebuckets on
   // mount and on resize. The seed shape stays stable so React doesn't blow
   // up hydration: same number of buckets, same DOM shape.
@@ -51,7 +57,7 @@ export function GalleryGrid({ images }: { images: GalleryImage[] }) {
       {buckets.map((bucket, i) => (
         <div key={i} className="flex min-w-0 flex-1 flex-col gap-12">
           {bucket.map((image) => (
-            <GalleryCard key={image.id} image={image} />
+            <GalleryCard key={image.id} image={image} isSignedIn={isSignedIn} />
           ))}
         </div>
       ))}

--- a/apps/gallery/app/actions.ts
+++ b/apps/gallery/app/actions.ts
@@ -1,0 +1,57 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+
+import { createClient } from "@/lib/supabase/server"
+
+export type VoteActionResult = { ok: true } | { ok: false; error: string }
+
+export async function voteGalleryImage(
+  imageId: string
+): Promise<VoteActionResult> {
+  if (!imageId) return { ok: false, error: "Missing image id." }
+
+  const supabase = await createClient()
+  const { data: claimsData } = await supabase.auth.getClaims()
+  const userId = claimsData?.claims?.sub
+  if (!userId) return { ok: false, error: "Please sign in first." }
+
+  const { error } = await supabase
+    .from("gallery_image_votes")
+    .insert({ image_id: imageId, user_id: userId })
+
+  if (error) {
+    // Unique violation means this user already voted for this image.
+    if (error.code === "23505") {
+      return { ok: false, error: "You already voted for this work." }
+    }
+    return { ok: false, error: `Vote failed: ${error.message}` }
+  }
+
+  revalidatePath("/")
+  return { ok: true }
+}
+
+export async function unvoteGalleryImage(
+  imageId: string
+): Promise<VoteActionResult> {
+  if (!imageId) return { ok: false, error: "Missing image id." }
+
+  const supabase = await createClient()
+  const { data: claimsData } = await supabase.auth.getClaims()
+  const userId = claimsData?.claims?.sub
+  if (!userId) return { ok: false, error: "Please sign in first." }
+
+  const { error } = await supabase
+    .from("gallery_image_votes")
+    .delete()
+    .eq("image_id", imageId)
+    .eq("user_id", userId)
+
+  if (error) {
+    return { ok: false, error: `Unvote failed: ${error.message}` }
+  }
+
+  revalidatePath("/")
+  return { ok: true }
+}

--- a/apps/gallery/app/page.tsx
+++ b/apps/gallery/app/page.tsx
@@ -11,6 +11,7 @@ export const dynamic = "force-dynamic"
 
 export default async function GalleryHomePage() {
   const supabase = await createClient()
+  const user = await getCurrentUser()
   const { data, error } = await supabase
     .from("gallery_images")
     .select("id, name, image_path, created_by, created_at")
@@ -20,8 +21,47 @@ export default async function GalleryHomePage() {
     console.error("[gallery] failed to load images", error)
   }
 
-  const images = (data ?? []) as GalleryImage[]
-  const user = await getCurrentUser()
+  const baseImages = data ?? []
+  const imageIds = baseImages.map((image) => image.id)
+
+  let voteCountsByImage = new Map<string, number>()
+  if (imageIds.length > 0) {
+    const { data: voteRows, error: voteError } = await supabase
+      .from("gallery_image_votes")
+      .select("image_id")
+      .in("image_id", imageIds)
+
+    if (voteError) {
+      console.error("[gallery] failed to load vote counts", voteError)
+    } else {
+      voteCountsByImage = (voteRows ?? []).reduce((map, row) => {
+        const current = map.get(row.image_id) ?? 0
+        map.set(row.image_id, current + 1)
+        return map
+      }, new Map<string, number>())
+    }
+  }
+
+  let votedImageSet = new Set<string>()
+  if (user && imageIds.length > 0) {
+    const { data: myVotes, error: myVotesError } = await supabase
+      .from("gallery_image_votes")
+      .select("image_id")
+      .eq("user_id", user.id)
+      .in("image_id", imageIds)
+
+    if (myVotesError) {
+      console.error("[gallery] failed to load user votes", myVotesError)
+    } else {
+      votedImageSet = new Set((myVotes ?? []).map((row) => row.image_id))
+    }
+  }
+
+  const images: GalleryImage[] = baseImages.map((image) => ({
+    ...image,
+    vote_count: voteCountsByImage.get(image.id) ?? 0,
+    voted_by_me: votedImageSet.has(image.id),
+  }))
 
   return (
     <PortalShell
@@ -38,7 +78,7 @@ export default async function GalleryHomePage() {
         </Link>
       }
     >
-      <GalleryGrid images={images} />
+      <GalleryGrid images={images} isSignedIn={Boolean(user)} />
     </PortalShell>
   )
 }

--- a/apps/gallery/app/page.tsx
+++ b/apps/gallery/app/page.tsx
@@ -24,6 +24,32 @@ export default async function GalleryHomePage() {
 
   const baseImages = data ?? []
   const imageIds = baseImages.map((image) => image.id)
+  const creatorIds = Array.from(
+    new Set(baseImages.map((image) => image.created_by).filter(Boolean))
+  ) as string[]
+
+  let uploaderNameById = new Map<string, string>()
+  if (creatorIds.length > 0) {
+    const { data: profileRows, error: profileError } = await supabase
+      .from("user_profiles")
+      .select("id, name, email")
+      .in("id", creatorIds)
+
+    if (profileError) {
+      console.error("[gallery] failed to load uploader profiles", profileError)
+    } else {
+      uploaderNameById = (profileRows ?? []).reduce((map, row) => {
+        const fallback =
+          typeof row.email === "string" ? row.email.split("@")[0] : null
+        const name =
+          (typeof row.name === "string" && row.name.trim()) ||
+          fallback ||
+          "Unknown"
+        map.set(row.id, name)
+        return map
+      }, new Map<string, string>())
+    }
+  }
 
   let voteCountsByImage = new Map<string, number>()
   if (imageIds.length > 0) {
@@ -60,6 +86,9 @@ export default async function GalleryHomePage() {
 
   const images: GalleryImage[] = baseImages.map((image) => ({
     ...image,
+    uploader_name: image.created_by
+      ? (uploaderNameById.get(image.created_by) ?? "Unknown")
+      : "Unknown",
     vote_count: voteCountsByImage.get(image.id) ?? 0,
     voted_by_me: votedImageSet.has(image.id),
   }))

--- a/apps/gallery/app/page.tsx
+++ b/apps/gallery/app/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link"
 import { PortalShell } from "@workspace/ui/components/portal-shell"
 
 import { GalleryGrid } from "@/app/_components/gallery-grid"
+import { SignOutButton } from "@/components/sign-out-button"
 import { createClient } from "@/lib/supabase/server"
 import type { GalleryImage } from "@/lib/gallery/types"
 import { getCurrentUser } from "@/lib/user"
@@ -70,12 +71,24 @@ export default async function GalleryHomePage() {
       containerClassName="mx-auto w-full max-w-7xl px-6 py-24"
       cornerClassName="text-lg"
       topRight={
-        <Link
-          href={user ? "/upload" : "/auth/login?next=/upload"}
-          className="transition-colors hover:text-foreground"
-        >
-          {user ? "Upload" : "Sign in"}
-        </Link>
+        user ? (
+          <div className="flex items-center gap-4">
+            <Link
+              href="/upload"
+              className="transition-colors hover:text-foreground"
+            >
+              Manage
+            </Link>
+            <SignOutButton />
+          </div>
+        ) : (
+          <Link
+            href="/auth/login?next=/upload"
+            className="transition-colors hover:text-foreground"
+          >
+            Sign in
+          </Link>
+        )
       }
     >
       <GalleryGrid images={images} isSignedIn={Boolean(user)} />

--- a/apps/gallery/app/page.tsx
+++ b/apps/gallery/app/page.tsx
@@ -52,20 +52,60 @@ export default async function GalleryHomePage() {
   }
 
   let voteCountsByImage = new Map<string, number>()
+  let voterNamesByImage = new Map<string, string[]>()
   if (imageIds.length > 0) {
     const { data: voteRows, error: voteError } = await supabase
       .from("gallery_image_votes")
-      .select("image_id")
+      .select("image_id, user_id")
       .in("image_id", imageIds)
 
     if (voteError) {
       console.error("[gallery] failed to load vote counts", voteError)
     } else {
+      const voterIds = Array.from(
+        new Set((voteRows ?? []).map((row) => row.user_id).filter(Boolean))
+      )
+      let voterNameById = new Map<string, string>()
+
+      if (voterIds.length > 0) {
+        const { data: voterProfiles, error: voterProfilesError } =
+          await supabase
+            .from("user_profiles")
+            .select("id, name, email")
+            .in("id", voterIds)
+
+        if (voterProfilesError) {
+          console.error(
+            "[gallery] failed to load voter profiles",
+            voterProfilesError
+          )
+        } else {
+          voterNameById = (voterProfiles ?? []).reduce((map, row) => {
+            const fallback =
+              typeof row.email === "string" ? row.email.split("@")[0] : null
+            const name =
+              (typeof row.name === "string" && row.name.trim()) ||
+              fallback ||
+              "Unknown"
+            map.set(row.id, name)
+            return map
+          }, new Map<string, string>())
+        }
+      }
+
       voteCountsByImage = (voteRows ?? []).reduce((map, row) => {
         const current = map.get(row.image_id) ?? 0
         map.set(row.image_id, current + 1)
         return map
       }, new Map<string, number>())
+
+      voterNamesByImage = (voteRows ?? []).reduce((map, row) => {
+        const list = map.get(row.image_id) ?? []
+        const name = voterNameById.get(row.user_id) ?? "Unknown"
+        list.push(name)
+        map.set(row.image_id, list)
+        return map
+      }, new Map<string, string[]>())
     }
   }
 
@@ -91,6 +131,7 @@ export default async function GalleryHomePage() {
       : "Unknown",
     vote_count: voteCountsByImage.get(image.id) ?? 0,
     voted_by_me: votedImageSet.has(image.id),
+    voter_names: voterNamesByImage.get(image.id) ?? [],
   }))
 
   return (
@@ -120,7 +161,11 @@ export default async function GalleryHomePage() {
         )
       }
     >
-      <GalleryGrid images={images} isSignedIn={Boolean(user)} />
+      <GalleryGrid
+        images={images}
+        isSignedIn={Boolean(user)}
+        viewerName={user?.name ?? "You"}
+      />
     </PortalShell>
   )
 }

--- a/apps/gallery/app/upload/_components/upload-form.tsx
+++ b/apps/gallery/app/upload/_components/upload-form.tsx
@@ -17,39 +17,30 @@ export function UploadForm() {
   const formRef = useRef<HTMLFormElement>(null)
   const [pending, startTransition] = useTransition()
   const [name, setName] = useState("")
-  const [fileName, setFileName] = useState<string | null>(null)
+  const [fileNames, setFileNames] = useState<string[]>([])
+
+  function inferArtworkName(fileName: string): string {
+    const base = fileName.replace(/\.[^.]+$/, "").trim()
+    return base || "Untitled"
+  }
 
   function onSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault()
     const form = formRef.current
     const fileInput = form?.querySelector<HTMLInputElement>("#gallery-file")
-    const file = fileInput?.files?.[0]
+    const files = Array.from(fileInput?.files ?? [])
     const trimmed = name.trim()
 
-    if (!trimmed) {
-      toast.error("Name is required.")
+    if (files.length === 0) {
+      toast.error("Pick an image file.")
       return
     }
-    if (!file || file.size === 0) {
-      toast.error("Pick an image file.")
+    if (files.some((file) => file.size === 0)) {
+      toast.error("One of the selected files is empty.")
       return
     }
 
     startTransition(async () => {
-      const resolvedMime = resolveImageMimeType(file)
-      if (!resolvedMime) {
-        toast.error(
-          `Unsupported file type: ${file.type || "unknown"}. Use JPEG, PNG, WebP, GIF, AVIF, or HEIC.`
-        )
-        return
-      }
-
-      const ext = guessExtension(resolvedMime, file.name)
-      if (ext === "bin") {
-        toast.error("Unsupported file type.")
-        return
-      }
-
       const supabase = createClient()
       const { data: claimsData } = await supabase.auth.getClaims()
       const userId = claimsData?.claims?.sub
@@ -58,29 +49,60 @@ export function UploadForm() {
         return
       }
 
-      const objectPath = `${userId}/${crypto.randomUUID()}.${ext}`
+      let successCount = 0
+      const failed: string[] = []
 
-      const { error: uploadError } = await supabase.storage
-        .from("gallery")
-        .upload(objectPath, file, {
-          contentType: resolvedMime,
-          upsert: false,
-        })
+      for (const file of files) {
+        const resolvedMime = resolveImageMimeType(file)
+        if (!resolvedMime) {
+          failed.push(
+            `${file.name} (unsupported type: ${file.type || "unknown"})`
+          )
+          continue
+        }
 
-      if (uploadError) {
-        toast.error(`Upload failed: ${uploadError.message}`)
-        return
+        const ext = guessExtension(resolvedMime, file.name)
+        if (ext === "bin") {
+          failed.push(`${file.name} (unsupported extension)`)
+          continue
+        }
+
+        const objectPath = `${userId}/${crypto.randomUUID()}.${ext}`
+        const artworkName =
+          files.length === 1 && trimmed ? trimmed : inferArtworkName(file.name)
+
+        const { error: uploadError } = await supabase.storage
+          .from("gallery")
+          .upload(objectPath, file, {
+            contentType: resolvedMime,
+            upsert: false,
+          })
+
+        if (uploadError) {
+          failed.push(`${file.name} (${uploadError.message})`)
+          continue
+        }
+
+        const result = await registerGalleryImage(artworkName, objectPath)
+        if (result.ok) {
+          successCount += 1
+        } else {
+          await supabase.storage.from("gallery").remove([objectPath])
+          failed.push(`${file.name} (${result.error})`)
+        }
       }
 
-      const result = await registerGalleryImage(trimmed, objectPath)
-      if (result.ok) {
-        toast.success(`Uploaded "${trimmed}"`)
+      if (successCount > 0) {
+        const suffix = successCount > 1 ? "s" : ""
+        toast.success(`Uploaded ${successCount} work${suffix}.`)
         form?.reset()
         setName("")
-        setFileName(null)
-      } else {
-        await supabase.storage.from("gallery").remove([objectPath])
-        toast.error(result.error)
+        setFileNames([])
+      }
+      if (failed.length > 0) {
+        const preview = failed.slice(0, 3).join("; ")
+        const hidden = failed.length > 3 ? ` (+${failed.length - 3} more)` : ""
+        toast.error(`Failed ${failed.length}: ${preview}${hidden}`)
       }
     })
   }
@@ -89,12 +111,11 @@ export function UploadForm() {
     <form ref={formRef} onSubmit={onSubmit} className="flex flex-col gap-8">
       <div className="flex flex-col gap-3">
         <Label htmlFor="gallery-name" className="text-xl italic">
-          Name
+          Name (single upload only)
         </Label>
         <Input
           id="gallery-name"
           name="name"
-          required
           placeholder="Untitled, 2026"
           value={name}
           onChange={(e) => setName(e.target.value)}
@@ -104,7 +125,7 @@ export function UploadForm() {
       </div>
       <div className="flex flex-col gap-3">
         <Label htmlFor="gallery-file" className="text-xl italic">
-          Image
+          Images
         </Label>
         <Input
           id="gallery-file"
@@ -112,12 +133,18 @@ export function UploadForm() {
           type="file"
           accept="image/*"
           required
-          onChange={(e) => setFileName(e.target.files?.[0]?.name ?? null)}
+          multiple
+          onChange={(e) =>
+            setFileNames(Array.from(e.target.files ?? []).map((f) => f.name))
+          }
           disabled={pending}
           className="h-12 rounded-none border-0 border-b border-border bg-transparent px-0 !text-lg file:mr-4 file:!text-base focus-visible:border-foreground focus-visible:ring-0"
         />
-        {fileName ? (
-          <p className="text-base text-muted-foreground italic">{fileName}</p>
+        {fileNames.length > 0 ? (
+          <p className="text-base text-muted-foreground italic">
+            {fileNames.length} selected: {fileNames.slice(0, 3).join(", ")}
+            {fileNames.length > 3 ? ` (+${fileNames.length - 3} more)` : ""}
+          </p>
         ) : null}
       </div>
       <Button
@@ -126,7 +153,7 @@ export function UploadForm() {
         disabled={pending}
         className="mt-4 h-14 !text-lg italic"
       >
-        {pending ? "Uploading…" : "Upload"}
+        {pending ? "Uploading…" : "Upload selected"}
       </Button>
     </form>
   )

--- a/apps/gallery/app/upload/page.tsx
+++ b/apps/gallery/app/upload/page.tsx
@@ -34,14 +34,7 @@ export default async function UploadPage() {
       appHref="/"
       containerClassName="mx-auto w-full max-w-3xl px-6 py-24"
       cornerClassName="text-lg"
-      topRight={
-        <div className="flex items-center gap-4">
-          <Link href="/" className="transition-colors hover:text-foreground">
-            Gallery
-          </Link>
-          <SignOutButton />
-        </div>
-      }
+      topRight={<SignOutButton />}
       bottomLeft={
         <Link href="/" className="transition-colors hover:text-foreground">
           Back

--- a/apps/gallery/app/upload/page.tsx
+++ b/apps/gallery/app/upload/page.tsx
@@ -7,6 +7,7 @@ import { DeleteButton } from "@/app/upload/_components/delete-button"
 import { RenameButton } from "@/app/upload/_components/rename-button"
 import { UploadListThumb } from "@/app/upload/_components/upload-list-thumb"
 import { UploadForm } from "@/app/upload/_components/upload-form"
+import { SignOutButton } from "@/components/sign-out-button"
 import { createClient } from "@/lib/supabase/server"
 import type { GalleryImage } from "@/lib/gallery/types"
 import { getGalleryImageUrl } from "@/lib/gallery/url"
@@ -33,6 +34,14 @@ export default async function UploadPage() {
       appHref="/"
       containerClassName="mx-auto w-full max-w-3xl px-6 py-24"
       cornerClassName="text-lg"
+      topRight={
+        <div className="flex items-center gap-4">
+          <Link href="/" className="transition-colors hover:text-foreground">
+            Gallery
+          </Link>
+          <SignOutButton />
+        </div>
+      }
       bottomLeft={
         <Link href="/" className="transition-colors hover:text-foreground">
           Back
@@ -42,10 +51,10 @@ export default async function UploadPage() {
       <div className="flex flex-col gap-16">
         <div className="flex flex-col gap-3">
           <h1 className="text-6xl tracking-tight italic md:text-7xl">
-            Your works
+            Manage works
           </h1>
           <p className="text-lg text-muted-foreground md:text-xl">
-            Upload your own. Rename or delete what no longer fits.
+            Upload your own. Edit names, delete, and keep your wall tidy.
           </p>
         </div>
 

--- a/apps/gallery/components/sign-out-button.tsx
+++ b/apps/gallery/components/sign-out-button.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import { useTransition } from "react"
+import { useRouter } from "next/navigation"
+
+import { Button } from "@workspace/ui/components/button"
+
+import { createClient } from "@/lib/supabase/client"
+
+export function SignOutButton() {
+  const [pending, startTransition] = useTransition()
+  const router = useRouter()
+
+  function onClick() {
+    startTransition(async () => {
+      const supabase = createClient()
+      await supabase.auth.signOut()
+      router.replace("/")
+      router.refresh()
+    })
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      onClick={onClick}
+      disabled={pending}
+      className="h-auto p-0 text-lg font-normal hover:bg-transparent"
+    >
+      {pending ? "Signing out…" : "Sign out"}
+    </Button>
+  )
+}

--- a/apps/gallery/lib/gallery/types.ts
+++ b/apps/gallery/lib/gallery/types.ts
@@ -7,4 +7,5 @@ export type GalleryImage = {
   created_at: string
   vote_count: number
   voted_by_me: boolean
+  voter_names: string[]
 }

--- a/apps/gallery/lib/gallery/types.ts
+++ b/apps/gallery/lib/gallery/types.ts
@@ -4,4 +4,6 @@ export type GalleryImage = {
   image_path: string
   created_by: string | null
   created_at: string
+  vote_count: number
+  voted_by_me: boolean
 }

--- a/apps/gallery/lib/gallery/types.ts
+++ b/apps/gallery/lib/gallery/types.ts
@@ -1,6 +1,7 @@
 export type GalleryImage = {
   id: string
   name: string
+  uploader_name: string
   image_path: string
   created_by: string | null
   created_at: string

--- a/supabase/migrations/2026-05-05-gallery-votes-delete-policy.sql
+++ b/supabase/migrations/2026-05-05-gallery-votes-delete-policy.sql
@@ -1,0 +1,6 @@
+-- allow users to remove only their own votes
+drop policy if exists "gallery_image_votes_delete" on public.gallery_image_votes;
+
+create policy "gallery_image_votes_delete"
+on public.gallery_image_votes for delete
+using (user_id = auth.uid());

--- a/supabase/migrations/2026-05-05-gallery-votes.sql
+++ b/supabase/migrations/2026-05-05-gallery-votes.sql
@@ -1,0 +1,28 @@
+-- gallery votes: each authenticated user can vote at most once per image.
+create table public.gallery_image_votes (
+  image_id    uuid not null references public.gallery_images(id) on delete cascade,
+  user_id     uuid not null references public.user_profiles(id) on delete cascade,
+  created_at  timestamptz not null default now(),
+  primary key (image_id, user_id)
+);
+
+create index gallery_image_votes_image_created_at
+  on public.gallery_image_votes (image_id, created_at desc);
+
+create index gallery_image_votes_user_created_at
+  on public.gallery_image_votes (user_id, created_at desc);
+
+alter table public.gallery_image_votes enable row level security;
+
+-- Read: public (same as gallery images).
+create policy "gallery_image_votes_select"
+on public.gallery_image_votes for select
+using (true);
+
+-- Insert: signed-in user can only write their own vote row.
+create policy "gallery_image_votes_insert"
+on public.gallery_image_votes for insert
+with check (
+  auth.uid() is not null
+  and user_id = auth.uid()
+);


### PR DESCRIPTION
## Summary

This PR upgrades `gallery` into a more complete community gallery experience: authenticated users can vote/unvote once per image, uploader and voter names are visible, upload is now batch-capable, and signed-in navigation includes a proper sign-out path.

## Why

Gallery usage moved beyond simple upload/view. We needed:
- fair voting rules (one user, one vote per image),
- accountability/transparency (real-name display for uploader and likes),
- better creator workflow (batch upload),
- cleaner signed-in UX (manage entry + sign out).

## What changed

- **Voting system (with one-vote-per-user-per-image)**
  - Added `gallery_image_votes` with `(image_id, user_id)` PK and RLS policies.
  - Added server actions for vote and unvote.
  - UI vote button now supports toggle (vote / remove vote) with optimistic local updates.

- **Real-name display**
  - Resolve uploader names from `user_profiles` and show `by <name>` on cards and lightbox.
  - Resolve voter names from `user_profiles` and show `Liked by ...` preview on cards/lightbox.

- **Manage/upload UX**
  - Upload page positioned as management page (wording + nav cleanup).
  - Added sign-out button on gallery/upload signed-in states.
  - Removed duplicate navigation path on upload page.

- **Batch upload**
  - Upload form now supports multi-file selection.
  - Per-file upload/registration result handling.
  - Single-file upload can use custom name input; multi-file mode falls back to filename-derived names.

- **Schema / DB**
  - Added migrations:
    - `2026-05-05-gallery-votes.sql`
    - `2026-05-05-gallery-votes-delete-policy.sql`
  - Note: local Supabase CLI migration history in this repo is not fully aligned with remote naming format; SQL was applied manually via Dashboard in current flow.

## Test plan

- [x] `bun run typecheck --filter=gallery`
- [ ] `bun run lint`
- [ ] `bun run build`
- [x] Dev server golden path manually tested:
  - sign in → manage
  - upload single + multi
  - rename/delete own work
  - vote once / remove vote
  - liked-by and uploader names render
  - sign out
- [ ] (UI changes) attach before/after screenshots
- [x] (DB/env changes) Supabase schema updated (gallery votes table + policies)

## Screenshots

- To be attached (before/after for gallery card metadata, vote chip, and manage/upload flow).

## Breaking changes

無。  
(Requires `gallery_image_votes` table + policies to exist in the connected Supabase project.)