### PR TITLE
feat(gallery): let videos onto the wall, compressed in the browser

### DIFF
--- a/apps/gallery/app/_components/gallery-card.tsx
+++ b/apps/gallery/app/_components/gallery-card.tsx
@@ -33,7 +33,13 @@ export function GalleryCard({
   viewerName: string
 }) {
   const rotation = getRotation(image.id)
-  const url = getGalleryImageUrl(image.image_path)
+  const isVideo = image.media_type === "video"
+  const mediaUrl = getGalleryImageUrl(image.image_path)
+  // Videos always have a poster (DB constraint). Images render directly.
+  const thumbUrl =
+    isVideo && image.poster_path
+      ? getGalleryImageUrl(image.poster_path)
+      : mediaUrl
   const [thumbFailed, setThumbFailed] = useState(false)
   const [lightboxFailed, setLightboxFailed] = useState(false)
   const [isPending, startTransition] = useTransition()
@@ -104,16 +110,19 @@ export function GalleryCard({
                 Preview unavailable (try Safari for HEIC, or export as JPEG)
               </div>
             ) : (
-              <img
-                src={url}
-                alt={image.name}
-                width={1200}
-                height={1500}
-                loading="lazy"
-                decoding="async"
-                className="h-auto w-full object-cover"
-                onError={() => setThumbFailed(true)}
-              />
+              <>
+                <img
+                  src={thumbUrl}
+                  alt={image.name}
+                  width={1200}
+                  height={1500}
+                  loading="lazy"
+                  decoding="async"
+                  className="h-auto w-full object-cover"
+                  onError={() => setThumbFailed(true)}
+                />
+                {isVideo ? <PlayBadge /> : null}
+              </>
             )}
           </div>
         </DialogTrigger>
@@ -126,12 +135,27 @@ export function GalleryCard({
           <DialogTitle className="sr-only">{image.name}</DialogTitle>
           {lightboxFailed ? (
             <div className="max-w-[95vw] rounded-sm bg-muted px-8 py-16 text-center text-muted-foreground italic shadow-2xl">
-              This image cannot be previewed in your browser (common with HEIC).
-              Export as JPEG/PNG or open this page in Safari.
+              This {isVideo ? "video" : "image"} cannot be previewed in your
+              browser.
             </div>
+          ) : isVideo ? (
+            <video
+              src={mediaUrl}
+              poster={
+                image.poster_path
+                  ? getGalleryImageUrl(image.poster_path)
+                  : undefined
+              }
+              controls
+              autoPlay
+              playsInline
+              preload="metadata"
+              className="block h-auto max-h-[85vh] w-auto max-w-[95vw] bg-black object-contain shadow-2xl"
+              onError={() => setLightboxFailed(true)}
+            />
           ) : (
             <img
-              src={url}
+              src={mediaUrl}
               alt={image.name}
               className="block h-auto max-h-[85vh] w-auto max-w-[95vw] bg-white object-contain shadow-2xl"
               onError={() => setLightboxFailed(true)}
@@ -221,5 +245,29 @@ export function GalleryCard({
         </button>
       </figcaption>
     </figure>
+  )
+}
+
+function PlayBadge() {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "pointer-events-none absolute inset-0 flex items-center justify-center",
+        "bg-gradient-to-t from-black/30 via-transparent to-transparent"
+      )}
+    >
+      <div className="flex h-14 w-14 items-center justify-center rounded-full bg-white/85 text-foreground shadow-lg backdrop-blur-sm">
+        <svg
+          width="22"
+          height="22"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          aria-hidden
+        >
+          <path d="M8 5v14l11-7z" />
+        </svg>
+      </div>
+    </div>
   )
 }

--- a/apps/gallery/app/page.tsx
+++ b/apps/gallery/app/page.tsx
@@ -15,7 +15,9 @@ export default async function GalleryHomePage() {
   const user = await getCurrentUser()
   const { data, error } = await supabase
     .from("gallery_images")
-    .select("id, name, image_path, created_by, created_at")
+    .select(
+      "id, name, image_path, media_type, poster_path, duration_seconds, created_by, created_at"
+    )
     .order("created_at", { ascending: false })
 
   if (error) {
@@ -125,7 +127,14 @@ export default async function GalleryHomePage() {
   }
 
   const images: GalleryImage[] = baseImages.map((image) => ({
-    ...image,
+    id: image.id,
+    name: image.name,
+    image_path: image.image_path,
+    media_type: image.media_type === "video" ? "video" : "image",
+    poster_path: image.poster_path ?? null,
+    duration_seconds: image.duration_seconds ?? null,
+    created_by: image.created_by,
+    created_at: image.created_at,
     uploader_name: image.created_by
       ? (uploaderNameById.get(image.created_by) ?? "Unknown")
       : "Unknown",

--- a/apps/gallery/app/upload/_components/delete-button.tsx
+++ b/apps/gallery/app/upload/_components/delete-button.tsx
@@ -21,17 +21,19 @@ import { deleteGalleryImage } from "@/app/upload/actions"
 export function DeleteButton({
   id,
   imagePath,
+  posterPath,
   name,
 }: {
   id: string
   imagePath: string
+  posterPath?: string | null
   name: string
 }) {
   const [pending, startTransition] = useTransition()
 
   function onConfirm() {
     startTransition(async () => {
-      const result = await deleteGalleryImage(id, imagePath)
+      const result = await deleteGalleryImage(id, imagePath, posterPath)
       if (result.ok) {
         toast.success(`Deleted "${name}"`)
       } else {
@@ -55,7 +57,7 @@ export function DeleteButton({
         <AlertDialogHeader>
           <AlertDialogTitle>Delete &ldquo;{name}&rdquo;?</AlertDialogTitle>
           <AlertDialogDescription>
-            This removes the image from the gallery and the storage bucket.
+            This removes the work from the gallery and the storage bucket.
             Cannot be undone.
           </AlertDialogDescription>
         </AlertDialogHeader>

--- a/apps/gallery/app/upload/_components/upload-form.tsx
+++ b/apps/gallery/app/upload/_components/upload-form.tsx
@@ -9,8 +9,32 @@ import { Input } from "@workspace/ui/components/input"
 import { Label } from "@workspace/ui/components/label"
 
 import { registerGalleryImage } from "@/app/upload/actions"
-import { guessExtension, resolveImageMimeType } from "@/lib/gallery/mime"
+import {
+  guessExtension,
+  resolveMediaMimeType,
+  type ResolvedMime,
+} from "@/lib/gallery/mime"
 import { createClient } from "@/lib/supabase/client"
+import {
+  VIDEO_MAX_DURATION_SECONDS,
+  compressVideo,
+  type CompressPhase,
+} from "@/lib/gallery/video-compress"
+
+type Status =
+  | { kind: "idle" }
+  | {
+      kind: "working"
+      label: string
+      ratio: number
+    }
+
+const PHASE_LABEL: Record<CompressPhase, string> = {
+  init: "Loading encoder",
+  probe: "Reading video",
+  compress: "Compressing to 720p",
+  poster: "Capturing cover frame",
+}
 
 /** Client uploads bytes to Supabase Storage; server action only registers the row (no 413 on Vercel). */
 export function UploadForm() {
@@ -18,6 +42,7 @@ export function UploadForm() {
   const [pending, startTransition] = useTransition()
   const [name, setName] = useState("")
   const [fileNames, setFileNames] = useState<string[]>([])
+  const [status, setStatus] = useState<Status>({ kind: "idle" })
 
   function inferArtworkName(fileName: string): string {
     const base = fileName.replace(/\.[^.]+$/, "").trim()
@@ -32,7 +57,7 @@ export function UploadForm() {
     const trimmed = name.trim()
 
     if (files.length === 0) {
-      toast.error("Pick an image file.")
+      toast.error("Pick a file.")
       return
     }
     if (files.some((file) => file.size === 0)) {
@@ -52,45 +77,51 @@ export function UploadForm() {
       let successCount = 0
       const failed: string[] = []
 
-      for (const file of files) {
-        const resolvedMime = resolveImageMimeType(file)
-        if (!resolvedMime) {
+      for (let i = 0; i < files.length; i++) {
+        const file = files[i]!
+        const labelPrefix =
+          files.length > 1 ? `(${i + 1}/${files.length}) ` : ""
+
+        const resolved = resolveMediaMimeType(file)
+        if (!resolved) {
           failed.push(
             `${file.name} (unsupported type: ${file.type || "unknown"})`
           )
           continue
         }
 
-        const ext = guessExtension(resolvedMime, file.name)
-        if (ext === "bin") {
-          failed.push(`${file.name} (unsupported extension)`)
-          continue
-        }
-
-        const objectPath = `${userId}/${crypto.randomUUID()}.${ext}`
         const artworkName =
           files.length === 1 && trimmed ? trimmed : inferArtworkName(file.name)
 
-        const { error: uploadError } = await supabase.storage
-          .from("gallery")
-          .upload(objectPath, file, {
-            contentType: resolvedMime,
-            upsert: false,
-          })
-
-        if (uploadError) {
-          failed.push(`${file.name} (${uploadError.message})`)
-          continue
-        }
-
-        const result = await registerGalleryImage(artworkName, objectPath)
-        if (result.ok) {
+        try {
+          if (resolved.kind === "image") {
+            await uploadImage({
+              supabase,
+              userId,
+              file,
+              resolved,
+              artworkName,
+              setStatus,
+              labelPrefix,
+            })
+          } else {
+            await uploadVideo({
+              supabase,
+              userId,
+              file,
+              artworkName,
+              setStatus,
+              labelPrefix,
+            })
+          }
           successCount += 1
-        } else {
-          await supabase.storage.from("gallery").remove([objectPath])
-          failed.push(`${file.name} (${result.error})`)
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err)
+          failed.push(`${file.name} (${message})`)
         }
       }
+
+      setStatus({ kind: "idle" })
 
       if (successCount > 0) {
         const suffix = successCount > 1 ? "s" : ""
@@ -125,13 +156,13 @@ export function UploadForm() {
       </div>
       <div className="flex flex-col gap-3">
         <Label htmlFor="gallery-file" className="text-xl italic">
-          Images
+          Images & videos
         </Label>
         <Input
           id="gallery-file"
           name="file"
           type="file"
-          accept="image/*"
+          accept="image/*,video/*"
           required
           multiple
           onChange={(e) =>
@@ -146,7 +177,22 @@ export function UploadForm() {
             {fileNames.length > 3 ? ` (+${fileNames.length - 3} more)` : ""}
           </p>
         ) : null}
+        <p className="text-sm text-muted-foreground italic">
+          Videos: max {VIDEO_MAX_DURATION_SECONDS}s, auto-compressed to 720p mp4
+          in your browser.
+        </p>
       </div>
+      {status.kind === "working" ? (
+        <div className="flex flex-col gap-2">
+          <p className="text-sm text-muted-foreground italic">{status.label}</p>
+          <div className="h-1 w-full overflow-hidden rounded-full bg-muted">
+            <div
+              className="h-full bg-foreground transition-[width] duration-200"
+              style={{ width: `${Math.round(status.ratio * 100)}%` }}
+            />
+          </div>
+        </div>
+      ) : null}
       <Button
         type="submit"
         size="lg"
@@ -157,4 +203,125 @@ export function UploadForm() {
       </Button>
     </form>
   )
+}
+
+type UploadCtx = {
+  supabase: ReturnType<typeof createClient>
+  userId: string
+  file: File
+  artworkName: string
+  setStatus: (s: Status) => void
+  labelPrefix: string
+}
+
+async function uploadImage(
+  ctx: UploadCtx & { resolved: ResolvedMime }
+): Promise<void> {
+  const {
+    supabase,
+    userId,
+    file,
+    resolved,
+    artworkName,
+    setStatus,
+    labelPrefix,
+  } = ctx
+  const ext = guessExtension(resolved.mime, file.name)
+  if (ext === "bin") throw new Error("Unsupported extension")
+
+  setStatus({
+    kind: "working",
+    label: `${labelPrefix}Uploading ${file.name}`,
+    ratio: 0.4,
+  })
+
+  const objectPath = `${userId}/${crypto.randomUUID()}.${ext}`
+  const { error: uploadError } = await supabase.storage
+    .from("gallery")
+    .upload(objectPath, file, {
+      contentType: resolved.mime,
+      upsert: false,
+    })
+  if (uploadError) throw new Error(uploadError.message)
+
+  setStatus({
+    kind: "working",
+    label: `${labelPrefix}Registering ${file.name}`,
+    ratio: 0.85,
+  })
+
+  const result = await registerGalleryImage({
+    name: artworkName,
+    imagePath: objectPath,
+    mediaType: "image",
+  })
+  if (!result.ok) {
+    await supabase.storage.from("gallery").remove([objectPath])
+    throw new Error(result.error)
+  }
+}
+
+async function uploadVideo(ctx: UploadCtx): Promise<void> {
+  const { supabase, userId, file, artworkName, setStatus, labelPrefix } = ctx
+
+  const compressed = await compressVideo(file, {
+    onProgress: (ratio, phase) => {
+      setStatus({
+        kind: "working",
+        label: `${labelPrefix}${PHASE_LABEL[phase]}`,
+        ratio,
+      })
+    },
+  })
+
+  const videoId = crypto.randomUUID()
+  const posterId = crypto.randomUUID()
+  const videoPath = `${userId}/${videoId}.${compressed.videoExt}`
+  const posterPath = `${userId}/${posterId}.${compressed.posterExt}`
+
+  setStatus({
+    kind: "working",
+    label: `${labelPrefix}Uploading video`,
+    ratio: 0.3,
+  })
+  const { error: videoErr } = await supabase.storage
+    .from("gallery")
+    .upload(videoPath, compressed.video, {
+      contentType: compressed.videoMime,
+      upsert: false,
+    })
+  if (videoErr) throw new Error(videoErr.message)
+
+  setStatus({
+    kind: "working",
+    label: `${labelPrefix}Uploading cover`,
+    ratio: 0.7,
+  })
+  const { error: posterErr } = await supabase.storage
+    .from("gallery")
+    .upload(posterPath, compressed.poster, {
+      contentType: compressed.posterMime,
+      upsert: false,
+    })
+  if (posterErr) {
+    await supabase.storage.from("gallery").remove([videoPath])
+    throw new Error(posterErr.message)
+  }
+
+  setStatus({
+    kind: "working",
+    label: `${labelPrefix}Registering`,
+    ratio: 0.9,
+  })
+  const result = await registerGalleryImage({
+    name: artworkName,
+    imagePath: videoPath,
+    mediaType: "video",
+    posterPath,
+    durationSeconds: compressed.durationSeconds,
+  })
+  if (!result.ok) {
+    await supabase.storage.from("gallery").remove([videoPath, posterPath])
+    throw new Error(result.error)
+  }
 }

--- a/apps/gallery/app/upload/_components/upload-list-thumb.tsx
+++ b/apps/gallery/app/upload/_components/upload-list-thumb.tsx
@@ -2,7 +2,15 @@
 
 import { useState } from "react"
 
-export function UploadListThumb({ src, alt }: { src: string; alt: string }) {
+export function UploadListThumb({
+  src,
+  alt,
+  isVideo = false,
+}: {
+  src: string
+  alt: string
+  isVideo?: boolean
+}) {
   const [failed, setFailed] = useState(false)
 
   if (failed) {
@@ -23,6 +31,18 @@ export function UploadListThumb({ src, alt }: { src: string; alt: string }) {
         decoding="async"
         onError={() => setFailed(true)}
       />
+      {isVideo ? (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/15"
+        >
+          <div className="flex h-7 w-7 items-center justify-center rounded-full bg-white/85 text-foreground">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M8 5v14l11-7z" />
+            </svg>
+          </div>
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/apps/gallery/app/upload/actions.ts
+++ b/apps/gallery/app/upload/actions.ts
@@ -7,28 +7,56 @@ import { createClient } from "@/lib/supabase/server"
 
 export type ActionResult = { ok: true } | { ok: false; error: string }
 
+export type RegisterMediaInput = {
+  name: string
+  imagePath: string
+  mediaType: "image" | "video"
+  posterPath?: string | null
+  durationSeconds?: number | null
+}
+
 /**
  * Registers a gallery row after the browser uploads the file directly to
  * Supabase Storage — avoids Vercel's ~4.5MB Server Action body limit (413).
  */
 export async function registerGalleryImage(
-  name: string,
-  imagePath: string
+  input: RegisterMediaInput
 ): Promise<ActionResult> {
-  const trimmed = name.trim()
+  const trimmed = input.name.trim()
   if (!trimmed) return { ok: false, error: "Name is required." }
-  if (!imagePath) return { ok: false, error: "Missing image path." }
+  if (!input.imagePath) return { ok: false, error: "Missing media path." }
+  if (input.mediaType !== "image" && input.mediaType !== "video") {
+    return { ok: false, error: "Invalid media type." }
+  }
+  if (input.mediaType === "video" && !input.posterPath) {
+    return { ok: false, error: "Video uploads require a poster image." }
+  }
+  if (input.mediaType === "image" && input.posterPath) {
+    return { ok: false, error: "Images must not have a poster path." }
+  }
 
   const supabase = await createClient()
   const { data: claimsData } = await supabase.auth.getClaims()
   const userId = claimsData?.claims?.sub
   if (!userId) return { ok: false, error: "Not signed in." }
 
-  if (!isValidClientObjectPath(imagePath, userId)) {
-    return { ok: false, error: "Invalid image path." }
+  if (!isValidClientObjectPath(input.imagePath, userId)) {
+    return { ok: false, error: "Invalid media path." }
+  }
+  if (
+    input.posterPath &&
+    !isValidClientObjectPath(input.posterPath, userId, { imageOnly: true })
+  ) {
+    return { ok: false, error: "Invalid poster path." }
   }
 
-  const fileName = imagePath.slice(userId.length + 1)
+  const expectedPaths = [input.imagePath]
+  if (input.posterPath) expectedPaths.push(input.posterPath)
+
+  const expectedNames = new Set(
+    expectedPaths.map((p) => p.slice(userId.length + 1))
+  )
+
   let uploaded = false
   for (let attempt = 0; attempt < 5 && !uploaded; attempt++) {
     if (attempt > 0) {
@@ -44,7 +72,8 @@ export async function registerGalleryImage(
         error: `Could not verify upload: ${listError.message}`,
       }
     }
-    uploaded = files?.some((f) => f.name === fileName) ?? false
+    const present = new Set((files ?? []).map((f) => f.name))
+    uploaded = [...expectedNames].every((n) => present.has(n))
   }
   if (!uploaded) {
     return {
@@ -53,14 +82,24 @@ export async function registerGalleryImage(
     }
   }
 
-  const { error: insertError } = await supabase.from("gallery_images").insert({
+  const insertPayload: Record<string, unknown> = {
     name: trimmed,
-    image_path: imagePath,
+    image_path: input.imagePath,
+    media_type: input.mediaType,
+    poster_path: input.posterPath ?? null,
+    duration_seconds:
+      input.mediaType === "video" && input.durationSeconds
+        ? Math.max(1, Math.round(input.durationSeconds))
+        : null,
     created_by: userId,
-  })
+  }
+
+  const { error: insertError } = await supabase
+    .from("gallery_images")
+    .insert(insertPayload)
 
   if (insertError) {
-    await supabase.storage.from("gallery").remove([imagePath])
+    await supabase.storage.from("gallery").remove(expectedPaths)
     return {
       ok: false,
       error: `Database insert failed: ${insertError.message}`,
@@ -74,7 +113,8 @@ export async function registerGalleryImage(
 
 export async function deleteGalleryImage(
   id: string,
-  imagePath: string
+  imagePath: string,
+  posterPath?: string | null
 ): Promise<ActionResult> {
   const supabase = await createClient()
 
@@ -87,11 +127,11 @@ export async function deleteGalleryImage(
     return { ok: false, error: `Delete failed: ${deleteError.message}` }
   }
 
-  // Storage cleanup. Best-effort — RLS already gated the row delete, so if
-  // this somehow fails we still log and move on; orphan objects are cheap.
+  const targets = [imagePath]
+  if (posterPath) targets.push(posterPath)
   const { error: storageError } = await supabase.storage
     .from("gallery")
-    .remove([imagePath])
+    .remove(targets)
   if (storageError) {
     console.error("[gallery] storage delete failed", storageError)
   }
@@ -132,16 +172,21 @@ export async function renameGalleryImage(
 const UUID_FILE_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.([a-z0-9]{2,5})$/i
 
-function isValidClientObjectPath(imagePath: string, userId: string): boolean {
-  if (!imagePath.startsWith(`${userId}/`)) return false
-  const rest = imagePath.slice(userId.length + 1)
+function isValidClientObjectPath(
+  path: string,
+  userId: string,
+  opts: { imageOnly?: boolean } = {}
+): boolean {
+  if (!path.startsWith(`${userId}/`)) return false
+  const rest = path.slice(userId.length + 1)
   if (!rest || rest.includes("/") || rest.includes("..")) return false
 
-  const m = UUID_FILE_RE.exec(rest)
+  const m = rest.match(UUID_FILE_RE)
   if (!m?.[1]) return false
   const ext = m[1].toLowerCase()
   const pseudoMime =
     ext === "jpg" ? "image/jpeg" : inferMimeFromFilename(`x.${ext}`)
   if (!pseudoMime || !ALLOWED_MIME.has(pseudoMime)) return false
+  if (opts.imageOnly && !pseudoMime.startsWith("image/")) return false
   return true
 }

--- a/apps/gallery/app/upload/page.tsx
+++ b/apps/gallery/app/upload/page.tsx
@@ -22,11 +22,24 @@ export default async function UploadPage() {
   const supabase = await createClient()
   const { data } = await supabase
     .from("gallery_images")
-    .select("id, name, image_path, created_by, created_at")
+    .select(
+      "id, name, image_path, media_type, poster_path, duration_seconds, created_by, created_at"
+    )
     .eq("created_by", user.id)
     .order("created_at", { ascending: false })
 
-  const myImages = (data ?? []) as GalleryImage[]
+  const myImages = (data ?? []) as Array<
+    Pick<
+      GalleryImage,
+      | "id"
+      | "name"
+      | "image_path"
+      | "media_type"
+      | "poster_path"
+      | "duration_seconds"
+      | "created_at"
+    >
+  >
 
   return (
     <PortalShell
@@ -63,31 +76,43 @@ export default async function UploadPage() {
             </p>
           ) : (
             <ul className="flex flex-col">
-              {myImages.map((image) => (
-                <li
-                  key={image.id}
-                  className="flex items-center gap-6 border-b border-border/60 py-5 last:border-b-0"
-                >
-                  <UploadListThumb
-                    src={getGalleryImageUrl(image.image_path)}
-                    alt={image.name}
-                  />
-                  <div className="flex flex-1 flex-col gap-1">
-                    <p className="text-2xl italic">{image.name}</p>
-                    <p className="text-sm text-muted-foreground">
-                      {new Date(image.created_at).toLocaleDateString()}
-                    </p>
-                  </div>
-                  <div className="flex shrink-0 items-center gap-1">
-                    <RenameButton id={image.id} name={image.name} />
-                    <DeleteButton
-                      id={image.id}
-                      imagePath={image.image_path}
-                      name={image.name}
+              {myImages.map((image) => {
+                const isVideo = image.media_type === "video"
+                const thumbPath =
+                  isVideo && image.poster_path
+                    ? image.poster_path
+                    : image.image_path
+                return (
+                  <li
+                    key={image.id}
+                    className="flex items-center gap-6 border-b border-border/60 py-5 last:border-b-0"
+                  >
+                    <UploadListThumb
+                      src={getGalleryImageUrl(thumbPath)}
+                      alt={image.name}
+                      isVideo={isVideo}
                     />
-                  </div>
-                </li>
-              ))}
+                    <div className="flex flex-1 flex-col gap-1">
+                      <p className="text-2xl italic">{image.name}</p>
+                      <p className="text-sm text-muted-foreground">
+                        {new Date(image.created_at).toLocaleDateString()}
+                        {isVideo && image.duration_seconds
+                          ? ` · ${image.duration_seconds}s video`
+                          : ""}
+                      </p>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-1">
+                      <RenameButton id={image.id} name={image.name} />
+                      <DeleteButton
+                        id={image.id}
+                        imagePath={image.image_path}
+                        posterPath={image.poster_path}
+                        name={image.name}
+                      />
+                    </div>
+                  </li>
+                )
+              })}
             </ul>
           )}
         </section>

--- a/apps/gallery/lib/gallery/mime.ts
+++ b/apps/gallery/lib/gallery/mime.ts
@@ -1,6 +1,6 @@
-/** Shared client + server validation for gallery image uploads. */
+/** Shared client + server validation for gallery media uploads. */
 
-export const ALLOWED_MIME = new Set([
+export const ALLOWED_IMAGE_MIME = new Set([
   "image/jpeg",
   "image/png",
   "image/webp",
@@ -10,19 +10,46 @@ export const ALLOWED_MIME = new Set([
   "image/heif",
 ])
 
+export const ALLOWED_VIDEO_MIME = new Set([
+  "video/webm",
+  "video/mp4",
+  "video/quicktime",
+])
+
+/** Kept as the union of both — the storage bucket policy mirrors this. */
+export const ALLOWED_MIME = new Set<string>([
+  ...ALLOWED_IMAGE_MIME,
+  ...ALLOWED_VIDEO_MIME,
+])
+
+export type MediaKind = "image" | "video"
+
+export type ResolvedMime = {
+  kind: MediaKind
+  mime: string
+}
+
 /** Browsers / OS file pickers often send "" or application/octet-stream. */
-export function resolveImageMimeType(file: File): string | null {
+export function resolveMediaMimeType(file: File): ResolvedMime | null {
   let t = file.type.trim().toLowerCase()
   if (t === "image/jpg") t = "image/jpeg"
 
-  if (t && t !== "application/octet-stream" && ALLOWED_MIME.has(t)) {
-    return t
+  if (t && t !== "application/octet-stream") {
+    if (ALLOWED_IMAGE_MIME.has(t)) return { kind: "image", mime: t }
+    if (ALLOWED_VIDEO_MIME.has(t)) return { kind: "video", mime: t }
   }
 
   const inferred = inferMimeFromFilename(file.name)
-  if (inferred && ALLOWED_MIME.has(inferred)) return inferred
-
+  if (!inferred) return null
+  if (ALLOWED_IMAGE_MIME.has(inferred)) return { kind: "image", mime: inferred }
+  if (ALLOWED_VIDEO_MIME.has(inferred)) return { kind: "video", mime: inferred }
   return null
+}
+
+/** Backwards-compat shim used by server-side validation paths. */
+export function resolveImageMimeType(file: File): string | null {
+  const resolved = resolveMediaMimeType(file)
+  return resolved?.kind === "image" ? resolved.mime : null
 }
 
 export function inferMimeFromFilename(filename: string): string | null {
@@ -43,6 +70,13 @@ export function inferMimeFromFilename(filename: string): string | null {
       return "image/heic"
     case "heif":
       return "image/heif"
+    case "webm":
+      return "video/webm"
+    case "mp4":
+    case "m4v":
+      return "video/mp4"
+    case "mov":
+      return "video/quicktime"
     default:
       return null
   }
@@ -66,6 +100,12 @@ export function guessExtension(mime: string, filename: string): string {
       return "heic"
     case "image/heif":
       return "heif"
+    case "video/webm":
+      return "webm"
+    case "video/mp4":
+      return "mp4"
+    case "video/quicktime":
+      return "mov"
     default:
       return "bin"
   }

--- a/apps/gallery/lib/gallery/types.ts
+++ b/apps/gallery/lib/gallery/types.ts
@@ -1,8 +1,13 @@
+import type { MediaKind } from "@/lib/gallery/mime"
+
 export type GalleryImage = {
   id: string
   name: string
   uploader_name: string
   image_path: string
+  media_type: MediaKind
+  poster_path: string | null
+  duration_seconds: number | null
   created_by: string | null
   created_at: string
   vote_count: number

--- a/apps/gallery/lib/gallery/video-compress.ts
+++ b/apps/gallery/lib/gallery/video-compress.ts
@@ -1,0 +1,233 @@
+"use client"
+
+import { FFmpeg } from "@ffmpeg/ffmpeg"
+import { fetchFile, toBlobURL } from "@ffmpeg/util"
+
+// Single-thread core — works without COOP/COEP / SharedArrayBuffer at the
+// cost of being slower than the MT build. Trade-off we like: zero header
+// gymnastics, ships behind the existing Vercel hosting.
+const FFMPEG_CORE_BASE = "https://unpkg.com/@ffmpeg/core@0.12.10/dist/umd"
+
+export const VIDEO_MAX_DURATION_SECONDS = 60
+export const VIDEO_MAX_INPUT_BYTES = 200 * 1024 * 1024
+
+export type CompressPhase = "init" | "probe" | "compress" | "poster"
+
+export type CompressResult = {
+  video: Blob
+  videoMime: "video/mp4"
+  videoExt: "mp4"
+  poster: Blob
+  posterMime: "image/jpeg"
+  posterExt: "jpg"
+  durationSeconds: number
+  width: number
+  height: number
+}
+
+export type CompressOptions = {
+  onProgress?: (ratio: number, phase: CompressPhase) => void
+  signal?: AbortSignal
+}
+
+let ffmpegSingleton: FFmpeg | null = null
+let ffmpegLoadPromise: Promise<FFmpeg> | null = null
+
+async function getFFmpeg(
+  onProgress?: CompressOptions["onProgress"]
+): Promise<FFmpeg> {
+  if (ffmpegSingleton) return ffmpegSingleton
+  if (ffmpegLoadPromise) return ffmpegLoadPromise
+
+  ffmpegLoadPromise = (async () => {
+    onProgress?.(0, "init")
+    const ffmpeg = new FFmpeg()
+    const [coreURL, wasmURL] = await Promise.all([
+      toBlobURL(`${FFMPEG_CORE_BASE}/ffmpeg-core.js`, "text/javascript"),
+      toBlobURL(`${FFMPEG_CORE_BASE}/ffmpeg-core.wasm`, "application/wasm"),
+    ])
+    onProgress?.(0.5, "init")
+    await ffmpeg.load({ coreURL, wasmURL })
+    ffmpegSingleton = ffmpeg
+    onProgress?.(1, "init")
+    return ffmpeg
+  })()
+
+  try {
+    return await ffmpegLoadPromise
+  } catch (err) {
+    ffmpegLoadPromise = null
+    throw err
+  }
+}
+
+export function probeVideo(
+  file: File
+): Promise<{ durationSeconds: number; width: number; height: number }> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file)
+    const video = document.createElement("video")
+    video.preload = "metadata"
+    video.muted = true
+    video.playsInline = true
+
+    const cleanup = () => {
+      URL.revokeObjectURL(url)
+      video.removeAttribute("src")
+      video.load()
+    }
+
+    video.onloadedmetadata = () => {
+      const durationSeconds = Number.isFinite(video.duration)
+        ? video.duration
+        : 0
+      const width = video.videoWidth
+      const height = video.videoHeight
+      cleanup()
+      if (!durationSeconds || !width || !height) {
+        reject(new Error("Could not read video metadata."))
+        return
+      }
+      resolve({ durationSeconds, width, height })
+    }
+    video.onerror = () => {
+      cleanup()
+      reject(new Error("Browser cannot decode this video."))
+    }
+
+    video.src = url
+  })
+}
+
+export async function compressVideo(
+  file: File,
+  opts: CompressOptions = {}
+): Promise<CompressResult> {
+  if (file.size > VIDEO_MAX_INPUT_BYTES) {
+    throw new Error(
+      `File too large (max ${VIDEO_MAX_INPUT_BYTES / 1024 / 1024} MB before compression).`
+    )
+  }
+
+  opts.onProgress?.(0, "probe")
+  const probe = await probeVideo(file)
+  if (probe.durationSeconds > VIDEO_MAX_DURATION_SECONDS + 0.5) {
+    throw new Error(
+      `Video too long (max ${VIDEO_MAX_DURATION_SECONDS}s, got ${Math.round(probe.durationSeconds)}s).`
+    )
+  }
+  opts.onProgress?.(1, "probe")
+
+  const ffmpeg = await getFFmpeg(opts.onProgress)
+  abortIfRequested(opts.signal)
+
+  const inputName = `in.${guessInputExt(file)}`
+  const outputName = "out.mp4"
+  const posterName = "poster.jpg"
+
+  const onCompressProgress = ({ progress }: { progress: number }) => {
+    const clamped = Math.max(0, Math.min(1, progress))
+    opts.onProgress?.(clamped, "compress")
+  }
+  ffmpeg.on("progress", onCompressProgress)
+
+  try {
+    await ffmpeg.writeFile(inputName, await fetchFile(file))
+    abortIfRequested(opts.signal)
+
+    opts.onProgress?.(0, "compress")
+    await ffmpeg.exec([
+      "-i",
+      inputName,
+      "-vf",
+      "scale='if(gt(iw,ih),min(1280,iw),-2)':'if(gt(iw,ih),-2,min(1280,ih))',fps=30",
+      "-c:v",
+      "libx264",
+      "-preset",
+      "veryfast",
+      "-crf",
+      "28",
+      "-maxrate",
+      "1M",
+      "-bufsize",
+      "2M",
+      "-pix_fmt",
+      "yuv420p",
+      "-c:a",
+      "aac",
+      "-b:a",
+      "96k",
+      "-movflags",
+      "+faststart",
+      outputName,
+    ])
+    abortIfRequested(opts.signal)
+    opts.onProgress?.(1, "compress")
+
+    opts.onProgress?.(0, "poster")
+    const posterAt = probe.durationSeconds > 1.5 ? "00:00:01" : "00:00:00.10"
+    await ffmpeg.exec([
+      "-ss",
+      posterAt,
+      "-i",
+      outputName,
+      "-frames:v",
+      "1",
+      "-vf",
+      "scale='if(gt(iw,ih),min(1280,iw),-2)':'if(gt(iw,ih),-2,min(1280,ih))'",
+      "-q:v",
+      "5",
+      posterName,
+    ])
+    opts.onProgress?.(1, "poster")
+    abortIfRequested(opts.signal)
+
+    const videoData = await ffmpeg.readFile(outputName)
+    const posterData = await ffmpeg.readFile(posterName)
+
+    const videoBytes = toUint8Array(videoData)
+    const posterBytes = toUint8Array(posterData)
+
+    return {
+      video: new Blob([videoBytes as BlobPart], { type: "video/mp4" }),
+      videoMime: "video/mp4",
+      videoExt: "mp4",
+      poster: new Blob([posterBytes as BlobPart], { type: "image/jpeg" }),
+      posterMime: "image/jpeg",
+      posterExt: "jpg",
+      durationSeconds: Math.round(probe.durationSeconds),
+      width: probe.width,
+      height: probe.height,
+    }
+  } finally {
+    ffmpeg.off("progress", onCompressProgress)
+    await Promise.allSettled([
+      ffmpeg.deleteFile(inputName),
+      ffmpeg.deleteFile(outputName),
+      ffmpeg.deleteFile(posterName),
+    ])
+  }
+}
+
+function guessInputExt(file: File): string {
+  const fromName = file.name.split(".").pop()?.toLowerCase()
+  if (fromName && /^[a-z0-9]{2,5}$/.test(fromName)) return fromName
+  if (file.type === "video/quicktime") return "mov"
+  if (file.type === "video/mp4") return "mp4"
+  if (file.type === "video/webm") return "webm"
+  return "mp4"
+}
+
+function toUint8Array(data: unknown): Uint8Array {
+  if (data instanceof Uint8Array) return data
+  if (typeof data === "string") return new TextEncoder().encode(data)
+  throw new Error("Unexpected ffmpeg output type.")
+}
+
+function abortIfRequested(signal: AbortSignal | undefined) {
+  if (signal?.aborted) {
+    throw signal.reason instanceof Error
+      ? signal.reason
+      : new Error("Compression aborted.")
+  }
+}

--- a/apps/gallery/package.json
+++ b/apps/gallery/package.json
@@ -13,6 +13,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@ffmpeg/ffmpeg": "^0.12.15",
+    "@ffmpeg/util": "^0.12.2",
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.104.0",
     "@tabler/icons-react": "^3.41.1",

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,8 @@
       "name": "gallery",
       "version": "0.0.1",
       "dependencies": {
+        "@ffmpeg/ffmpeg": "^0.12.15",
+        "@ffmpeg/util": "^0.12.2",
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.104.0",
         "@tabler/icons-react": "^3.41.1",
@@ -341,6 +343,12 @@
     "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@ffmpeg/ffmpeg": ["@ffmpeg/ffmpeg@0.12.15", "", { "dependencies": { "@ffmpeg/types": "^0.12.4" } }, "sha512-1C8Obr4GsN3xw+/1Ww6PFM84wSQAGsdoTuTWPOj2OizsRDLT4CXTaVjPhkw6ARyDus1B9X/L2LiXHqYYsGnRFw=="],
+
+    "@ffmpeg/types": ["@ffmpeg/types@0.12.4", "", {}, "sha512-k9vJQNBGTxE5AhYDtOYR5rO5fKsspbg51gbcwtbkw2lCdoIILzklulcjJfIDwrtn7XhDeF2M+THwJ2FGrLeV6A=="],
+
+    "@ffmpeg/util": ["@ffmpeg/util@0.12.2", "", {}, "sha512-ouyoW+4JB7WxjeZ2y6KpRvB+dLp7Cp4ro8z0HIVpZVCM7AwFlHa0c4R8Y/a4M3wMqATpYKhC7lSFHQ0T11MEDw=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
 

--- a/supabase/migrations/2026-05-08-gallery-video-support.sql
+++ b/supabase/migrations/2026-05-08-gallery-video-support.sql
@@ -1,0 +1,40 @@
+-- gallery.winlab.tw — let videos onto the wall.
+-- Existing rows stay images by default. Videos carry a poster image plus
+-- duration metadata so the grid can render a thumbnail without round-tripping
+-- the whole file just to grab the first frame.
+
+alter table public.gallery_images
+  add column media_type text not null default 'image',
+  add column poster_path text,
+  add column duration_seconds integer;
+
+alter table public.gallery_images
+  add constraint gallery_images_media_type_check
+  check (media_type in ('image', 'video'));
+
+-- Videos must have a poster (we generate it client-side from the first frame).
+-- Images must not — keeps the data model honest, no orphan poster paths.
+alter table public.gallery_images
+  add constraint gallery_images_poster_only_for_video
+  check (
+    (media_type = 'image' and poster_path is null)
+    or (media_type = 'video' and poster_path is not null)
+  );
+
+-- Cap object size at 30 MB. Compressed 720p/60s ~ 7-10 MB, so this leaves
+-- headroom without letting someone shovel a raw 4K clip into the bucket.
+update storage.buckets
+  set file_size_limit = 31457280,
+      allowed_mime_types = array[
+        'image/jpeg',
+        'image/png',
+        'image/webp',
+        'image/gif',
+        'image/avif',
+        'image/heic',
+        'image/heif',
+        'video/webm',
+        'video/mp4',
+        'video/quicktime'
+      ]
+  where id = 'gallery';


### PR DESCRIPTION
## Summary

Gallery 終於能傳影片了。瀏覽器端用 ffmpeg.wasm 壓到 720p mp4 後再上傳，順便抽第 1 秒幀當封面圖。

## Why

實驗室一直在問能不能放錄影作品。Cloud Supabase free tier 1 GB / 5 GB egress 月 hard cap，所以前期壓縮非做不可。挑單執行緒 ffmpeg.wasm 是為了避開 SharedArrayBuffer / COOP / COEP 那一整套 header 工程，跟 Supabase Storage 的 cross-origin 圖片載入兼容。

## What changed

- **Migration `2026-05-08-gallery-video-support.sql`** — `gallery_images` 加 `media_type` / `poster_path` / `duration_seconds`；雙向 check constraint 確保 image 沒 poster、video 必有 poster。
- **Storage bucket** — `gallery` bucket 加 `file_size_limit = 30 MB` + `allowed_mime_types` 白名單擴充到 video webm/mp4/quicktime（之前 `null` 是沒設限的隱性漏洞）。
- **`lib/gallery/video-compress.ts`（新）** — 封裝 ffmpeg.wasm，720p H.264 mp4 1 Mbps maxrate + AAC 96 kbps + `+faststart`，附帶第 1 秒 poster JPG。CDN（unpkg）載 core，零部署成本。
- **`lib/gallery/mime.ts`** — `resolveMediaMimeType()` 回傳 `{ kind: 'image' \| 'video', mime }`，舊的 `resolveImageMimeType` 留 wrapper 給 server-side validation 用。
- **`upload-form.tsx`** — image 走原路；video 先 probe duration（>60s 直接拒）→ 壓縮（多階段進度條）→ 上傳 video + poster 兩檔 → register。任一步失敗都 best-effort 清 storage。
- **`actions.ts`** — `registerGalleryImage` 改吃結構化 input，新增 video metadata 驗證（poster path 必須在同一 userId 資料夾且為合法 image 副檔名）。
- **`gallery-card.tsx`** — video 在 grid 顯示 poster + ▶ overlay；lightbox 用 `<video controls autoPlay playsInline>`。
- **`upload-list-thumb.tsx` / `delete-button.tsx`** — 加 `isVideo` / `posterPath` props，刪除時連 poster 一起清。

## Limits / 限制

- 單支影片最長 60s、原檔最大 200 MB、輸出 mp4 ≤ 30 MB。
- 沒做 chunked / resumable upload — 30 MB 以下單次上傳能接受，量產再考慮 tus.js。
- HEIC / ProRes 在某些瀏覽器 probe 不出 metadata，會讓使用者看到友善錯誤訊息。

## Test plan

- [x] `bun run typecheck` (gallery: 0 errors)
- [x] `bun run lint` (gallery: 0 errors, 4 warnings — 全是既有 \`<img>\` pattern)
- [x] `next dev` 開機正常，`GET /` 200，`GET /upload` 307（未登入導向 login，符合預期）
- [x] Migration 已 apply 到 cloud Supabase，schema + bucket 設定 verified
- [ ] Owner 實機測試 — 登入 /upload 傳一支手機影片走完 ffmpeg.wasm → 上傳 → 首頁 grid → lightbox 播放 golden path

## Screenshots

待 owner 實測補上。

## Breaking changes

無。Migration 對既有 27 張 image 完全相容（`media_type` default `'image'`，poster_path 約束跟舊資料一致）。