### PR TITLE
feat(meetings): dynamic groups with user picker, wider schedule table

### DIFF
--- a/apps/portal/app/meetings/_components/groups-panel.tsx
+++ b/apps/portal/app/meetings/_components/groups-panel.tsx
@@ -2,11 +2,13 @@
 
 import { useState } from "react"
 
-import { IconPencil } from "@tabler/icons-react"
+import { IconPlus, IconTrash, IconX } from "@tabler/icons-react"
 import { Button } from "@workspace/ui/components/button"
-import { Input } from "@workspace/ui/components/input"
 
+import { useLabUsers } from "@/hooks/meetings/use-lab-users"
 import {
+  useAddMeetingGroup,
+  useDeleteMeetingGroup,
   useMeetingGroups,
   useUpdateMeetingGroup,
 } from "@/hooks/meetings/use-meeting-groups"
@@ -21,18 +23,29 @@ function GroupCard({
   isAdmin: boolean
 }) {
   const [editing, setEditing] = useState(false)
-  const [draft, setDraft] = useState(members.join(" "))
+  const [draft, setDraft] = useState<string[]>(members)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+
   const update = useUpdateMeetingGroup()
+  const del = useDeleteMeetingGroup()
+  const { data: labUsers = [] } = useLabUsers()
+
+  function toggleUser(name: string) {
+    setDraft((prev) =>
+      prev.includes(name) ? prev.filter((m) => m !== name) : [...prev, name]
+    )
+  }
 
   function save() {
-    const next = draft
-      .split(/[\s,、]+/)
-      .map((s) => s.trim())
-      .filter(Boolean)
     update.mutate(
-      { groupNumber, members: next },
+      { groupNumber, members: draft },
       { onSuccess: () => setEditing(false) }
     )
+  }
+
+  function cancelEdit() {
+    setDraft(members)
+    setEditing(false)
   }
 
   return (
@@ -41,30 +54,89 @@ function GroupCard({
         <span className="text-xs font-medium text-muted-foreground">
           小組 {groupNumber}
         </span>
+
         {isAdmin && !editing && (
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-6 w-6 text-muted-foreground"
-            onClick={() => {
-              setDraft(members.join(" "))
-              setEditing(true)
-            }}
-          >
-            <IconPencil className="h-3.5 w-3.5" />
-          </Button>
+          <div className="flex items-center gap-1">
+            {confirmDelete ? (
+              <>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  className="h-6 px-2 text-xs"
+                  disabled={del.isPending}
+                  onClick={() => del.mutate(groupNumber)}
+                >
+                  確定刪除
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6"
+                  onClick={() => setConfirmDelete(false)}
+                >
+                  <IconX className="h-3 w-3" />
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 text-muted-foreground"
+                  onClick={() => {
+                    setDraft(members)
+                    setEditing(true)
+                  }}
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="h-3.5 w-3.5"
+                  >
+                    <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
+                  </svg>
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 text-muted-foreground hover:text-destructive"
+                  onClick={() => setConfirmDelete(true)}
+                >
+                  <IconTrash className="h-3.5 w-3.5" />
+                </Button>
+              </>
+            )}
+          </div>
         )}
       </div>
 
       {editing ? (
-        <div className="flex flex-col gap-2">
-          <Input
-            value={draft}
-            onChange={(e) => setDraft(e.target.value)}
-            placeholder="以空格或逗號分隔"
-            className="h-8 text-sm"
-            autoFocus
-          />
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-wrap gap-1.5">
+            {labUsers.map((u) => {
+              const name = u.name ?? ""
+              const selected = draft.includes(name)
+              return (
+                <button
+                  key={u.id}
+                  type="button"
+                  onClick={() => toggleUser(name)}
+                  className={`rounded-md px-2 py-0.5 text-xs transition-colors ${
+                    selected
+                      ? "bg-foreground text-background"
+                      : "bg-muted text-muted-foreground hover:bg-muted/70"
+                  }`}
+                >
+                  {name}
+                </button>
+              )
+            })}
+          </div>
           <div className="flex gap-2">
             <Button
               size="sm"
@@ -78,7 +150,7 @@ function GroupCard({
               size="sm"
               variant="ghost"
               className="h-7 text-xs"
-              onClick={() => setEditing(false)}
+              onClick={cancelEdit}
             >
               取消
             </Button>
@@ -86,11 +158,15 @@ function GroupCard({
         </div>
       ) : (
         <div className="flex flex-wrap gap-1.5">
-          {members.map((m) => (
-            <span key={m} className="rounded-md bg-muted px-2 py-0.5 text-xs">
-              {m}
-            </span>
-          ))}
+          {members.length === 0 ? (
+            <span className="text-xs text-muted-foreground">（空組）</span>
+          ) : (
+            members.map((m) => (
+              <span key={m} className="rounded-md bg-muted px-2 py-0.5 text-xs">
+                {m}
+              </span>
+            ))
+          )}
         </div>
       )}
     </div>
@@ -99,14 +175,32 @@ function GroupCard({
 
 export function GroupsPanel({ isAdmin }: { isAdmin: boolean }) {
   const { data: groups = [], isLoading } = useMeetingGroups()
+  const add = useAddMeetingGroup()
 
   if (isLoading) {
     return <p className="text-sm text-muted-foreground">載入中…</p>
   }
 
+  const nextNumber =
+    groups.length > 0 ? Math.max(...groups.map((g) => g.groupNumber)) + 1 : 1
+
   return (
     <div className="flex flex-col gap-2">
-      <p className="text-xs text-muted-foreground">提問小組</p>
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-muted-foreground">提問小組</p>
+        {isAdmin && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 gap-1 px-2 text-xs text-muted-foreground"
+            disabled={add.isPending}
+            onClick={() => add.mutate(nextNumber)}
+          >
+            <IconPlus className="h-3 w-3" />
+            新增小組
+          </Button>
+        )}
+      </div>
       <div className="grid grid-cols-2 gap-2">
         {groups.map((g) => (
           <GroupCard

--- a/apps/portal/app/meetings/_components/schedule-tab.tsx
+++ b/apps/portal/app/meetings/_components/schedule-tab.tsx
@@ -19,6 +19,7 @@ import {
   useDeleteMeeting,
   useClaimMeeting,
 } from "@/hooks/meetings/use-meetings"
+import { useMeetingGroups } from "@/hooks/meetings/use-meeting-groups"
 import { useMeetingsAdmin } from "@/hooks/meetings/use-meetings-admin"
 import { useLabUsers } from "@/hooks/meetings/use-lab-users"
 import type { Meeting } from "@/lib/meetings/types"
@@ -54,6 +55,7 @@ export function ScheduleTab({ year }: { year: number }) {
   const { isAdmin } = useMeetingsAdmin()
   const { data: meetings = [], isLoading } = useMeetings(year)
   const { data: labUsers = [] } = useLabUsers()
+  const { data: groups = [] } = useMeetingGroups()
   const deleteMeeting = useDeleteMeeting()
   const claimMeeting = useClaimMeeting()
 
@@ -68,18 +70,18 @@ export function ScheduleTab({ year }: { year: number }) {
   return (
     <div className="flex flex-col gap-4">
       <div className="overflow-x-auto rounded-md border">
-        <Table>
+        <Table className="min-w-[860px]">
           <TableHeader>
             <TableRow>
               <TableHead className="w-20">週次</TableHead>
               <TableHead className="w-24">日期</TableHead>
-              <TableHead>報告人</TableHead>
-              <TableHead className="w-10 text-center">PPT</TableHead>
-              <TableHead className="w-10 text-center">錄影</TableHead>
-              <TableHead>Paper</TableHead>
-              <TableHead className="w-16 text-center">小組</TableHead>
-              <TableHead className="hidden md:table-cell">備註</TableHead>
-              <TableHead className="w-16" />
+              <TableHead className="w-24">報告人</TableHead>
+              <TableHead className="w-12 text-center">PPT</TableHead>
+              <TableHead className="w-12 text-center">錄影</TableHead>
+              <TableHead className="min-w-[200px]">Paper</TableHead>
+              <TableHead className="min-w-[120px]">小組</TableHead>
+              <TableHead className="w-32">備註</TableHead>
+              <TableHead className="w-24" />
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -138,16 +140,25 @@ export function ScheduleTab({ year }: { year: number }) {
                       </span>
                     )}
                   </TableCell>
-                  <TableCell className="text-center">
+                  <TableCell>
                     {m.questionGroupNumber ? (
-                      <span className="inline-flex items-center rounded-full border px-1.5 py-0.5 text-xs text-muted-foreground tabular-nums">
-                        G{m.questionGroupNumber}
-                      </span>
+                      <div className="flex flex-col gap-0.5">
+                        <span className="text-xs font-medium text-muted-foreground">
+                          G{m.questionGroupNumber}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {groups
+                            .find(
+                              (g) => g.groupNumber === m.questionGroupNumber
+                            )
+                            ?.members.join("　") ?? ""}
+                        </span>
+                      </div>
                     ) : (
                       <span className="text-xs text-muted-foreground">—</span>
                     )}
                   </TableCell>
-                  <TableCell className="hidden text-xs text-muted-foreground md:table-cell">
+                  <TableCell className="text-xs text-muted-foreground">
                     {m.notes ?? ""}
                   </TableCell>
                   <TableCell>

--- a/apps/portal/hooks/meetings/use-meeting-groups.ts
+++ b/apps/portal/hooks/meetings/use-meeting-groups.ts
@@ -51,3 +51,41 @@ export function useUpdateMeetingGroup() {
     onError: (e: Error) => toast.error(e.message),
   })
 }
+
+export function useAddMeetingGroup() {
+  const supabase = createClient()
+  const qc = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (nextNumber: number) => {
+      const { error } = await supabase
+        .from("meeting_groups")
+        .insert({ group_number: nextNumber, members: [] })
+      if (error) throw new Error(error.message)
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["meeting_groups"] })
+    },
+    onError: (e: Error) => toast.error(e.message),
+  })
+}
+
+export function useDeleteMeetingGroup() {
+  const supabase = createClient()
+  const qc = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (groupNumber: number) => {
+      const { error } = await supabase
+        .from("meeting_groups")
+        .delete()
+        .eq("group_number", groupNumber)
+      if (error) throw new Error(error.message)
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["meeting_groups"] })
+      toast.success("小組已刪除")
+    },
+    onError: (e: Error) => toast.error(e.message),
+  })
+}

--- a/supabase/migrations/2026-05-09-meeting-groups-dynamic.sql
+++ b/supabase/migrations/2026-05-09-meeting-groups-dynamic.sql
@@ -1,0 +1,4 @@
+-- Allow any positive group_number (remove fixed upper-bound of 9)
+ALTER TABLE public.meeting_groups
+  DROP CONSTRAINT IF EXISTS meeting_groups_group_number_check,
+  ADD CONSTRAINT meeting_groups_group_number_positive CHECK (group_number > 0);


### PR DESCRIPTION
## Summary

- DB: remove `CHECK (group_number BETWEEN 1 AND 9)` → groups can now be added/removed freely
- Admin can add new groups (+ 新增小組) and delete existing ones (trash icon + inline confirm)
- Group member editing now uses toggle chips from `user_profiles` instead of free-text input
- Schedule table: `小組` column shows `G{n}` + member names; `備註` always visible; table has `min-w-[860px]` to prevent column squishing

## Migration

`supabase/migrations/2026-05-09-meeting-groups-dynamic.sql` — already applied to production.

## Test plan

- [ ] Admin: 新增小組 button creates an empty group card
- [ ] Admin: trash icon shows inline "確定刪除" confirm before deleting
- [ ] Admin: edit mode shows all lab members as toggle chips; click to add/remove
- [ ] Schedule table: 小組 column shows member names under G{n}
- [ ] Schedule table: 備註 column visible without horizontal scroll

🤖 Generated with [Claude Code](https://claude.ai/claude-code)