### PR TITLE
feat(receipts): point-and-click status and tag filters next to the search box

### DIFF
--- a/apps/portal/app/receipts/_components/filter-chips.tsx
+++ b/apps/portal/app/receipts/_components/filter-chips.tsx
@@ -1,0 +1,100 @@
+"use client"
+
+import { Skeleton } from "@workspace/ui/components/skeleton"
+
+import { useTags } from "@/hooks/receipts/use-tags"
+import type { ReceiptStatus, Tag } from "@/lib/receipts/types"
+
+import { STATUS_LABELS } from "./status-select"
+
+const STATUSES: ReceiptStatus[] = ["pending", "approved", "rejected"]
+
+export function ReceiptsFilterChips({
+  selectedStatuses,
+  onToggleStatus,
+  selectedTagIds,
+  onToggleTag,
+}: {
+  selectedStatuses: Set<ReceiptStatus>
+  onToggleStatus: (status: ReceiptStatus) => void
+  selectedTagIds: Set<string>
+  onToggleTag: (tagId: string) => void
+}) {
+  const { data: tags, isLoading } = useTags()
+
+  return (
+    <div className="flex flex-col gap-2">
+      <FilterRow label="狀態">
+        {STATUSES.map((s) => (
+          <Chip
+            key={s}
+            label={STATUS_LABELS[s]}
+            active={selectedStatuses.has(s)}
+            onClick={() => onToggleStatus(s)}
+          />
+        ))}
+      </FilterRow>
+
+      <FilterRow label="標籤">
+        {isLoading ? (
+          <>
+            <Skeleton className="h-6 w-14 rounded-full" />
+            <Skeleton className="h-6 w-16 rounded-full" />
+            <Skeleton className="h-6 w-12 rounded-full" />
+          </>
+        ) : !tags || tags.length === 0 ? (
+          <span className="text-xs text-muted-foreground">尚無標籤</span>
+        ) : (
+          tags.map((tag: Tag) => (
+            <Chip
+              key={tag.id}
+              label={tag.name}
+              active={selectedTagIds.has(tag.id)}
+              onClick={() => onToggleTag(tag.id)}
+            />
+          ))
+        )}
+      </FilterRow>
+    </div>
+  )
+}
+
+function FilterRow({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <span className="mr-1 text-xs text-muted-foreground">{label}</span>
+      {children}
+    </div>
+  )
+}
+
+function Chip({
+  label,
+  active,
+  onClick,
+}: {
+  label: string
+  active: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={
+        active
+          ? "inline-flex h-6 items-center rounded-full bg-primary px-2.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          : "inline-flex h-6 items-center rounded-full border border-border px-2.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+      }
+    >
+      {label}
+    </button>
+  )
+}

--- a/apps/portal/app/receipts/_components/receipts-view.tsx
+++ b/apps/portal/app/receipts/_components/receipts-view.tsx
@@ -14,8 +14,9 @@ import {
 } from "@workspace/ui/components/table"
 
 import { useReceipts } from "@/hooks/receipts/use-receipts"
-import type { Receipt } from "@/lib/receipts/types"
+import type { Receipt, ReceiptStatus } from "@/lib/receipts/types"
 
+import { ReceiptsFilterChips } from "./filter-chips"
 import { ReceiptPreviewDialog } from "./receipt-preview-dialog"
 import { ReceiptRowActions } from "./row-actions"
 import { ReceiptsSearchBar } from "./search-bar"
@@ -33,11 +34,28 @@ export function ReceiptsView() {
     isRefetching,
   } = useReceipts()
   const [search, setSearch] = useState("")
+  const [selectedStatuses, setSelectedStatuses] = useState<Set<ReceiptStatus>>(
+    new Set()
+  )
+  const [selectedTagIds, setSelectedTagIds] = useState<Set<string>>(new Set())
 
   const filtered = useMemo(
-    () => filterReceipts(receipts ?? [], search),
-    [receipts, search]
+    () =>
+      filterReceipts(receipts ?? [], {
+        search,
+        selectedStatuses,
+        selectedTagIds,
+      }),
+    [receipts, search, selectedStatuses, selectedTagIds]
   )
+
+  const toggleStatus = (s: ReceiptStatus) =>
+    setSelectedStatuses((prev) => toggleSet(prev, s))
+  const toggleTag = (id: string) =>
+    setSelectedTagIds((prev) => toggleSet(prev, id))
+
+  const hasActiveFilter =
+    !!search.trim() || selectedStatuses.size > 0 || selectedTagIds.size > 0
 
   return (
     <div className="flex flex-col gap-6">
@@ -46,7 +64,15 @@ export function ReceiptsView() {
         <UploadDialog />
       </div>
 
-      <ReceiptsSearchBar value={search} onChange={setSearch} />
+      <div className="flex flex-col gap-3">
+        <ReceiptsSearchBar value={search} onChange={setSearch} />
+        <ReceiptsFilterChips
+          selectedStatuses={selectedStatuses}
+          onToggleStatus={toggleStatus}
+          selectedTagIds={selectedTagIds}
+          onToggleTag={toggleTag}
+        />
+      </div>
 
       <div className="rounded-2xl border border-border">
         <Table>
@@ -88,7 +114,9 @@ export function ReceiptsView() {
                   colSpan={5}
                   className="py-10 text-center text-sm text-muted-foreground"
                 >
-                  找不到符合「{search}」的收據。
+                  {hasActiveFilter
+                    ? "找不到符合篩選條件的收據。"
+                    : "（沒有資料。）"}
                 </TableCell>
               </TableRow>
             ) : (
@@ -142,10 +170,28 @@ export function ReceiptsView() {
   )
 }
 
-function filterReceipts(receipts: Receipt[], search: string): Receipt[] {
+function filterReceipts(
+  receipts: Receipt[],
+  {
+    search,
+    selectedStatuses,
+    selectedTagIds,
+  }: {
+    search: string
+    selectedStatuses: Set<ReceiptStatus>
+    selectedTagIds: Set<string>
+  }
+): Receipt[] {
   const q = search.trim().toLowerCase()
-  if (!q) return receipts
   return receipts.filter((r) => {
+    if (selectedStatuses.size > 0 && !selectedStatuses.has(r.status))
+      return false
+    if (selectedTagIds.size > 0) {
+      const owned = new Set(r.tags.map((t) => t.id))
+      const anyHit = [...selectedTagIds].some((id) => owned.has(id))
+      if (!anyHit) return false
+    }
+    if (!q) return true
     const haystack = [
       r.name,
       STATUS_LABELS[r.status],
@@ -156,6 +202,13 @@ function filterReceipts(receipts: Receipt[], search: string): Receipt[] {
       .toLowerCase()
     return haystack.includes(q)
   })
+}
+
+function toggleSet<T>(prev: Set<T>, value: T): Set<T> {
+  const next = new Set(prev)
+  if (next.has(value)) next.delete(value)
+  else next.add(value)
+  return next
 }
 
 function SkeletonRows() {


### PR DESCRIPTION
## Why

Typing a tag name to filter felt off — once you have a known set of tags and a fixed set of statuses, picking from a list is faster and avoids typos. The free-text search stays for full-text matching across name + status + tag names.

## What changed

- **`filter-chips.tsx`** (new) — two rows of toggleable chips: 狀態 (3 statuses) and 標籤 (all tags from `useTags`). Active chip = `bg-primary` filled; inactive = `outline`. Skeletons while tags load. Empty-state copy when no tags exist.
- **`receipts-view.tsx`** — adds `selectedStatuses: Set<ReceiptStatus>` and `selectedTagIds: Set<string>`. Filter logic is AND across all three axes:
  1. status whitelist (if any selected)
  2. tag whitelist — receipt must have **at least one** of the selected tags (OR within axis)
  3. text search (existing fuzzy match)
- Empty-state copy distinguishes "no data" from "filtered out".

## Design system note

Chips use `--primary` / `outline` variants — staying inside the grayscale token set, no new hue tokens introduced. Same emphasis logic as the tag badges themselves.

## Test plan

- [x] `bun run typecheck` ✅
- [x] `bun run lint` ✅
- [ ] Toggle a status chip → list narrows; toggle off → restores
- [ ] Multi-select two tags → see receipts that have **either** tag
- [ ] Combine search "a" + status "approved" + a tag → AND semantics work
- [ ] Empty-state copy correct for: no data, all filtered out, search-only no match