### PR TITLE
chore: sweep stragglers into the page-header design system

### DIFF
--- a/apps/portal/app/admin/_components/user-management.tsx
+++ b/apps/portal/app/admin/_components/user-management.tsx
@@ -55,7 +55,7 @@ export function UserManagement() {
   }
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-10">
       <div className="flex flex-col gap-1">
         <h1 className="font-medium">用戶管理</h1>
         <p className="text-sm text-muted-foreground">

--- a/apps/portal/app/debt/_components/debt-home.tsx
+++ b/apps/portal/app/debt/_components/debt-home.tsx
@@ -38,35 +38,38 @@ export function DebtHome() {
   }
 
   return (
-    <div className="grid gap-6">
-      <section>
-        <BalanceOverview
-          iOwe={balances?.iOwe ?? []}
-          owedToMe={balances?.owedToMe ?? []}
-        />
-      </section>
-
-      <section>
-        <div className="mb-3 flex items-center justify-between">
-          <h2 className="text-sm font-medium">我的分帳</h2>
-          {!showForm && (
-            <Button size="sm" onClick={handleNew}>
-              <IconPlus />
-              新增
-            </Button>
-          )}
+    <div className="flex flex-col gap-10">
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-1">
+          <h1 className="font-medium">Debt</h1>
+          <p className="text-sm text-muted-foreground">
+            實驗室分帳。每月 10 號自動產生上個月的淨額結算。
+          </p>
         </div>
+        {!showForm && (
+          <Button size="sm" onClick={handleNew}>
+            <IconPlus />
+            新增分帳
+          </Button>
+        )}
+      </div>
+
+      <BalanceOverview
+        iOwe={balances?.iOwe ?? []}
+        owedToMe={balances?.owedToMe ?? []}
+      />
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-sm font-medium">我的分帳</h2>
 
         {showForm && (
-          <div className="mb-4">
-            <ExpenseForm expense={editingExpense} onClose={handleClose} />
-          </div>
+          <ExpenseForm expense={editingExpense} onClose={handleClose} />
         )}
 
         {!expenses || expenses.length === 0 ? (
           <p className="text-xs text-muted-foreground">還沒有任何分帳紀錄</p>
         ) : (
-          <div className="grid gap-1">
+          <div className="flex flex-col gap-1">
             {expenses.map((expense) => (
               <ExpenseCard
                 key={expense.id}

--- a/apps/portal/app/debt/settlements/page.tsx
+++ b/apps/portal/app/debt/settlements/page.tsx
@@ -2,7 +2,7 @@ import { SettlementsList } from "../_components/settlements-list"
 
 export default function DebtSettlementsPage() {
   return (
-    <div className="grid gap-6">
+    <div className="flex flex-col gap-10">
       <div className="flex flex-col gap-1">
         <h1 className="font-medium">結算單</h1>
         <p className="text-sm text-muted-foreground">

--- a/apps/portal/app/meetings/_components/papers-tab.tsx
+++ b/apps/portal/app/meetings/_components/papers-tab.tsx
@@ -1,7 +1,5 @@
 "use client"
 
-import { useState } from "react"
-
 import { Button } from "@workspace/ui/components/button"
 import {
   Table,
@@ -18,88 +16,75 @@ import {
 } from "@/hooks/meetings/use-teacher-papers"
 import { useMeetingsAdmin } from "@/hooks/meetings/use-meetings-admin"
 
-import { AddPaperDialog } from "./add-paper-dialog"
-
 export function PapersTab() {
   const { isAdmin } = useMeetingsAdmin()
   const { data: papers = [], isLoading } = useTeacherPapers()
   const deletePaper = useDeleteTeacherPaper()
-  const [addOpen, setAddOpen] = useState(false)
 
   if (isLoading) {
     return <p className="text-sm text-muted-foreground">載入中…</p>
   }
 
+  if (papers.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">尚無老師提供的 papers。</p>
+    )
+  }
+
   return (
-    <div className="flex flex-col gap-4">
-      {isAdmin && (
-        <div className="flex justify-end">
-          <Button size="sm" onClick={() => setAddOpen(true)}>
-            新增
-          </Button>
-        </div>
-      )}
-
-      {papers.length === 0 ? (
-        <p className="text-sm text-muted-foreground">尚無老師提供的 papers。</p>
-      ) : (
-        <div className="overflow-x-auto rounded-md border">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-24">日期</TableHead>
-                <TableHead>Paper 名稱</TableHead>
-                <TableHead className="w-20">來源</TableHead>
-                <TableHead className="w-16" />
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {papers.map((p) => (
-                <TableRow key={p.id}>
-                  <TableCell className="text-xs text-muted-foreground">
-                    {new Date(p.providedDate).toLocaleDateString("zh-TW", {
-                      year: "numeric",
-                      month: "numeric",
-                      day: "numeric",
-                    })}
-                  </TableCell>
-                  <TableCell>
-                    {p.fileLink ? (
-                      <a
-                        href={p.fileLink}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-sm hover:underline"
-                      >
-                        {p.paperName}
-                      </a>
-                    ) : (
-                      <span className="text-sm">{p.paperName}</span>
-                    )}
-                  </TableCell>
-                  <TableCell className="text-xs text-muted-foreground">
-                    {p.source ?? "—"}
-                  </TableCell>
-                  <TableCell>
-                    {isAdmin && (
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        className="h-7 px-2 text-xs text-destructive hover:text-destructive"
-                        onClick={() => deletePaper.mutate(p.id)}
-                      >
-                        刪除
-                      </Button>
-                    )}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
-      )}
-
-      {isAdmin && <AddPaperDialog open={addOpen} onOpenChange={setAddOpen} />}
+    <div className="overflow-x-auto rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-24">日期</TableHead>
+            <TableHead>Paper 名稱</TableHead>
+            <TableHead className="w-20">來源</TableHead>
+            <TableHead className="w-16" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {papers.map((p) => (
+            <TableRow key={p.id}>
+              <TableCell className="text-xs text-muted-foreground">
+                {new Date(p.providedDate).toLocaleDateString("zh-TW", {
+                  year: "numeric",
+                  month: "numeric",
+                  day: "numeric",
+                })}
+              </TableCell>
+              <TableCell>
+                {p.fileLink ? (
+                  <a
+                    href={p.fileLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm hover:underline"
+                  >
+                    {p.paperName}
+                  </a>
+                ) : (
+                  <span className="text-sm">{p.paperName}</span>
+                )}
+              </TableCell>
+              <TableCell className="text-xs text-muted-foreground">
+                {p.source ?? "—"}
+              </TableCell>
+              <TableCell>
+                {isAdmin && (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 px-2 text-xs text-destructive hover:text-destructive"
+                    onClick={() => deletePaper.mutate(p.id)}
+                  >
+                    刪除
+                  </Button>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
     </div>
   )
 }

--- a/apps/portal/app/meetings/page.tsx
+++ b/apps/portal/app/meetings/page.tsx
@@ -15,6 +15,7 @@ import {
 import { useMeetingsAdmin } from "@/hooks/meetings/use-meetings-admin"
 
 import { AddMeetingDialog } from "./_components/add-meeting-dialog"
+import { AddPaperDialog } from "./_components/add-paper-dialog"
 import { InfoTab } from "./_components/info-tab"
 import { PapersTab } from "./_components/papers-tab"
 import { ScheduleTab } from "./_components/schedule-tab"
@@ -28,7 +29,8 @@ export default function MeetingsPage() {
   const { isAdmin } = useMeetingsAdmin()
 
   const [activeTab, setActiveTab] = useState("schedule")
-  const [addOpen, setAddOpen] = useState(false)
+  const [addMeetingOpen, setAddMeetingOpen] = useState(false)
+  const [addPaperOpen, setAddPaperOpen] = useState(false)
 
   function setYear(y: number) {
     const params = new URLSearchParams(searchParams.toString())
@@ -36,18 +38,21 @@ export default function MeetingsPage() {
     router.push(`?${params.toString()}`)
   }
 
-  const showAddButton = isAdmin && activeTab === "schedule"
-
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-10">
       <div className="flex items-center justify-between">
         <div className="flex flex-col gap-1">
           <h1 className="font-medium">Lab Meetings</h1>
           <p className="text-sm text-muted-foreground">WinLab 每週報告排班</p>
         </div>
-        {showAddButton && (
-          <Button size="sm" onClick={() => setAddOpen(true)}>
+        {isAdmin && activeTab === "schedule" && (
+          <Button size="sm" onClick={() => setAddMeetingOpen(true)}>
             新增週次
+          </Button>
+        )}
+        {isAdmin && activeTab === "papers" && (
+          <Button size="sm" onClick={() => setAddPaperOpen(true)}>
+            新增 Paper
           </Button>
         )}
       </div>
@@ -94,11 +99,14 @@ export default function MeetingsPage() {
       </Tabs>
 
       {isAdmin && (
-        <AddMeetingDialog
-          year={year}
-          open={addOpen}
-          onOpenChange={setAddOpen}
-        />
+        <>
+          <AddMeetingDialog
+            year={year}
+            open={addMeetingOpen}
+            onOpenChange={setAddMeetingOpen}
+          />
+          <AddPaperDialog open={addPaperOpen} onOpenChange={setAddPaperOpen} />
+        </>
       )}
     </div>
   )

--- a/apps/portal/app/receipts/_components/receipts-view.tsx
+++ b/apps/portal/app/receipts/_components/receipts-view.tsx
@@ -58,7 +58,7 @@ export function ReceiptsView() {
     !!search.trim() || selectedStatuses.size > 0 || selectedTagIds.size > 0
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-10">
       <div className="flex items-center justify-between">
         <div className="flex flex-col gap-1">
           <h1 className="font-medium">收據</h1>
@@ -79,7 +79,7 @@ export function ReceiptsView() {
         />
       </div>
 
-      <div className="rounded-2xl border border-border">
+      <div className="rounded-xl border border-border">
         <Table>
           <TableHeader>
             <TableRow>


### PR DESCRIPTION
## Why

Right after #71 I did a portal-wide audit for design system alignment. Found a handful of stragglers that still didn't match the convention used by bento / trip / leave / approve / profile / portal home.

## What changed

### meetings — papers tab's add button + outer gap
- 老師 Papers tab had its own \`新增\` button floating above the table. Hoisted to the page title row, matching what we just did for 新增週次. The title-row action now flips based on \`activeTab\` (\`新增週次\` / \`新增 Paper\`).
- Outer container \`gap-6\` → \`gap-10\` to match the rest.

### receipts — outer gap + table corner
- Outer container \`gap-6\` → \`gap-10\`.
- Table wrapper \`rounded-2xl\` → \`rounded-xl\` so it agrees with cards everywhere else.

### admin/user-management — outer gap
- \`gap-6\` → \`gap-10\`.

### debt/debt-home — missing page header
- \`/debt\` had **no \`<h1>\` at all** — I'd missed it the first time. Added title + description.
- Lifted \`新增\` from inside the \`我的分帳\` section header to the page title row, renamed \`新增分帳\` for clarity.
- \`grid gap-6\` → \`flex flex-col gap-10\`.
- Section list switched from \`grid gap-1\` to \`flex flex-col gap-1\` for consistency.

### debt/settlements — outer container
- \`grid gap-6\` → \`flex flex-col gap-10\`.

## After this PR

All seven business app top-level views (admin / approve / bento / debt / leave / meetings / profile / receipts / reimburse / trip / portal home) share:

\`\`\`tsx
<div className="flex flex-col gap-10">
  <div className="flex items-center justify-between">
    <div className="flex flex-col gap-1">
      <h1 className="font-medium">…</h1>
      <p className="text-sm text-muted-foreground">…</p>
    </div>
    {primaryAction}
  </div>
  …
</div>
\`\`\`

## Test plan

- [x] \`bun run typecheck --filter=portal\` — green
- [x] \`bun run lint --filter=portal\` — 0 errors
- [x] \`bun run build --filter=portal\` — green
- [ ] /meetings — \`新增週次\` shows on schedule tab, \`新增 Paper\` shows on papers tab, neither shows on info tab
- [ ] /debt — title + description visible, \`新增分帳\` opens the form
- [ ] /receipts — title row + table corners look like the rest of the apps