### PR TITLE
fix(receipts): nudge filter chips to line up with the search box and table

### DIFF
--- a/apps/portal/app/receipts/_components/filter-chips.tsx
+++ b/apps/portal/app/receipts/_components/filter-chips.tsx
@@ -23,7 +23,7 @@ export function ReceiptsFilterChips({
   const { data: tags, isLoading } = useTags()
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-2 pl-3">
       <FilterRow label="狀態">
         {STATUSES.map((s) => (
           <Chip


### PR DESCRIPTION
## Why

Filter chips were hugging the container's left edge while the search box and table sit inside their own borders — visually the chips poked out one row at a time.

## What changed

`pl-3` on the chip column so 「狀態」/「標籤」 labels start where the eye expects after the search input above them.

## Test plan

- [x] typecheck / lint ✅
- [ ] Eyeball — chip row left edge no longer visually escapes the search box's column