### PR TITLE
feat(receipts): tag library, search bar, and a way to label receipts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ npm-debug.log*
 
 # Git worktrees
 .worktrees/
+
+# Supabase CLI scratch
+supabase/.temp/

--- a/apps/portal/app/receipts/_components/receipts-view.tsx
+++ b/apps/portal/app/receipts/_components/receipts-view.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+import { Plus } from "lucide-react"
+import { useMemo, useState } from "react"
+
 import { Skeleton } from "@workspace/ui/components/skeleton"
 import {
   Table,
@@ -11,10 +14,14 @@ import {
 } from "@workspace/ui/components/table"
 
 import { useReceipts } from "@/hooks/receipts/use-receipts"
+import type { Receipt } from "@/lib/receipts/types"
 
 import { ReceiptPreviewDialog } from "./receipt-preview-dialog"
 import { ReceiptRowActions } from "./row-actions"
-import { StatusSelect } from "./status-select"
+import { ReceiptsSearchBar } from "./search-bar"
+import { STATUS_LABELS, StatusSelect } from "./status-select"
+import { TagBadge } from "./tag-badge"
+import { TagPickerPopover } from "./tag-picker-popover"
 import { UploadDialog } from "./upload-dialog"
 
 export function ReceiptsView() {
@@ -25,6 +32,12 @@ export function ReceiptsView() {
     refetch,
     isRefetching,
   } = useReceipts()
+  const [search, setSearch] = useState("")
+
+  const filtered = useMemo(
+    () => filterReceipts(receipts ?? [], search),
+    [receipts, search]
+  )
 
   return (
     <div className="flex flex-col gap-6">
@@ -33,12 +46,15 @@ export function ReceiptsView() {
         <UploadDialog />
       </div>
 
+      <ReceiptsSearchBar value={search} onChange={setSearch} />
+
       <div className="rounded-2xl border border-border">
         <Table>
           <TableHeader>
             <TableRow>
               <TableHead>名稱</TableHead>
               <TableHead className="w-20">檔案</TableHead>
+              <TableHead className="min-w-48">標籤</TableHead>
               <TableHead className="w-40">狀態</TableHead>
               <TableHead className="w-12 text-right">動作</TableHead>
             </TableRow>
@@ -49,7 +65,7 @@ export function ReceiptsView() {
             ) : !receipts || receipts.length === 0 ? (
               <TableRow>
                 <TableCell
-                  colSpan={4}
+                  colSpan={5}
                   className="py-10 text-center text-sm text-muted-foreground"
                 >
                   {error ? (
@@ -66,12 +82,45 @@ export function ReceiptsView() {
                   )}
                 </TableCell>
               </TableRow>
+            ) : filtered.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={5}
+                  className="py-10 text-center text-sm text-muted-foreground"
+                >
+                  找不到符合「{search}」的收據。
+                </TableCell>
+              </TableRow>
             ) : (
-              receipts.map((r) => (
+              filtered.map((r) => (
                 <TableRow key={r.id}>
                   <TableCell className="font-medium">{r.name}</TableCell>
                   <TableCell>
                     <ReceiptPreviewDialog path={r.imagePath} name={r.name} />
+                  </TableCell>
+                  <TableCell>
+                    <TagPickerPopover
+                      receiptId={r.id}
+                      attachedTagIds={r.tags.map((t) => t.id)}
+                      trigger={
+                        <button
+                          type="button"
+                          className="-mx-1 flex flex-wrap items-center gap-1.5 rounded-md px-1 py-1 hover:bg-muted/60"
+                          aria-label={`管理 ${r.name} 的標籤`}
+                        >
+                          {r.tags.length === 0 ? (
+                            <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                              <Plus className="size-3" />
+                              加標籤
+                            </span>
+                          ) : (
+                            r.tags.map((tag) => (
+                              <TagBadge key={tag.id} tag={tag} />
+                            ))
+                          )}
+                        </button>
+                      }
+                    />
                   </TableCell>
                   <TableCell>
                     <StatusSelect id={r.id} value={r.status} />
@@ -93,6 +142,22 @@ export function ReceiptsView() {
   )
 }
 
+function filterReceipts(receipts: Receipt[], search: string): Receipt[] {
+  const q = search.trim().toLowerCase()
+  if (!q) return receipts
+  return receipts.filter((r) => {
+    const haystack = [
+      r.name,
+      STATUS_LABELS[r.status],
+      r.status,
+      ...r.tags.map((t) => t.name),
+    ]
+      .join(" ")
+      .toLowerCase()
+    return haystack.includes(q)
+  })
+}
+
 function SkeletonRows() {
   return (
     <>
@@ -103,6 +168,9 @@ function SkeletonRows() {
           </TableCell>
           <TableCell>
             <Skeleton className="size-9 rounded-md" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-5 w-24 rounded-full" />
           </TableCell>
           <TableCell>
             <Skeleton className="h-9 w-32" />

--- a/apps/portal/app/receipts/_components/search-bar.tsx
+++ b/apps/portal/app/receipts/_components/search-bar.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { Search } from "lucide-react"
+
+import { Input } from "@workspace/ui/components/input"
+
+export function ReceiptsSearchBar({
+  value,
+  onChange,
+}: {
+  value: string
+  onChange: (next: string) => void
+}) {
+  return (
+    <div className="relative">
+      <Search className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+      <Input
+        placeholder="搜尋名稱、狀態或標籤…"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="pl-9"
+      />
+    </div>
+  )
+}

--- a/apps/portal/app/receipts/_components/status-select.tsx
+++ b/apps/portal/app/receipts/_components/status-select.tsx
@@ -14,11 +14,13 @@ import {
 import { useUpdateReceiptStatus } from "@/hooks/receipts/use-receipts"
 import type { ReceiptStatus } from "@/lib/receipts/types"
 
-const LABELS: Record<ReceiptStatus, string> = {
+export const STATUS_LABELS: Record<ReceiptStatus, string> = {
   pending: "審核中",
   approved: "審核完成",
   rejected: "已拒絕",
 }
+
+const LABELS = STATUS_LABELS
 
 const VARIANTS: Record<ReceiptStatus, "secondary" | "default" | "destructive"> =
   {

--- a/apps/portal/app/receipts/_components/tag-badge.tsx
+++ b/apps/portal/app/receipts/_components/tag-badge.tsx
@@ -1,0 +1,15 @@
+import { Badge } from "@workspace/ui/components/badge"
+
+import type { Tag, TagVariant } from "@/lib/receipts/types"
+
+const TAG_VARIANT_LABEL: Record<TagVariant, string> = {
+  default: "強調",
+  secondary: "一般",
+  outline: "弱化",
+}
+
+export function TagBadge({ tag }: { tag: Tag }) {
+  return <Badge variant={tag.variant}>{tag.name}</Badge>
+}
+
+export { TAG_VARIANT_LABEL }

--- a/apps/portal/app/receipts/_components/tag-picker-popover.tsx
+++ b/apps/portal/app/receipts/_components/tag-picker-popover.tsx
@@ -1,0 +1,209 @@
+"use client"
+
+import { Check, Plus, Tag as TagIcon, Trash2 } from "lucide-react"
+import { useState } from "react"
+import { toast } from "sonner"
+
+import { Badge } from "@workspace/ui/components/badge"
+import { Button } from "@workspace/ui/components/button"
+import { Input } from "@workspace/ui/components/input"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@workspace/ui/components/popover"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@workspace/ui/components/select"
+import { Skeleton } from "@workspace/ui/components/skeleton"
+
+import {
+  useCreateTag,
+  useDeleteTag,
+  useTags,
+  useToggleTag,
+} from "@/hooks/receipts/use-tags"
+import { TAG_VARIANTS, type Tag, type TagVariant } from "@/lib/receipts/types"
+
+import { TAG_VARIANT_LABEL } from "./tag-badge"
+
+export function TagPickerPopover({
+  receiptId,
+  attachedTagIds,
+  trigger,
+}: {
+  receiptId: string
+  attachedTagIds: string[]
+  trigger: React.ReactNode
+}) {
+  const [open, setOpen] = useState(false)
+  const { data: tags, isLoading } = useTags()
+  const toggle = useToggleTag()
+  const remove = useDeleteTag()
+
+  const attached = new Set(attachedTagIds)
+
+  const handleToggle = (tag: Tag) => {
+    const isAttached = attached.has(tag.id)
+    toggle.mutate(
+      { receiptId, tagId: tag.id, attached: isAttached },
+      {
+        onError: (err) => toast.error(`更新標籤失敗：${err.message}`),
+      }
+    )
+  }
+
+  const handleDelete = (tag: Tag) => {
+    remove.mutate(
+      { id: tag.id },
+      {
+        onSuccess: () => toast.success(`已刪除「${tag.name}」`),
+        onError: (err) => toast.error(`刪除失敗：${err.message}`),
+      }
+    )
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      <PopoverContent align="start" className="w-72 p-0">
+        <div className="flex flex-col">
+          <div className="px-3 py-2 text-xs font-medium text-muted-foreground">
+            標籤
+          </div>
+          <div className="max-h-64 overflow-y-auto">
+            {isLoading ? (
+              <div className="flex flex-col gap-2 px-3 pb-3">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <Skeleton key={i} className="h-7 rounded-md" />
+                ))}
+              </div>
+            ) : !tags || tags.length === 0 ? (
+              <p className="px-3 pb-3 text-xs text-muted-foreground">
+                還沒有標籤，下面建一個。
+              </p>
+            ) : (
+              tags.map((tag) => (
+                <TagRow
+                  key={tag.id}
+                  tag={tag}
+                  isAttached={attached.has(tag.id)}
+                  onToggle={() => handleToggle(tag)}
+                  onDelete={() => handleDelete(tag)}
+                />
+              ))
+            )}
+          </div>
+          <div className="border-t border-border" />
+          <CreateTagInline />
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+function TagRow({
+  tag,
+  isAttached,
+  onToggle,
+  onDelete,
+}: {
+  tag: Tag
+  isAttached: boolean
+  onToggle: () => void
+  onDelete: () => void
+}) {
+  return (
+    <div className="group flex items-center gap-2 px-3 py-1.5 hover:bg-muted">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex flex-1 items-center gap-2 text-left"
+      >
+        <span className="flex size-4 shrink-0 items-center justify-center text-muted-foreground">
+          {isAttached && <Check className="size-3.5" />}
+        </span>
+        <Badge variant={tag.variant}>{tag.name}</Badge>
+      </button>
+      <button
+        type="button"
+        onClick={onDelete}
+        className="text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 hover:text-destructive"
+        aria-label={`刪除標籤 ${tag.name}`}
+      >
+        <Trash2 className="size-3.5" />
+      </button>
+    </div>
+  )
+}
+
+function CreateTagInline() {
+  const [name, setName] = useState("")
+  const [variant, setVariant] = useState<TagVariant>("secondary")
+  const create = useCreateTag()
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    create.mutate(
+      { name, variant },
+      {
+        onSuccess: (tag) => {
+          toast.success(`已新增「${tag.name}」`)
+          setName("")
+        },
+        onError: (err) => toast.error(`新增失敗：${err.message}`),
+      }
+    )
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-2 p-3"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+        <TagIcon className="size-3.5" />
+        新增標籤
+      </div>
+      <Input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="標籤名稱"
+        className="h-8 text-sm"
+        disabled={create.isPending}
+      />
+      <div className="flex gap-2">
+        <Select
+          value={variant}
+          onValueChange={(v) => setVariant(v as TagVariant)}
+          disabled={create.isPending}
+        >
+          <SelectTrigger className="h-8 flex-1 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {TAG_VARIANTS.map((v) => (
+              <SelectItem key={v} value={v}>
+                {TAG_VARIANT_LABEL[v]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button
+          type="submit"
+          size="sm"
+          disabled={create.isPending || !name.trim()}
+          className="h-8"
+        >
+          <Plus className="size-3.5" />
+          新增
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/apps/portal/hooks/receipts/query-keys.ts
+++ b/apps/portal/hooks/receipts/query-keys.ts
@@ -2,6 +2,9 @@ export const queryKeys = {
   receipts: {
     all: ["receipts", "list"] as const,
   },
+  tags: {
+    all: ["receipts", "tags"] as const,
+  },
   admin: {
     status: ["receipts", "admin"] as const,
   },

--- a/apps/portal/hooks/receipts/use-receipts.ts
+++ b/apps/portal/hooks/receipts/use-receipts.ts
@@ -11,7 +11,7 @@ import {
 import {
   RECEIPTS_BUCKET,
   toReceipt,
-  type DatabaseReceipt,
+  type DatabaseReceiptWithTags,
   type Receipt,
   type ReceiptStatus,
 } from "@/lib/receipts/types"
@@ -21,6 +21,15 @@ import { queryKeys } from "./query-keys"
 const TABLE = "receipts"
 const SIGNED_URL_TTL = 60 * 60 // one hour — covers the time a tab stays open
 
+// Embed tags via the assignments join table; PostgREST returns
+// { receipt_tag_assignments: [{ receipt_tags: {...} }, ...] }
+const RECEIPT_WITH_TAGS_SELECT = `
+  *,
+  receipt_tag_assignments (
+    receipt_tags ( id, name, variant, created_by, created_at )
+  )
+`
+
 export function useReceipts() {
   const supabase = createClient()
   return useQuery({
@@ -28,13 +37,13 @@ export function useReceipts() {
     queryFn: async (): Promise<Receipt[]> => {
       const { data, error } = await supabase
         .from(TABLE)
-        .select("*")
+        .select(RECEIPT_WITH_TAGS_SELECT)
         .order("created_at", { ascending: false })
       if (error) {
         console.error("[receipts] list query failed", error)
         throw new Error(error.message || "讀取收據失敗")
       }
-      return (data as DatabaseReceipt[]).map(toReceipt)
+      return (data as unknown as DatabaseReceiptWithTags[]).map(toReceipt)
     },
     retry: 2,
   })
@@ -85,7 +94,7 @@ export function useUploadReceipt() {
         await supabase.storage.from(RECEIPTS_BUCKET).remove([path])
         throw error
       }
-      return toReceipt(data as DatabaseReceipt)
+      return toReceipt(data as unknown as DatabaseReceiptWithTags)
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: queryKeys.receipts.all })
@@ -108,7 +117,7 @@ export function useUpdateReceiptName() {
         .select()
         .single()
       if (error) throw error
-      return toReceipt(data as DatabaseReceipt)
+      return toReceipt(data as unknown as DatabaseReceiptWithTags)
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: queryKeys.receipts.all })
@@ -154,7 +163,7 @@ export function useUpdateReceiptStatus() {
         .select()
         .single()
       if (error) throw error
-      return toReceipt(data as DatabaseReceipt)
+      return toReceipt(data as unknown as DatabaseReceiptWithTags)
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: queryKeys.receipts.all })

--- a/apps/portal/hooks/receipts/use-tags.ts
+++ b/apps/portal/hooks/receipts/use-tags.ts
@@ -1,0 +1,122 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { createClient } from "@/lib/supabase/client"
+import {
+  toTag,
+  type DatabaseTag,
+  type Tag,
+  type TagVariant,
+} from "@/lib/receipts/types"
+
+import { queryKeys } from "./query-keys"
+
+const TAGS_TABLE = "receipt_tags"
+const ASSIGNMENTS_TABLE = "receipt_tag_assignments"
+
+export function useTags() {
+  const supabase = createClient()
+  return useQuery({
+    queryKey: queryKeys.tags.all,
+    queryFn: async (): Promise<Tag[]> => {
+      const { data, error } = await supabase
+        .from(TAGS_TABLE)
+        .select("*")
+        .order("name", { ascending: true })
+      if (error) {
+        console.error("[receipts] tag list query failed", error)
+        throw new Error(error.message || "讀取標籤失敗")
+      }
+      return (data as DatabaseTag[]).map(toTag)
+    },
+    retry: 2,
+  })
+}
+
+export function useCreateTag() {
+  const supabase = createClient()
+  const qc = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      name,
+      variant = "secondary",
+    }: {
+      name: string
+      variant?: TagVariant
+    }) => {
+      const trimmed = name.trim()
+      if (!trimmed) throw new Error("標籤名稱不能空白")
+      const { data, error } = await supabase
+        .from(TAGS_TABLE)
+        .insert({ name: trimmed, variant })
+        .select()
+        .single()
+      if (error) {
+        // 23505 = unique_violation; PostgREST surfaces it as "duplicate key…"
+        if (error.code === "23505") throw new Error(`「${trimmed}」已存在`)
+        throw error
+      }
+      return toTag(data as DatabaseTag)
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.tags.all })
+    },
+  })
+}
+
+export function useDeleteTag() {
+  const supabase = createClient()
+  const qc = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ id }: { id: string }) => {
+      const { error } = await supabase.from(TAGS_TABLE).delete().eq("id", id)
+      if (error) throw error
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.tags.all })
+      // assignments cascade-delete on the DB side; refetch receipts to drop
+      // the tag from any cards still showing it.
+      qc.invalidateQueries({ queryKey: queryKeys.receipts.all })
+    },
+  })
+}
+
+// Toggle whether a tag is attached to a receipt. We pass `attached` (current
+// state) so the mutation knows whether to insert or delete — saves a roundtrip
+// vs. checking server-side.
+export function useToggleTag() {
+  const supabase = createClient()
+  const qc = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      receiptId,
+      tagId,
+      attached,
+    }: {
+      receiptId: string
+      tagId: string
+      attached: boolean
+    }) => {
+      if (attached) {
+        const { error } = await supabase
+          .from(ASSIGNMENTS_TABLE)
+          .delete()
+          .eq("receipt_id", receiptId)
+          .eq("tag_id", tagId)
+        if (error) throw error
+      } else {
+        const { error } = await supabase
+          .from(ASSIGNMENTS_TABLE)
+          .insert({ receipt_id: receiptId, tag_id: tagId })
+        if (error) throw error
+      }
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.receipts.all })
+    },
+  })
+}

--- a/apps/portal/lib/receipts/types.ts
+++ b/apps/portal/lib/receipts/types.ts
@@ -1,5 +1,27 @@
 export type ReceiptStatus = "pending" | "approved" | "rejected"
 
+export type TagVariant = "default" | "secondary" | "outline"
+
+export const TAG_VARIANTS: TagVariant[] = ["default", "secondary", "outline"]
+
+export interface DatabaseTag {
+  id: string
+  name: string
+  variant: TagVariant
+  created_by: string | null
+  created_at: string
+}
+
+export interface Tag {
+  id: string
+  name: string
+  variant: TagVariant
+}
+
+export function toTag(row: DatabaseTag): Tag {
+  return { id: row.id, name: row.name, variant: row.variant }
+}
+
 export interface DatabaseReceipt {
   id: string
   name: string
@@ -8,6 +30,12 @@ export interface DatabaseReceipt {
   created_by: string | null
   created_at: string
   updated_at: string
+}
+
+// Shape returned when we embed tags via PostgREST:
+//   select(*, receipt_tag_assignments(receipt_tags(*)))
+export interface DatabaseReceiptWithTags extends DatabaseReceipt {
+  receipt_tag_assignments: { receipt_tags: DatabaseTag | null }[] | null
 }
 
 export interface InsertReceipt {
@@ -27,15 +55,21 @@ export interface Receipt {
   imagePath: string
   status: ReceiptStatus
   createdAt: string
+  tags: Tag[]
 }
 
-export function toReceipt(row: DatabaseReceipt): Receipt {
+export function toReceipt(row: DatabaseReceiptWithTags): Receipt {
+  const tags = (row.receipt_tag_assignments ?? [])
+    .map((a) => a.receipt_tags)
+    .filter((t): t is DatabaseTag => t !== null)
+    .map(toTag)
   return {
     id: row.id,
     name: row.name,
     imagePath: row.image_path,
     status: row.status,
     createdAt: row.created_at,
+    tags,
   }
 }
 

--- a/supabase/migrations/2026-05-06-receipts-tags.sql
+++ b/supabase/migrations/2026-05-06-receipts-tags.sql
@@ -1,0 +1,72 @@
+-- receipts app: tags.
+-- A reusable tag library plus a many-to-many between tags and receipts.
+-- Variant is grayscale-emphasis (default / secondary / outline) to stay
+-- inside portal's neutral design system — no hue tokens introduced.
+
+-- =============================================================================
+-- Tag library
+-- =============================================================================
+
+create table public.receipt_tags (
+  id         uuid primary key default gen_random_uuid(),
+  name       text not null,
+  variant    text not null default 'secondary'
+               check (variant in ('default', 'secondary', 'outline')),
+  created_by uuid references public.user_profiles(id) on delete set null,
+  created_at timestamptz not null default now()
+);
+
+-- Tag names are case-insensitively unique so "Travel" and "travel"
+-- can't both exist and confuse the picker.
+create unique index receipt_tags_name_unique
+  on public.receipt_tags (lower(name));
+
+-- =============================================================================
+-- Many-to-many between receipts and tags
+-- =============================================================================
+
+create table public.receipt_tag_assignments (
+  receipt_id uuid not null references public.receipts(id) on delete cascade,
+  tag_id     uuid not null references public.receipt_tags(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  primary key (receipt_id, tag_id)
+);
+
+create index receipt_tag_assignments_tag
+  on public.receipt_tag_assignments (tag_id);
+
+-- =============================================================================
+-- RLS — receipts admins only, same gate as the receipts table
+-- =============================================================================
+
+alter table public.receipt_tags enable row level security;
+alter table public.receipt_tag_assignments enable row level security;
+
+create policy "receipt_tags_select"
+on public.receipt_tags for select
+using (public.is_receipts_admin());
+
+create policy "receipt_tags_insert"
+on public.receipt_tags for insert
+with check (public.is_receipts_admin());
+
+create policy "receipt_tags_update"
+on public.receipt_tags for update
+using (public.is_receipts_admin())
+with check (public.is_receipts_admin());
+
+create policy "receipt_tags_delete"
+on public.receipt_tags for delete
+using (public.is_receipts_admin());
+
+create policy "receipt_tag_assignments_select"
+on public.receipt_tag_assignments for select
+using (public.is_receipts_admin());
+
+create policy "receipt_tag_assignments_insert"
+on public.receipt_tag_assignments for insert
+with check (public.is_receipts_admin());
+
+create policy "receipt_tag_assignments_delete"
+on public.receipt_tag_assignments for delete
+using (public.is_receipts_admin());


### PR DESCRIPTION
## Why

Receipts admins were stuck eyeballing rows to remember which receipt belonged to which trip / event / vendor — no grouping, no quick search. This PR gives them a reusable tag library and a fuzzy search across name / status / tags.

## What changed

**DB** — `supabase/migrations/2026-05-06-receipts-tags.sql`
- `receipt_tags` — id / name / variant (`default | secondary | outline`) / created_by / created_at. Case-insensitive unique index on name.
- `receipt_tag_assignments` — many-to-many between receipts and tags, both sides cascade-delete.
- RLS gates everything behind `is_receipts_admin()`, same line as the receipts table.

**Why grayscale-emphasis instead of hue colours**: portal's `globals.css` is fully neutral (chart colours included); the only chromatic token is `--destructive`. Introducing red/green/blue would be a hue palette that nothing else in portal has. Three emphasis levels deliver the visual-weight differentiation the feature needed without inventing a new design-system axis.

**Frontend**
- `lib/receipts/types.ts` — `Tag` / `TagVariant` / `Receipt.tags`; `toReceipt` flattens the embedded join shape.
- `hooks/receipts/use-tags.ts` — `useTags` / `useCreateTag` / `useDeleteTag` / `useToggleTag`. Unique-violation maps to a friendly toast.
- `hooks/receipts/use-receipts.ts` — list query embeds tags via `receipt_tag_assignments(receipt_tags(...))`.
- `app/receipts/_components/`
  - `tag-badge.tsx` — display only.
  - `tag-picker-popover.tsx` — toggle existing tags, hover-reveal delete, inline create with name + emphasis level.
  - `search-bar.tsx` — Search icon + Input, fuzzy-matches name / status label / tag names.
  - `receipts-view.tsx` — wires search, adds `標籤` column, distinguishes empty-list vs. nothing-matches copy.
  - `status-select.tsx` — exports `STATUS_LABELS` so search can reuse it.

## Test plan

- [x] `bun run typecheck` ✅
- [x] `bun run lint` ✅ (0 errors on new files; 15 pre-existing warnings in `reimburse/` / `approve/` / `theme-toggle.tsx` untouched)
- [ ] Apply migration via Supabase MCP / dashboard before the deploy lands on prod
- [ ] Click-through: create tag → attach → search by tag name → detach → delete tag (assignments cascade)
- [ ] Verify empty state still says "還沒有收據" not "找不到"

## Notes for reviewer

- Migration is **not yet applied** to the Supabase project — the feature stays inert until someone runs it. After merge, ping me to apply via MCP, or apply by hand.
- Search is single-input fuzzy; no facet filter (YAGNI). Easy to extend later if anyone asks.