### PR TITLE
feat: tidy admin actions and align page headers across apps

### DIFF
--- a/apps/portal/app/meetings/_components/schedule-tab.tsx
+++ b/apps/portal/app/meetings/_components/schedule-tab.tsx
@@ -23,7 +23,6 @@ import { useMeetingsAdmin } from "@/hooks/meetings/use-meetings-admin"
 import { useLabUsers } from "@/hooks/meetings/use-lab-users"
 import type { Meeting } from "@/lib/meetings/types"
 
-import { AddMeetingDialog } from "./add-meeting-dialog"
 import { MeetingEditDialog } from "./meeting-edit-dialog"
 
 function getCurrentWeekId(meetings: Meeting[]): string | null {
@@ -58,7 +57,6 @@ export function ScheduleTab({ year }: { year: number }) {
   const deleteMeeting = useDeleteMeeting()
   const claimMeeting = useClaimMeeting()
 
-  const [addOpen, setAddOpen] = useState(false)
   const [editTarget, setEditTarget] = useState<Meeting | null>(null)
 
   const currentWeekId = getCurrentWeekId(meetings)
@@ -69,14 +67,6 @@ export function ScheduleTab({ year }: { year: number }) {
 
   return (
     <div className="flex flex-col gap-4">
-      {isAdmin && (
-        <div className="flex justify-end">
-          <Button size="sm" onClick={() => setAddOpen(true)}>
-            新增週次
-          </Button>
-        </div>
-      )}
-
       <div className="overflow-x-auto rounded-md border">
         <Table>
           <TableHeader>
@@ -196,14 +186,6 @@ export function ScheduleTab({ year }: { year: number }) {
           </TableBody>
         </Table>
       </div>
-
-      {isAdmin && (
-        <AddMeetingDialog
-          year={year}
-          open={addOpen}
-          onOpenChange={setAddOpen}
-        />
-      )}
 
       {editTarget && (
         <MeetingEditDialog

--- a/apps/portal/app/meetings/page.tsx
+++ b/apps/portal/app/meetings/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useRouter, useSearchParams } from "next/navigation"
+import { useState } from "react"
 
 import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react"
 import { Button } from "@workspace/ui/components/button"
@@ -11,6 +12,9 @@ import {
   TabsTrigger,
 } from "@workspace/ui/components/tabs"
 
+import { useMeetingsAdmin } from "@/hooks/meetings/use-meetings-admin"
+
+import { AddMeetingDialog } from "./_components/add-meeting-dialog"
 import { InfoTab } from "./_components/info-tab"
 import { PapersTab } from "./_components/papers-tab"
 import { ScheduleTab } from "./_components/schedule-tab"
@@ -21,6 +25,10 @@ export default function MeetingsPage() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const year = Number(searchParams.get("year")) || CURRENT_YEAR
+  const { isAdmin } = useMeetingsAdmin()
+
+  const [activeTab, setActiveTab] = useState("schedule")
+  const [addOpen, setAddOpen] = useState(false)
 
   function setYear(y: number) {
     const params = new URLSearchParams(searchParams.toString())
@@ -28,14 +36,23 @@ export default function MeetingsPage() {
     router.push(`?${params.toString()}`)
   }
 
+  const showAddButton = isAdmin && activeTab === "schedule"
+
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex flex-col gap-1">
-        <h1 className="font-medium">Lab Meetings</h1>
-        <p className="text-sm text-muted-foreground">WinLab 每週報告排班</p>
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-1">
+          <h1 className="font-medium">Lab Meetings</h1>
+          <p className="text-sm text-muted-foreground">WinLab 每週報告排班</p>
+        </div>
+        {showAddButton && (
+          <Button size="sm" onClick={() => setAddOpen(true)}>
+            新增週次
+          </Button>
+        )}
       </div>
 
-      <Tabs defaultValue="schedule">
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabsList>
           <TabsTrigger value="schedule">排班表</TabsTrigger>
           <TabsTrigger value="papers">老師 Papers</TabsTrigger>
@@ -75,6 +92,14 @@ export default function MeetingsPage() {
           <InfoTab />
         </TabsContent>
       </Tabs>
+
+      {isAdmin && (
+        <AddMeetingDialog
+          year={year}
+          open={addOpen}
+          onOpenChange={setAddOpen}
+        />
+      )}
     </div>
   )
 }

--- a/apps/portal/app/receipts/_components/receipts-view.tsx
+++ b/apps/portal/app/receipts/_components/receipts-view.tsx
@@ -59,8 +59,13 @@ export function ReceiptsView() {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center justify-between gap-4">
-        <h1 className="text-2xl font-medium">收據</h1>
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-1">
+          <h1 className="font-medium">收據</h1>
+          <p className="text-sm text-muted-foreground">
+            報帳憑證管理。上傳、加標籤、追蹤狀態。
+          </p>
+        </div>
         <UploadDialog />
       </div>
 

--- a/apps/portal/app/trip/_components/edit-trip-dialog.tsx
+++ b/apps/portal/app/trip/_components/edit-trip-dialog.tsx
@@ -1,0 +1,107 @@
+"use client"
+
+import { useState } from "react"
+import { toast } from "sonner"
+
+import { Button } from "@workspace/ui/components/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@workspace/ui/components/dialog"
+import { Input } from "@workspace/ui/components/input"
+import { Label } from "@workspace/ui/components/label"
+import { Textarea } from "@workspace/ui/components/textarea"
+
+import { useUpdateTrip } from "@/hooks/trip/use-trips"
+
+export function EditTripDialog({
+  id,
+  name,
+  description,
+  onClose,
+}: {
+  id: string
+  name: string
+  description: string | null
+  onClose: () => void
+}) {
+  const [draftName, setDraftName] = useState(name)
+  const [draftDesc, setDraftDesc] = useState(description ?? "")
+  const update = useUpdateTrip()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const next = draftName.trim()
+    if (!next) return
+    try {
+      await update.mutateAsync({
+        id,
+        name: next,
+        description: draftDesc.trim() || null,
+      })
+      toast.success("已儲存")
+      onClose()
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "儲存失敗")
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={(next) => !next && onClose()}>
+      <DialogContent>
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>編輯 Trip</DialogTitle>
+            <DialogDescription>改名稱或說明，檔案不會動到。</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="trip-name-edit">
+                名稱 <span className="text-destructive">*</span>
+              </Label>
+              <Input
+                id="trip-name-edit"
+                value={draftName}
+                onChange={(e) => setDraftName(e.target.value)}
+                disabled={update.isPending}
+                required
+                autoFocus
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="trip-desc-edit">說明</Label>
+              <Textarea
+                id="trip-desc-edit"
+                value={draftDesc}
+                onChange={(e) => setDraftDesc(e.target.value)}
+                placeholder="日期、補助上限、特別說明…"
+                rows={3}
+                disabled={update.isPending}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onClose}
+              disabled={update.isPending}
+            >
+              取消
+            </Button>
+            <Button
+              type="submit"
+              disabled={update.isPending || !draftName.trim()}
+            >
+              {update.isPending ? "儲存中…" : "儲存"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/portal/app/trip/_components/trip-card.tsx
+++ b/apps/portal/app/trip/_components/trip-card.tsx
@@ -1,42 +1,15 @@
 "use client"
 
-import { Lock, LockOpen, Trash2 } from "lucide-react"
 import Link from "next/link"
-import { toast } from "sonner"
 
 import { Badge } from "@workspace/ui/components/badge"
-import { Button } from "@workspace/ui/components/button"
 
-import { useDeleteTrip, useSetTripStatus } from "@/hooks/trip/use-trips"
 import type { Trip } from "@/lib/trip/types"
 
-import { ConfirmDialog } from "./confirm-dialog"
+import { TripRowActions } from "./trip-row-actions"
 
 export function TripCard({ trip, isAdmin }: { trip: Trip; isAdmin: boolean }) {
-  const setStatus = useSetTripStatus()
-  const deleteTrip = useDeleteTrip()
   const isOpen = trip.status === "open"
-
-  const handleToggle = async () => {
-    try {
-      await setStatus.mutateAsync({
-        id: trip.id,
-        status: isOpen ? "closed" : "open",
-      })
-      toast.success(isOpen ? "已關閉" : "已重新開啟")
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "切換失敗")
-    }
-  }
-
-  const handleDelete = async () => {
-    try {
-      await deleteTrip.mutateAsync(trip.id)
-      toast.success("已刪除")
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "刪除失敗")
-    }
-  }
 
   return (
     <div className="flex items-center gap-3 rounded-xl border border-border bg-card p-4">
@@ -54,51 +27,7 @@ export function TripCard({ trip, isAdmin }: { trip: Trip; isAdmin: boolean }) {
       <Badge variant="outline" className="shrink-0 text-xs">
         {isOpen ? "進行中" : "已關閉"}
       </Badge>
-      {isAdmin && (
-        <>
-          <ConfirmDialog
-            trigger={
-              <Button
-                size="icon"
-                variant="ghost"
-                className="size-8 shrink-0 text-muted-foreground"
-                aria-label={isOpen ? "關閉 trip" : "重新開啟 trip"}
-              >
-                {isOpen ? (
-                  <Lock className="size-4" />
-                ) : (
-                  <LockOpen className="size-4" />
-                )}
-              </Button>
-            }
-            title={isOpen ? "關閉這個 trip？" : "重新開啟這個 trip？"}
-            description={
-              isOpen
-                ? "關閉後成員無法再上傳/修改/刪除自己的檔案。"
-                : "重新開啟後成員可以繼續上傳。"
-            }
-            confirmText={isOpen ? "關閉" : "開啟"}
-            onConfirm={handleToggle}
-          />
-          <ConfirmDialog
-            trigger={
-              <Button
-                size="icon"
-                variant="ghost"
-                className="size-8 shrink-0 text-muted-foreground"
-                aria-label="刪除 trip"
-              >
-                <Trash2 className="size-4" />
-              </Button>
-            }
-            title="刪除這個 trip？"
-            description={`${trip.name} — 連同所有成員上傳的檔案一起被刪掉，無法復原。`}
-            confirmText="刪除"
-            variant="destructive"
-            onConfirm={handleDelete}
-          />
-        </>
-      )}
+      {isAdmin && <TripRowActions trip={trip} />}
     </div>
   )
 }

--- a/apps/portal/app/trip/_components/trip-row-actions.tsx
+++ b/apps/portal/app/trip/_components/trip-row-actions.tsx
@@ -1,0 +1,168 @@
+"use client"
+
+import { Lock, LockOpen, MoreHorizontal, Pencil, Trash2 } from "lucide-react"
+import { useState } from "react"
+import { toast } from "sonner"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@workspace/ui/components/alert-dialog"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@workspace/ui/components/dropdown-menu"
+
+import { useDeleteTrip, useSetTripStatus } from "@/hooks/trip/use-trips"
+import type { Trip } from "@/lib/trip/types"
+
+import { EditTripDialog } from "./edit-trip-dialog"
+
+export function TripRowActions({ trip }: { trip: Trip }) {
+  const [editOpen, setEditOpen] = useState(false)
+  const [toggleOpen, setToggleOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+
+  const setStatus = useSetTripStatus()
+  const deleteTrip = useDeleteTrip()
+  const isOpen = trip.status === "open"
+
+  const handleToggle = async () => {
+    try {
+      await setStatus.mutateAsync({
+        id: trip.id,
+        status: isOpen ? "closed" : "open",
+      })
+      toast.success(isOpen ? "已關閉" : "已重新開啟")
+      setToggleOpen(false)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "切換失敗")
+    }
+  }
+
+  const handleDelete = async () => {
+    try {
+      await deleteTrip.mutateAsync(trip.id)
+      toast.success("已刪除")
+      setDeleteOpen(false)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "刪除失敗")
+    }
+  }
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="inline-flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            aria-label={`動作 — ${trip.name}`}
+          >
+            <MoreHorizontal className="size-4" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onSelect={() => setEditOpen(true)}>
+            <Pencil className="size-4" />
+            編輯
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setToggleOpen(true)}>
+            {isOpen ? (
+              <>
+                <Lock className="size-4" />
+                關閉
+              </>
+            ) : (
+              <>
+                <LockOpen className="size-4" />
+                重新開啟
+              </>
+            )}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onSelect={() => setDeleteOpen(true)}
+            className="text-destructive focus:text-destructive"
+          >
+            <Trash2 className="size-4" />
+            刪除
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {editOpen && (
+        <EditTripDialog
+          id={trip.id}
+          name={trip.name}
+          description={trip.description}
+          onClose={() => setEditOpen(false)}
+        />
+      )}
+
+      <AlertDialog open={toggleOpen} onOpenChange={setToggleOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {isOpen ? "關閉這個 trip？" : "重新開啟這個 trip？"}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {isOpen
+                ? "關閉後成員無法再上傳/修改/刪除自己的檔案。"
+                : "重新開啟後成員可以繼續上傳。"}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={setStatus.isPending}>
+              取消
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault()
+                void handleToggle()
+              }}
+              disabled={setStatus.isPending}
+            >
+              {setStatus.isPending ? "處理中..." : isOpen ? "關閉" : "開啟"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>刪除這個 trip？</AlertDialogTitle>
+            <AlertDialogDescription>
+              {trip.name} — 連同所有成員上傳的檔案一起被刪掉，無法復原。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteTrip.isPending}>
+              取消
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault()
+                void handleDelete()
+              }}
+              disabled={deleteTrip.isPending}
+              className="text-destructive-foreground bg-destructive hover:bg-destructive/90"
+            >
+              {deleteTrip.isPending ? "處理中..." : "刪除"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}

--- a/apps/portal/hooks/trip/use-trips.ts
+++ b/apps/portal/hooks/trip/use-trips.ts
@@ -66,6 +66,34 @@ export function useCreateTrip() {
   })
 }
 
+export function useUpdateTrip() {
+  const supabase = createClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (params: {
+      id: string
+      name: string
+      description?: string | null
+    }) => {
+      const { data, error } = await supabase
+        .from("trips")
+        .update({
+          name: params.name,
+          description: params.description ?? null,
+        })
+        .eq("id", params.id)
+        .select()
+        .single()
+      if (error) throw error
+      return data as Trip
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.trips.all })
+    },
+  })
+}
+
 export function useSetTripStatus() {
   const supabase = createClient()
   const queryClient = useQueryClient()


### PR DESCRIPTION
## Why

Three small inconsistencies were nagging at the admin UX:

1. **trip** had two separate icon buttons (lock + delete) that broke the receipts-style `...` row-actions pattern, and admins could only delete trips — not rename them.
2. **/receipts** title was `text-2xl font-medium` with no description; every other app uses plain `font-medium` + a description line.
3. **/meetings** had `新增週次` floating above the table, when primary admin actions belong in the page title row (like trip / leave / bento).

## What changed

### trip — proper `...` row actions
- Add `useUpdateTrip` hook for name + description
- Add `EditTripDialog` (mirrors `EditReceiptDialog`)
- Add `TripRowActions` — one `...` dropdown with **編輯** / **關閉(or 重新開啟)** / **刪除**
- `TripCard` admin block: two icon buttons → one dropdown

### receipts — heading aligned to design system
- `text-2xl font-medium` → `font-medium`
- Wrap in `flex flex-col gap-1` with a description line
- Drop the now-redundant `gap-4`

### meetings — `新增週次` moved to title row
- `Tabs` is now controlled via `activeTab` state
- `addOpen` + `AddMeetingDialog` lifted to `page.tsx`
- Title row renders the button only when `isAdmin && activeTab === "schedule"`
- `schedule-tab.tsx` no longer owns the button

## Test plan

- [x] `bun run typecheck --filter=portal` — green
- [x] `bun run lint --filter=portal` — 0 errors (19 pre-existing warnings, none in changed files)
- [x] `bun run build --filter=portal` — green
- [ ] Click-through on /trip — admin sees `...` menu, edit dialog saves name/desc, lock/delete still work
- [ ] Click-through on /receipts — title looks like other apps
- [ ] Click-through on /meetings — `新增週次` only shows in title row when on schedule tab as admin