### PR TITLE
chore: wire up bun test with first batch of pure-logic tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   check:
-    name: typecheck · lint · test · build
+    name: typecheck · lint · build
     runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   check:
-    name: typecheck · lint · build
+    name: typecheck · lint · test · build
     runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -32,6 +32,9 @@ jobs:
 
       - name: Lint
         run: bun run lint
+
+      - name: Test
+        run: bun run test
 
       - name: Build
         run: bun run build

--- a/apps/gallery/lib/gallery/mime.test.ts
+++ b/apps/gallery/lib/gallery/mime.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  ALLOWED_IMAGE_MIME,
+  ALLOWED_VIDEO_MIME,
+  guessExtension,
+  inferMimeFromFilename,
+  resolveImageMimeType,
+  resolveMediaMimeType,
+} from "@/lib/gallery/mime"
+
+describe("resolveMediaMimeType", () => {
+  test("trusts explicit image mime types", () => {
+    const file = new File([], "art.png", { type: "image/png" })
+    expect(resolveMediaMimeType(file)).toEqual({
+      kind: "image",
+      mime: "image/png",
+    })
+  })
+
+  test("trusts explicit video mime types", () => {
+    const file = new File([], "clip.mp4", { type: "video/mp4" })
+    expect(resolveMediaMimeType(file)).toEqual({
+      kind: "video",
+      mime: "video/mp4",
+    })
+  })
+
+  test("normalizes image/jpg to image/jpeg", () => {
+    const file = new File([], "photo.jpg", { type: "image/jpg" })
+    expect(resolveMediaMimeType(file)).toEqual({
+      kind: "image",
+      mime: "image/jpeg",
+    })
+  })
+
+  test("falls back to extension when type is empty", () => {
+    const file = new File([], "movie.mov", { type: "" })
+    expect(resolveMediaMimeType(file)).toEqual({
+      kind: "video",
+      mime: "video/quicktime",
+    })
+  })
+
+  test("falls back to extension when type is application/octet-stream", () => {
+    const file = new File([], "x.webp", { type: "application/octet-stream" })
+    expect(resolveMediaMimeType(file)).toEqual({
+      kind: "image",
+      mime: "image/webp",
+    })
+  })
+
+  test("rejects unknown types with no recognizable extension", () => {
+    const file = new File([], "scary.exe", { type: "application/x-msdownload" })
+    expect(resolveMediaMimeType(file)).toBeNull()
+  })
+
+  test("rejects extensions outside the whitelist even if type is empty", () => {
+    const file = new File([], "track.mp3", { type: "" })
+    expect(resolveMediaMimeType(file)).toBeNull()
+  })
+})
+
+describe("resolveImageMimeType", () => {
+  test("returns string only when the resolved kind is image", () => {
+    const img = new File([], "a.png", { type: "image/png" })
+    expect(resolveImageMimeType(img)).toBe("image/png")
+  })
+
+  test("returns null for video uploads — server-side image-only paths must reject them", () => {
+    const vid = new File([], "a.mp4", { type: "video/mp4" })
+    expect(resolveImageMimeType(vid)).toBeNull()
+  })
+})
+
+describe("inferMimeFromFilename", () => {
+  test("covers every allowed extension", () => {
+    const cases: Array<[string, string]> = [
+      ["a.jpg", "image/jpeg"],
+      ["a.jpeg", "image/jpeg"],
+      ["a.png", "image/png"],
+      ["a.webp", "image/webp"],
+      ["a.gif", "image/gif"],
+      ["a.avif", "image/avif"],
+      ["a.heic", "image/heic"],
+      ["a.heif", "image/heif"],
+      ["a.webm", "video/webm"],
+      ["a.mp4", "video/mp4"],
+      ["a.m4v", "video/mp4"],
+      ["a.mov", "video/quicktime"],
+    ]
+    for (const [name, mime] of cases) {
+      expect(inferMimeFromFilename(name)).toBe(mime)
+    }
+  })
+
+  test("returns null for unknown extension", () => {
+    expect(inferMimeFromFilename("x.bin")).toBeNull()
+    expect(inferMimeFromFilename("noext")).toBeNull()
+  })
+})
+
+describe("guessExtension", () => {
+  test("trusts a sensible filename extension first", () => {
+    expect(guessExtension("image/jpeg", "photo.jpg")).toBe("jpg")
+    expect(guessExtension("video/mp4", "clip.MP4")).toBe("mp4")
+  })
+
+  test("falls back to mime when the filename has no extension-like tail", () => {
+    expect(guessExtension("image/webp", "")).toBe("webp")
+    expect(guessExtension("video/webm", "filenamewithoutdot")).toBe("webm")
+  })
+
+  test("returns 'bin' for unsupported mime + no extension-like tail", () => {
+    expect(guessExtension("application/zip", "")).toBe("bin")
+  })
+})
+
+describe("whitelist invariants", () => {
+  test("image and video sets do not overlap", () => {
+    for (const mime of ALLOWED_IMAGE_MIME) {
+      expect(ALLOWED_VIDEO_MIME.has(mime)).toBe(false)
+    }
+  })
+})

--- a/apps/gallery/package.json
+++ b/apps/gallery/package.json
@@ -10,7 +10,8 @@
     "start": "next start",
     "lint": "eslint",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
   },
   "dependencies": {
     "@ffmpeg/ffmpeg": "^0.12.15",

--- a/apps/gallery/package.json
+++ b/apps/gallery/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",
+    "@types/bun": "^1.3.13",
     "@types/node": "^25.1.0",
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19.2.3",

--- a/apps/portal/lib/approve/validation.test.ts
+++ b/apps/portal/lib/approve/validation.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test"
+
+import type { ApproveField } from "@/lib/approve/types"
+import { validateForSubmit } from "@/lib/approve/validation"
+
+function field(overrides: Partial<ApproveField> = {}): ApproveField {
+  return {
+    id: "f-1",
+    document_id: "doc-1",
+    signer_id: "user-1",
+    page: 0,
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 50,
+    category: "signature",
+    label: null,
+    value: null,
+    signed_at: null,
+    created_at: "2024-01-01T00:00:00Z",
+    ...overrides,
+  }
+}
+
+describe("validateForSubmit", () => {
+  test("rejects an empty title", () => {
+    expect(
+      validateForSubmit({
+        title: "  ",
+        filePath: "x.pdf",
+        fields: [field()],
+      })
+    ).toEqual({ ok: false, reason: "標題不可空白" })
+  })
+
+  test("rejects a missing file path", () => {
+    expect(
+      validateForSubmit({
+        title: "Quarterly form",
+        filePath: null,
+        fields: [field()],
+      })
+    ).toEqual({ ok: false, reason: "還沒上傳 PDF" })
+  })
+
+  test("rejects an empty field list", () => {
+    expect(
+      validateForSubmit({
+        title: "Quarterly form",
+        filePath: "x.pdf",
+        fields: [],
+      })
+    ).toEqual({ ok: false, reason: "至少要放一個方塊" })
+  })
+
+  test("rejects a field whose signer is null", () => {
+    expect(
+      validateForSubmit({
+        title: "Quarterly form",
+        filePath: "x.pdf",
+        fields: [field({ signer_id: null })],
+      })
+    ).toEqual({ ok: false, reason: "有方塊還沒選 signer" })
+  })
+
+  test("accepts a fully populated input", () => {
+    expect(
+      validateForSubmit({
+        title: "Quarterly form",
+        filePath: "x.pdf",
+        fields: [field()],
+      })
+    ).toEqual({ ok: true })
+  })
+})

--- a/apps/portal/lib/bento/date.test.ts
+++ b/apps/portal/lib/bento/date.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test"
+
+import { parseOrderDate } from "@/lib/bento/date"
+
+describe("parseOrderDate", () => {
+  test("formats an 8-digit YYYYMMDD into YYYY/MM/DD", () => {
+    expect(parseOrderDate("20240715")).toBe("2024/07/15")
+  })
+
+  test("returns the original string when it is not 8 digits", () => {
+    expect(parseOrderDate("2024-07-15")).toBe("2024-07-15")
+    expect(parseOrderDate("2024715")).toBe("2024715")
+    expect(parseOrderDate("abcd1234")).toBe("abcd1234")
+  })
+
+  test("treats empty or short input as a passthrough", () => {
+    expect(parseOrderDate("")).toBe("")
+    expect(parseOrderDate("123")).toBe("123")
+  })
+})

--- a/apps/portal/lib/debt/balance.test.ts
+++ b/apps/portal/lib/debt/balance.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from "bun:test"
+
+import { computeBalances, getUnsettledPeriodStart } from "@/lib/debt/balance"
+
+describe("getUnsettledPeriodStart", () => {
+  test("returns the unix epoch when nothing has been settled yet", () => {
+    expect(getUnsettledPeriodStart(null)).toBe("1970-01-01T00:00:00Z")
+  })
+
+  test("rolls a mid-year period into the next month", () => {
+    expect(getUnsettledPeriodStart("2024-06")).toBe("2024-07-01T00:00:00Z")
+  })
+
+  test("rolls December into January of the following year", () => {
+    expect(getUnsettledPeriodStart("2024-12")).toBe("2025-01-01T00:00:00Z")
+  })
+
+  test("treats malformed periods as never-settled rather than crashing", () => {
+    expect(getUnsettledPeriodStart("garbage")).toBe("1970-01-01T00:00:00Z")
+    expect(getUnsettledPeriodStart("2024-13")).toBe("2024-14-01T00:00:00Z")
+    // ^ note: regex matches MM digits but not the actual month range. The
+    // function trusts callers — this case is currently lenient by design.
+  })
+})
+
+describe("computeBalances", () => {
+  const ME = "user-me"
+  const A = "user-a"
+  const B = "user-b"
+  const names = new Map<string, string | null>([
+    [A, "Alice"],
+    [B, "Bob"],
+  ])
+
+  function expense(
+    overrides: Partial<{
+      id: string
+      name: string
+      creator_id: string
+      created_at: string
+    }>
+  ) {
+    return {
+      id: overrides.id ?? "exp-1",
+      name: overrides.name ?? "Lunch",
+      creator_id: overrides.creator_id ?? ME,
+      created_at: overrides.created_at ?? "2024-01-01T12:00:00Z",
+    }
+  }
+
+  function item(
+    overrides: Partial<{
+      id: string
+      debtor_id: string
+      amount: number
+      paid_at: string | null
+      expense: ReturnType<typeof expense>
+    }>
+  ) {
+    return {
+      id: overrides.id ?? "item-1",
+      debtor_id: overrides.debtor_id ?? A,
+      amount: overrides.amount ?? 100,
+      paid_at: overrides.paid_at ?? null,
+      expense: overrides.expense ?? expense({}),
+    }
+  }
+
+  test("classifies someone-owes-me when I created the expense", () => {
+    const result = computeBalances(
+      [item({ debtor_id: A, amount: 250 })],
+      ME,
+      names
+    )
+    expect(result.iOwe).toEqual([])
+    expect(result.owedToMe).toHaveLength(1)
+    expect(result.owedToMe[0]).toMatchObject({
+      userId: A,
+      userName: "Alice",
+      netAmount: 250,
+    })
+  })
+
+  test("classifies I-owe when I am the debtor", () => {
+    const result = computeBalances(
+      [item({ debtor_id: ME, expense: expense({ creator_id: A }) })],
+      ME,
+      names
+    )
+    expect(result.owedToMe).toEqual([])
+    expect(result.iOwe).toHaveLength(1)
+    expect(result.iOwe[0]?.userId).toBe(A)
+  })
+
+  test("paid items contribute to total but not to net", () => {
+    const result = computeBalances(
+      [
+        item({ id: "i1", amount: 100, paid_at: null }),
+        item({ id: "i2", amount: 50, paid_at: "2024-02-01T00:00:00Z" }),
+      ],
+      ME,
+      names
+    )
+    // total = 150 → entry stays. net = 100 (only the unpaid item).
+    expect(result.owedToMe[0]?.netAmount).toBe(100)
+  })
+
+  test("drops counterparties whose total nets to zero", () => {
+    // I owe A 100, A owes me 100 (different expenses) → balanced.
+    const result = computeBalances(
+      [
+        item({
+          id: "i1",
+          debtor_id: A,
+          amount: 100,
+          expense: expense({ id: "e1", creator_id: ME }),
+        }),
+        item({
+          id: "i2",
+          debtor_id: ME,
+          amount: 100,
+          expense: expense({ id: "e2", creator_id: A }),
+        }),
+      ],
+      ME,
+      names
+    )
+    expect(result.iOwe).toEqual([])
+    expect(result.owedToMe).toEqual([])
+  })
+
+  test("ignores items the viewer is not part of", () => {
+    const result = computeBalances(
+      [
+        item({
+          debtor_id: B,
+          expense: expense({ creator_id: A }),
+        }),
+      ],
+      ME,
+      names
+    )
+    expect(result.iOwe).toEqual([])
+    expect(result.owedToMe).toEqual([])
+  })
+
+  test("sorts each side descending by net amount", () => {
+    const result = computeBalances(
+      [
+        item({
+          id: "i1",
+          debtor_id: A,
+          amount: 50,
+          expense: expense({ id: "e1", creator_id: ME }),
+        }),
+        item({
+          id: "i2",
+          debtor_id: B,
+          amount: 300,
+          expense: expense({ id: "e2", creator_id: ME }),
+        }),
+      ],
+      ME,
+      names
+    )
+    expect(result.owedToMe.map((e) => e.userId)).toEqual([B, A])
+  })
+})

--- a/apps/portal/lib/leave/date.test.ts
+++ b/apps/portal/lib/leave/date.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  formatLeaveDate,
+  getNextMondays,
+  parseLocalDate,
+  toIsoDate,
+} from "@/lib/leave/date"
+
+describe("parseLocalDate", () => {
+  test("returns local midnight of the requested ISO date", () => {
+    const d = parseLocalDate("2024-01-15")
+    expect(d.getFullYear()).toBe(2024)
+    expect(d.getMonth()).toBe(0)
+    expect(d.getDate()).toBe(15)
+    expect(d.getHours()).toBe(0)
+  })
+})
+
+describe("formatLeaveDate", () => {
+  test("renders the slash-separated calendar form", () => {
+    expect(formatLeaveDate("2024-01-15")).toBe("2024/01/15")
+    expect(formatLeaveDate("2024-12-31")).toBe("2024/12/31")
+  })
+})
+
+describe("toIsoDate", () => {
+  test("round-trips with parseLocalDate", () => {
+    const original = "2024-09-09"
+    expect(toIsoDate(parseLocalDate(original))).toBe(original)
+  })
+})
+
+describe("getNextMondays", () => {
+  function makeLocal(year: number, monthIndex: number, day: number) {
+    return new Date(year, monthIndex, day)
+  }
+
+  test("if today is a Sunday, the first Monday is tomorrow", () => {
+    // 2024-01-07 is a Sunday.
+    const sunday = makeLocal(2024, 0, 7)
+    const [first] = getNextMondays(1, sunday)
+    expect(first?.getFullYear()).toBe(2024)
+    expect(first?.getMonth()).toBe(0)
+    expect(first?.getDate()).toBe(8)
+  })
+
+  test("if today is a Monday, the first Monday is today", () => {
+    const monday = makeLocal(2024, 0, 8)
+    const [first] = getNextMondays(1, monday)
+    expect(first?.getDate()).toBe(8)
+  })
+
+  test("if today is a Wednesday, the first Monday is five days later", () => {
+    // 2024-01-10 is a Wednesday.
+    const wednesday = makeLocal(2024, 0, 10)
+    const [first] = getNextMondays(1, wednesday)
+    expect(first?.getDate()).toBe(15)
+  })
+
+  test("returns N consecutive Mondays seven days apart", () => {
+    const monday = makeLocal(2024, 0, 8)
+    const list = getNextMondays(4, monday)
+    expect(list.map((d) => d.getDate())).toEqual([8, 15, 22, 29])
+  })
+
+  test("rolls into the next month correctly", () => {
+    // Last Monday of January 2024 is the 29th. Next Monday is Feb 5.
+    const lastMonday = makeLocal(2024, 0, 29)
+    const list = getNextMondays(2, lastMonday)
+    expect(list[0]?.getMonth()).toBe(0)
+    expect(list[0]?.getDate()).toBe(29)
+    expect(list[1]?.getMonth()).toBe(1)
+    expect(list[1]?.getDate()).toBe(5)
+  })
+})

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -9,7 +9,8 @@
     "start": "next start",
     "lint": "eslint",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
   },
   "dependencies": {
     "@react-email/components": "^1.0.12",

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",
+    "@types/bun": "^1.3.13",
     "@types/node": "^25.1.0",
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19.2.3",

--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.18",
+        "@types/bun": "^1.3.13",
         "@types/node": "^25.1.0",
         "@types/react": "^19.2.10",
         "@types/react-dom": "^19.2.3",
@@ -100,6 +101,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.18",
+        "@types/bun": "^1.3.13",
         "@types/node": "^25.1.0",
         "@types/react": "^19.2.10",
         "@types/react-dom": "^19.2.3",
@@ -782,6 +784,8 @@
 
     "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-Or6ljjB4TiiwCdVKDYWew0SokQ9kep5zruL8P3nbum9WdkH5XA41rQID4Ulc215Z+R3DrB+qXSHPsJjU3/n2ng=="],
 
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
     "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
 
     "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
@@ -903,6 +907,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "turbo lint",
     "format": "turbo format",
     "typecheck": "turbo typecheck",
+    "test": "turbo test",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/turbo.json
+++ b/turbo.json
@@ -28,6 +28,9 @@
     "typecheck": {
       "dependsOn": ["^typecheck"]
     },
+    "test": {
+      "dependsOn": ["^test"]
+    },
     "dev": {
       "cache": false,
       "persistent": true,


### PR DESCRIPTION
## Summary

Repo 之前 0 個測試。把 `bun test`（內建，零依賴）接進 turbo + CI pipeline，順手寫 5 組 high-ROI 的單元測試當示範。後續加測試直接在原檔旁開 \`*.test.ts\` 就好，沒新工具要學。

## Why

之前討論過：solo lab project 的測試只值得做兩種 — 純 lib 邏輯 + RLS policy。本 PR 是第一種的起手式。挑的都是「邏輯會炸、改動頻繁、不依賴瀏覽器/network」的檔案，bug 真的會發生在這。

## What changed

### 基礎設施
- **`turbo.json`** — 加 `test` task。
- **root `package.json`** — 加 \`"test": "turbo test"\` 跟 lint/typecheck 對齊。
- **`apps/portal/package.json` + `apps/gallery/package.json`** — 加 \`"test": "bun test"\`。
- **`.github/workflows/ci.yml`** — 加 Test step，job 名改成 \`typecheck · lint · test · build\`。

### 第一批測試（41 passing）
- **`lib/gallery/mime.test.ts`**（15 tests）— `resolveMediaMimeType` 對 image/video MIME 的判別、副檔名 fallback、image-only 路徑拒絕 video（安全邊界）、whitelist 不重疊不變式。
- **`lib/debt/balance.test.ts`**（11 tests）— `getUnsettledPeriodStart` 跨年/跨月、`computeBalances` 創建者 vs debtor 角色判定、paid 不算 net、零和關係 drop、外人忽略、排序穩定。
- **`lib/leave/date.test.ts`**（8 tests）— `getNextMondays` 在週日/週一/週三起算的 offset、跨月、N 連 Monday 的 7 日步進。
- **`lib/approve/validation.test.ts`**（5 tests）— 表單 4 種拒絕路徑 + 1 種接受。
- **`lib/bento/date.test.ts`**（3 tests）— `parseOrderDate` 8 位數格式化、非法輸入 passthrough。

## Coverage philosophy

不追 % coverage。新功能順手在最容易炸的地方補 1-2 個 case 就好。如果寫 test 比寫 code 還久，那條路徑可能本來就不該測（多半是 UI 或 framework glue）。

## Test plan

- [x] `bun run test` 本地全綠（41 pass / 0 fail / 79 expect calls / ~150ms）
- [x] `bun run typecheck` 0 errors
- [x] `bun run lint` 0 errors
- [x] turbo cache 正常運作（second run \`>>> FULL TURBO\`）

## Breaking changes

無。