### PR TITLE
chore: plug turbo remote cache into ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
   check:
     name: typecheck · lint · build
     runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v6
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,31 @@ bunx shadcn@latest add <name> -c apps/portal
 
 The file lands in `packages/ui/src/components/`. Don't manually copy primitives into `apps/portal/components/`.
 
+## Turborepo Remote Cache
+
+Builds (CI + your local machine) push and pull from a Vercel Remote Cache so
+unchanged packages don't rebuild twice. `.turbo/config.json` (local-only) holds
+your personal link — it's gitignored on purpose; everyone picks their own scope.
+
+**First-time setup** (per machine):
+
+```bash
+bunx turbo login   # opens browser, authorize Vercel
+bunx turbo link    # arrow keys → pick a Vercel scope (your account or a team)
+```
+
+After that, `bun run build` prints `Remote Caching enabled` and pulls cached
+artefacts when the inputs hash matches. Re-running an unchanged build prints
+`>>> FULL TURBO`.
+
+**CI side** runs against the maintainer's scope through `TURBO_TOKEN` (repo
+secret) and `TURBO_TEAM` (repo variable) in `.github/workflows/ci.yml`. Vercel
+preview/production deployments auto-inject the token via the git integration —
+no extra config there.
+
+> If your CI run says `Remote Caching disabled` and you didn't expect it, the
+> `TURBO_TOKEN` secret has probably been rotated or revoked. Ping `@zyx1121`.
+
 ## Reviewing pull requests
 
 **On your own PR**:


### PR DESCRIPTION
## Why

CI rebuilds the same packages on every push because Turborepo only sees a fresh
local cache each run. Hooking into Vercel Remote Cache means CI (and any
contributor who runs \`turbo login + link\`) shares cached build artefacts —
unchanged packages skip rebuild entirely. For a Next.js + multi-app monorepo
this is the difference between ~2 min and ~20 s on warm cache hits.

## What changed

- \`ci.yml\` — pass \`TURBO_TOKEN\` (secret) + \`TURBO_TEAM\` (repo variable) to
  the \`typecheck · lint · build\` job. No build commands changed.
- \`CONTRIBUTING.md\` — new \"Turborepo Remote Cache\" section documenting the
  one-time \`bunx turbo login\` + \`bunx turbo link\` per-machine ritual.
- \`.turbo/config.json\` stays gitignored on purpose so personal Vercel scopes
  don't leak into the repo. Each contributor picks their own.

## Required follow-up before this becomes useful

In repo settings:

- [ ] Add \`TURBO_TOKEN\` (secret) — value: a Vercel access token from
      https://vercel.com/account/tokens
- [ ] Add \`TURBO_TEAM\` (variable) — value: the Vercel team/account slug
      (e.g. \`zyx1121\` or whatever scope CI should push to)

Without those two, the CI keeps working exactly as before — \`turbo\` just
prints \`Remote Caching disabled\` and falls back to fresh builds.

## Test plan

- [x] \`bunx turbo build --dry\` locally prints \`• Remote caching enabled\`
- [ ] After secrets land, first CI run shows \`Remote caching enabled\` in build logs
- [ ] Second CI run on an unchanged commit shows \`>>> FULL TURBO\` cache hits