### PR TITLE
feat(meetings): expose presenter_email in schedule API response

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,42 @@ No test runner. Don't add one without asking.
 
 Write commits as `<type>: description`, English, written like a person. Full branch / PR / review rules live in `CONTRIBUTING.md`.
 
+### GitHub issue + PR workflow
+
+**Before pushing and opening a PR**, always follow these steps:
+
+1. **Check for an existing issue** — search with `gh issue list` or `gh issue list --search "<keyword>"`. If one already tracks the bug or feature, note its number.
+
+2. **If no issue exists, create one first**:
+
+```bash
+gh issue create \
+  --title "<concise title>" \
+  --body "<what, why, and how to reproduce if a bug>" \
+  --label "bug"         # or "enhancement", "documentation", etc. \
+  --assignee "JaeggerJose"   # assign to the relevant person
+```
+
+Available labels: `bug`, `enhancement`, `documentation`, `duplicate`, `question`, `help wanted`, `good first issue`, `invalid`, `wontfix`, `dependencies`, `javascript`, `github_actions`.  
+Known collaborators: `beenson`, `Tim7179`, `stanleyshen2003`, `N0Ball`, `JaeggerJose`, `zyx1121`, `Metabolism2003`, `qqqqq4545`.
+
+3. **Reference the issue in the PR body** using `Closes #<number>` so GitHub auto-closes it on merge.
+
+```bash
+gh pr create --title "..." --body "$(cat <<'EOF'
+Closes #<issue-number>
+
+## Summary
+...
+
+## Test plan
+- [ ] ...
+EOF
+)"
+```
+
+Never open a PR without a linked issue. Exceptions: typo fixes, dependency bumps, and trivial chores where an issue would be pure overhead.
+
 ## Architecture
 
 ### Monorepo topology

--- a/apps/portal/app/api/meetings/schedule/route.ts
+++ b/apps/portal/app/api/meetings/schedule/route.ts
@@ -49,11 +49,22 @@ export async function GET(request: NextRequest) {
 
   const m = data as DbMeeting
 
+  let presenterEmail: string | null = null
+  if (m.presenter_user_id) {
+    const { data: profile } = await supabase
+      .from("user_profiles")
+      .select("email")
+      .eq("id", m.presenter_user_id)
+      .maybeSingle()
+    presenterEmail = profile?.email ?? null
+  }
+
   return NextResponse.json(
     {
       date: m.scheduled_date,
       week: m.week_label,
       presenter: m.presenter,
+      presenter_email: presenterEmail,
       paper: m.paper_title,
     },
     { headers: CORS }


### PR DESCRIPTION
Closes #85

## Summary
- Add `presenter_email: string | null` field to `GET /api/meetings/schedule` response
- Fetches the email from `user_profiles` via `presenter_user_id` in the same request
- Returns `null` when no presenter is assigned to the meeting

## Test plan
- [ ] Call `/api/meetings/schedule` — verify `presenter_email` appears in each meeting object
- [ ] Verify meetings without a presenter return `presenter_email: null`