### PR TITLE
feat(meetings): question groups, location, start_time per meeting

### DIFF
--- a/apps/portal/app/api/meetings/schedule/route.ts
+++ b/apps/portal/app/api/meetings/schedule/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server"
 
 import { createClient } from "@supabase/supabase-js"
 
-import type { DbMeeting } from "@/lib/meetings/types"
+import type { DbMeeting, DbMeetingGroup } from "@/lib/meetings/types"
 
 function createServiceClient() {
   return createClient(
@@ -34,20 +34,71 @@ export async function GET(request: NextRequest) {
   }
 
   const supabase = createServiceClient()
-  const { data, error } = await supabase
-    .from("meetings")
-    .select("*")
-    .eq("scheduled_date", date)
-    .maybeSingle()
 
-  if (error || !data || (data as DbMeeting).is_holiday) {
+  const [{ data: meetingData, error }, { data: upcomingData }] =
+    await Promise.all([
+      supabase
+        .from("meetings")
+        .select("*")
+        .eq("scheduled_date", date)
+        .maybeSingle(),
+      supabase
+        .from("meetings")
+        .select("presenter, scheduled_date")
+        .gt("scheduled_date", date)
+        .eq("is_holiday", false)
+        .not("presenter", "is", null)
+        .order("scheduled_date", { ascending: true })
+        .limit(12),
+    ])
+
+  if (error || !meetingData || (meetingData as DbMeeting).is_holiday) {
     return NextResponse.json(
       { error: "No schedule found for this date" },
       { status: 404, headers: CORS }
     )
   }
 
-  const m = data as DbMeeting
+  const m = meetingData as DbMeeting
+
+  // Fetch presenter email
+  let presenterEmail: string | null = null
+  if (m.presenter_user_id) {
+    const { data: profile } = await supabase
+      .from("user_profiles")
+      .select("email")
+      .eq("id", m.presenter_user_id)
+      .maybeSingle()
+    presenterEmail = profile?.email ?? null
+  }
+
+  // Fetch question group members if assigned
+  let questionGroup: { number: number; members: string[] } | null = null
+  if (m.question_group_number) {
+    const { data: group } = await supabase
+      .from("meeting_groups")
+      .select("group_number, members")
+      .eq("group_number", m.question_group_number)
+      .maybeSingle()
+    if (group) {
+      const g = group as Pick<DbMeetingGroup, "group_number" | "members">
+      questionGroup = { number: g.group_number, members: g.members }
+    }
+  }
+
+  // Deduplicate presenter_order (keep first occurrence per name)
+  const upcoming = (upcomingData ?? []) as Array<{
+    presenter: string | null
+    scheduled_date: string
+  }>
+  const seen = new Set<string>()
+  const presenterOrder: string[] = []
+  for (const row of upcoming) {
+    if (row.presenter && !seen.has(row.presenter)) {
+      seen.add(row.presenter)
+      presenterOrder.push(row.presenter)
+    }
+  }
 
   let presenterEmail: string | null = null
   if (m.presenter_user_id) {
@@ -66,6 +117,11 @@ export async function GET(request: NextRequest) {
       presenter: m.presenter,
       presenter_email: presenterEmail,
       paper: m.paper_title,
+      location: m.location,
+      start_time: m.start_time,
+      question_group: questionGroup,
+      next_presenter: presenterOrder[0] ?? null,
+      presenter_order: presenterOrder,
     },
     { headers: CORS }
   )

--- a/apps/portal/app/api/meetings/schedule/route.ts
+++ b/apps/portal/app/api/meetings/schedule/route.ts
@@ -100,16 +100,6 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  let presenterEmail: string | null = null
-  if (m.presenter_user_id) {
-    const { data: profile } = await supabase
-      .from("user_profiles")
-      .select("email")
-      .eq("id", m.presenter_user_id)
-      .maybeSingle()
-    presenterEmail = profile?.email ?? null
-  }
-
   return NextResponse.json(
     {
       date: m.scheduled_date,

--- a/apps/portal/app/meetings/_components/groups-panel.tsx
+++ b/apps/portal/app/meetings/_components/groups-panel.tsx
@@ -1,0 +1,127 @@
+"use client"
+
+import { useState } from "react"
+
+import { IconPencil } from "@tabler/icons-react"
+import { Button } from "@workspace/ui/components/button"
+import { Input } from "@workspace/ui/components/input"
+
+import {
+  useMeetingGroups,
+  useUpdateMeetingGroup,
+} from "@/hooks/meetings/use-meeting-groups"
+
+function GroupCard({
+  groupNumber,
+  members,
+  isAdmin,
+}: {
+  groupNumber: number
+  members: string[]
+  isAdmin: boolean
+}) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(members.join(" "))
+  const update = useUpdateMeetingGroup()
+
+  function save() {
+    const next = draft
+      .split(/[\s,、]+/)
+      .map((s) => s.trim())
+      .filter(Boolean)
+    update.mutate(
+      { groupNumber, members: next },
+      { onSuccess: () => setEditing(false) }
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border p-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-muted-foreground">
+          小組 {groupNumber}
+        </span>
+        {isAdmin && !editing && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 text-muted-foreground"
+            onClick={() => {
+              setDraft(members.join(" "))
+              setEditing(true)
+            }}
+          >
+            <IconPencil className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </div>
+
+      {editing ? (
+        <div className="flex flex-col gap-2">
+          <Input
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder="以空格或逗號分隔"
+            className="h-8 text-sm"
+            autoFocus
+          />
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              className="h-7 text-xs"
+              disabled={update.isPending}
+              onClick={save}
+            >
+              {update.isPending ? "儲存中…" : "儲存"}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 text-xs"
+              onClick={() => setEditing(false)}
+            >
+              取消
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-wrap gap-1.5">
+          {members.map((m) => (
+            <span key={m} className="rounded-md bg-muted px-2 py-0.5 text-xs">
+              {m}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function GroupsPanel({ isAdmin }: { isAdmin: boolean }) {
+  const { data: groups = [], isLoading } = useMeetingGroups()
+
+  if (isLoading) {
+    return <p className="text-sm text-muted-foreground">載入中…</p>
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-xs text-muted-foreground">提問小組</p>
+      <div className="grid grid-cols-2 gap-2">
+        {groups.map((g) => (
+          <GroupCard
+            key={g.groupNumber}
+            groupNumber={g.groupNumber}
+            members={g.members}
+            isAdmin={isAdmin}
+          />
+        ))}
+      </div>
+      {isAdmin && (
+        <p className="text-xs text-muted-foreground">
+          ＊若有組員於同週報告，將與下一組的成員對調
+        </p>
+      )}
+    </div>
+  )
+}

--- a/apps/portal/app/meetings/_components/info-tab.tsx
+++ b/apps/portal/app/meetings/_components/info-tab.tsx
@@ -2,9 +2,11 @@ import Link from "next/link"
 
 import { Card, CardContent } from "@workspace/ui/components/card"
 
+import { GroupsPanel } from "./groups-panel"
+
 const INFO = [
   { label: "地點", value: "EC 411" },
-  { label: "時間", value: "週一 16:30 – 18:30" },
+  { label: "時間", value: "週一 15:30" },
   {
     label: "Teams 會議",
     value: "加入 Teams",
@@ -27,28 +29,33 @@ const INFO = [
   },
 ]
 
-export function InfoTab() {
+export function InfoTab({ isAdmin }: { isAdmin: boolean }) {
   return (
-    <div className="flex flex-col gap-3">
-      {INFO.map((item) => (
-        <Card key={item.label}>
-          <CardContent className="flex items-center justify-between py-4">
-            <span className="text-sm text-muted-foreground">{item.label}</span>
-            {item.href ? (
-              <Link
-                href={item.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-sm transition-colors hover:text-foreground"
-              >
-                {item.value}
-              </Link>
-            ) : (
-              <span className="text-sm font-medium">{item.value}</span>
-            )}
-          </CardContent>
-        </Card>
-      ))}
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-3">
+        {INFO.map((item) => (
+          <Card key={item.label}>
+            <CardContent className="flex items-center justify-between py-4">
+              <span className="text-sm text-muted-foreground">
+                {item.label}
+              </span>
+              {item.href ? (
+                <Link
+                  href={item.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm transition-colors hover:text-foreground"
+                >
+                  {item.value}
+                </Link>
+              ) : (
+                <span className="text-sm font-medium">{item.value}</span>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      <GroupsPanel isAdmin={isAdmin} />
     </div>
   )
 }

--- a/apps/portal/app/meetings/_components/meeting-edit-dialog.tsx
+++ b/apps/portal/app/meetings/_components/meeting-edit-dialog.tsx
@@ -11,6 +11,13 @@ import {
 import { Button } from "@workspace/ui/components/button"
 import { Checkbox } from "@workspace/ui/components/checkbox"
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@workspace/ui/components/select"
+import {
   Dialog,
   DialogContent,
   DialogFooter,
@@ -121,6 +128,11 @@ export function MeetingEditDialog({
   const [weekLabel, setWeekLabel] = useState(meeting.weekLabel ?? "")
   const [date, setDate] = useState(meeting.scheduledDate)
   const [isHoliday, setIsHoliday] = useState(meeting.isHoliday)
+  const [location, setLocation] = useState(meeting.location)
+  const [startTime, setStartTime] = useState(meeting.startTime)
+  const [questionGroupNumber, setQuestionGroupNumber] = useState<number | null>(
+    meeting.questionGroupNumber
+  )
   const [presenterUserId, setPresenterUserId] = useState(
     meeting.presenterUserId ?? "__none__"
   )
@@ -150,6 +162,9 @@ export function MeetingEditDialog({
     setWeekLabel(meeting.weekLabel ?? "")
     setDate(meeting.scheduledDate)
     setIsHoliday(meeting.isHoliday)
+    setLocation(meeting.location)
+    setStartTime(meeting.startTime)
+    setQuestionGroupNumber(meeting.questionGroupNumber)
     setPresenterUserId(meeting.presenterUserId ?? "__none__")
     setPaperTitle(meeting.paperTitle ?? "")
     setPaperLink(meeting.paperLink ?? "")
@@ -215,6 +230,9 @@ export function MeetingEditDialog({
           weekLabel: weekLabel || null,
           scheduledDate: date,
           isHoliday,
+          location: location || "EC 411",
+          startTime: startTime || "15:30",
+          questionGroupNumber,
         },
         { onSuccess: () => onOpenChange(false) }
       )
@@ -258,6 +276,45 @@ export function MeetingEditDialog({
                 />
                 假日 / 暫停（不需要報告人）
               </label>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="flex flex-col gap-1.5">
+                  <Label>地點</Label>
+                  <Input
+                    value={location}
+                    onChange={(e) => setLocation(e.target.value)}
+                    placeholder="EC 411"
+                  />
+                </div>
+                <div className="flex flex-col gap-1.5">
+                  <Label>時間</Label>
+                  <Input
+                    value={startTime}
+                    onChange={(e) => setStartTime(e.target.value)}
+                    placeholder="15:30"
+                  />
+                </div>
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <Label>提問小組</Label>
+                <Select
+                  value={questionGroupNumber?.toString() ?? "none"}
+                  onValueChange={(v) =>
+                    setQuestionGroupNumber(v === "none" ? null : Number(v))
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="未指定" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">未指定</SelectItem>
+                    {[1, 2, 3, 4].map((n) => (
+                      <SelectItem key={n} value={String(n)}>
+                        小組 {n}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
             </>
           )}
           {!isHoliday && (

--- a/apps/portal/app/meetings/_components/schedule-tab.tsx
+++ b/apps/portal/app/meetings/_components/schedule-tab.tsx
@@ -77,6 +77,7 @@ export function ScheduleTab({ year }: { year: number }) {
               <TableHead className="w-10 text-center">PPT</TableHead>
               <TableHead className="w-10 text-center">錄影</TableHead>
               <TableHead>Paper</TableHead>
+              <TableHead className="w-16 text-center">小組</TableHead>
               <TableHead className="hidden md:table-cell">備註</TableHead>
               <TableHead className="w-16" />
             </TableRow>
@@ -135,6 +136,15 @@ export function ScheduleTab({ year }: { year: number }) {
                       >
                         {m.paperTitle ?? "—"}
                       </span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-center">
+                    {m.questionGroupNumber ? (
+                      <span className="inline-flex items-center rounded-full border px-1.5 py-0.5 text-xs text-muted-foreground tabular-nums">
+                        G{m.questionGroupNumber}
+                      </span>
+                    ) : (
+                      <span className="text-xs text-muted-foreground">—</span>
                     )}
                   </TableCell>
                   <TableCell className="hidden text-xs text-muted-foreground md:table-cell">

--- a/apps/portal/app/meetings/page.tsx
+++ b/apps/portal/app/meetings/page.tsx
@@ -107,7 +107,7 @@ export default function MeetingsPage() {
           <PapersTab />
         </TabsContent>
         <TabsContent value="info" className="mt-4">
-          <InfoTab />
+          <InfoTab isAdmin={isAdmin} />
         </TabsContent>
       </Tabs>
 

--- a/apps/portal/hooks/meetings/query-keys.ts
+++ b/apps/portal/hooks/meetings/query-keys.ts
@@ -12,4 +12,7 @@ export const queryKeys = {
   users: {
     all: ["meetings", "users"] as const,
   },
+  groups: {
+    all: ["meeting_groups"] as const,
+  },
 }

--- a/apps/portal/hooks/meetings/use-meeting-groups.ts
+++ b/apps/portal/hooks/meetings/use-meeting-groups.ts
@@ -1,0 +1,53 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+
+import { createClient } from "@/lib/supabase/client"
+import {
+  toMeetingGroup,
+  type DbMeetingGroup,
+  type MeetingGroup,
+} from "@/lib/meetings/types"
+
+export function useMeetingGroups() {
+  const supabase = createClient()
+
+  return useQuery({
+    queryKey: ["meeting_groups"],
+    queryFn: async (): Promise<MeetingGroup[]> => {
+      const { data, error } = await supabase
+        .from("meeting_groups")
+        .select("*")
+        .order("group_number")
+      if (error) throw new Error(error.message)
+      return (data as DbMeetingGroup[]).map(toMeetingGroup)
+    },
+  })
+}
+
+export function useUpdateMeetingGroup() {
+  const supabase = createClient()
+  const qc = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      groupNumber,
+      members,
+    }: {
+      groupNumber: number
+      members: string[]
+    }) => {
+      const { error } = await supabase
+        .from("meeting_groups")
+        .update({ members, updated_at: new Date().toISOString() })
+        .eq("group_number", groupNumber)
+      if (error) throw new Error(error.message)
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["meeting_groups"] })
+      toast.success("小組已更新")
+    },
+    onError: (e: Error) => toast.error(e.message),
+  })
+}

--- a/apps/portal/hooks/meetings/use-meetings.ts
+++ b/apps/portal/hooks/meetings/use-meetings.ts
@@ -126,6 +126,9 @@ export function useAdminUpdateMeeting() {
       videoUploaded,
       videoLink,
       notes,
+      location,
+      startTime,
+      questionGroupNumber,
     }: {
       id: string
       weekLabel: string | null
@@ -140,6 +143,9 @@ export function useAdminUpdateMeeting() {
       videoUploaded: boolean
       videoLink: string | null
       notes: string | null
+      location: string
+      startTime: string
+      questionGroupNumber: number | null
     }) => {
       const { error } = await supabase
         .from(TABLE)
@@ -156,6 +162,9 @@ export function useAdminUpdateMeeting() {
           video_uploaded: videoUploaded,
           video_link: videoLink,
           notes,
+          location,
+          start_time: startTime,
+          question_group_number: questionGroupNumber,
         })
         .eq("id", id)
       if (error) throw new Error(error.message || "更新失敗")

--- a/apps/portal/lib/meetings/types.ts
+++ b/apps/portal/lib/meetings/types.ts
@@ -13,6 +13,9 @@ export interface Meeting {
   paperTitle: string | null
   paperLink: string | null
   notes: string | null
+  location: string
+  startTime: string
+  questionGroupNumber: number | null
   createdAt: string
 }
 
@@ -23,6 +26,11 @@ export interface TeacherPaper {
   fileLink: string | null
   source: string | null
   createdAt: string
+}
+
+export interface MeetingGroup {
+  groupNumber: number
+  members: string[]
 }
 
 export interface DbMeeting {
@@ -40,6 +48,9 @@ export interface DbMeeting {
   paper_title: string | null
   paper_link: string | null
   notes: string | null
+  location: string
+  start_time: string
+  question_group_number: number | null
   created_at: string
 }
 
@@ -50,6 +61,12 @@ export interface DbTeacherPaper {
   file_link: string | null
   source: string | null
   created_at: string
+}
+
+export interface DbMeetingGroup {
+  group_number: number
+  members: string[]
+  updated_at: string
 }
 
 export function toMeeting(row: DbMeeting): Meeting {
@@ -68,6 +85,9 @@ export function toMeeting(row: DbMeeting): Meeting {
     paperTitle: row.paper_title,
     paperLink: row.paper_link,
     notes: row.notes,
+    location: row.location,
+    startTime: row.start_time,
+    questionGroupNumber: row.question_group_number,
     createdAt: row.created_at,
   }
 }
@@ -80,5 +100,12 @@ export function toTeacherPaper(row: DbTeacherPaper): TeacherPaper {
     fileLink: row.file_link,
     source: row.source,
     createdAt: row.created_at,
+  }
+}
+
+export function toMeetingGroup(row: DbMeetingGroup): MeetingGroup {
+  return {
+    groupNumber: row.group_number,
+    members: row.members,
   }
 }

--- a/supabase/migrations/2026-05-09-meeting-groups.sql
+++ b/supabase/migrations/2026-05-09-meeting-groups.sql
@@ -1,0 +1,39 @@
+-- Add per-meeting location, start_time, and question group to meetings
+ALTER TABLE public.meetings
+  ADD COLUMN IF NOT EXISTS location    text NOT NULL DEFAULT 'EC 411',
+  ADD COLUMN IF NOT EXISTS start_time  text NOT NULL DEFAULT '15:30',
+  ADD COLUMN IF NOT EXISTS question_group_number int;
+
+-- Meeting question groups (updated each semester by admin)
+CREATE TABLE IF NOT EXISTS public.meeting_groups (
+  group_number  int PRIMARY KEY CHECK (group_number BETWEEN 1 AND 9),
+  members       text[] NOT NULL DEFAULT '{}',
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.meetings
+  ADD CONSTRAINT fk_meeting_question_group
+    FOREIGN KEY (question_group_number)
+    REFERENCES public.meeting_groups(group_number)
+    ON DELETE SET NULL;
+
+-- Seed initial groups
+INSERT INTO public.meeting_groups (group_number, members) VALUES
+  (1, ARRAY['洺玄', '岱廷', '翊婕']),
+  (2, ARRAY['昱宏', '詠翔', '翰成']),
+  (3, ARRAY['胤翔', '朝福', '睿丞']),
+  (4, ARRAY['洺玄', '昱宏', '岱廷'])
+ON CONFLICT (group_number) DO NOTHING;
+
+-- RLS
+ALTER TABLE public.meeting_groups ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "authenticated read meeting_groups"
+  ON public.meeting_groups FOR SELECT
+  TO authenticated USING (true);
+
+CREATE POLICY "meetings admin write meeting_groups"
+  ON public.meeting_groups FOR ALL
+  TO authenticated
+  USING (is_meetings_admin())
+  WITH CHECK (is_meetings_admin());


### PR DESCRIPTION
Closes #89

## Summary

- `meeting_groups` table with RLS, seeded with 4 groups (可每學期由 admin 更新)
- `meetings` 新增 `location`、`start_time`、`question_group_number` 欄位
- Schedule API 回傳 `question_group`、`next_presenter`、`presenter_order`（從未來幾週排班推導，不需另建 config 表）
- Admin 編輯 dialog 加地點、時間欄位與小組下拉選單
- 排班表新增「小組」欄顯示 `G{n}` badge
- Meeting 資訊 tab 新增 `GroupsPanel`，admin 可 inline 編輯各組成員
- Google Script ReminderEmail.gs 改從 API 讀取 `question_groups` 與 `presenter_order`（移除舊 `CONFIG.PRESENTER_ORDER` / `CONFIG.QUESTION_GROUPS`）

## Migration

`supabase/migrations/2026-05-09-meeting-groups.sql` — 已套用至 production。

## Test plan

- [ ] Admin 可在 edit dialog 選擇小組（1–4 或「未指定」）
- [ ] 排班表「小組」欄正確顯示 `G1`–`G4` 或 `—`
- [ ] Meeting 資訊 tab → 提問小組顯示四組成員
- [ ] Admin 點鉛筆圖示後可修改組員並儲存
- [ ] `/api/meetings/schedule?date=...` 回傳含 `question_group`、`next_presenter`、`presenter_order` 的 JSON

🤖 Generated with [Claude Code](https://claude.ai/claude-code)