### PR TITLE
fix(bulletin): move bulletin board between user card and app nav

### DIFF
--- a/apps/portal/app/page.tsx
+++ b/apps/portal/app/page.tsx
@@ -62,6 +62,7 @@ export default async function Page() {
           email={currentUser.email}
           avatarUrl={currentUser.avatarUrl}
         />
+        <BulletinBoard />
         <nav className="flex flex-col gap-3">
           {apps.map((app) => (
             <Button
@@ -97,7 +98,6 @@ export default async function Page() {
             </Button>
           ))}
         </div>
-        <BulletinBoard />
         <SignOutButton />
       </div>
     </PortalShell>


### PR DESCRIPTION
Closes #87

## Summary
- Moves `<BulletinBoard />` from the bottom of the page to between `<UserCard />` and `<nav>`
- Better visual hierarchy: who you are → important announcements → pick an app

## Test plan
- [ ] Visit portal home — bulletin board section appears between user card and app list