### PR TITLE
feat(bulletin): email notifications for new announcements

### DIFF
--- a/apps/portal/.env.example
+++ b/apps/portal/.env.example
@@ -22,3 +22,8 @@ NEXT_PUBLIC_SITE_URL=
 NEXTCLOUD_URL=
 NEXTCLOUD_USERNAME=
 NEXTCLOUD_APP_PASSWORD=
+
+# Shared secret for the bulletin board notification API.
+# Used by Google Apps Script to fetch unnotified announcements and mark them sent.
+# Generate with: openssl rand -hex 32
+BULLETIN_API_SECRET=

--- a/apps/portal/app/api/bulletin/mark-notified/route.ts
+++ b/apps/portal/app/api/bulletin/mark-notified/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { createClient } from "@supabase/supabase-js"
+
+function createServiceClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SECRET_KEY!
+  )
+}
+
+function isAuthorized(request: NextRequest): boolean {
+  const secret = process.env.BULLETIN_API_SECRET
+  if (!secret) return false
+  const auth = request.headers.get("Authorization") ?? ""
+  return auth === `Bearer ${secret}`
+}
+
+const CORS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Content-Type": "application/json; charset=utf-8",
+}
+
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS })
+}
+
+export async function POST(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      { status: 401, headers: CORS }
+    )
+  }
+
+  let ids: string[]
+  try {
+    const body = await request.json()
+    if (
+      !Array.isArray(body.ids) ||
+      body.ids.some((id: unknown) => typeof id !== "string")
+    ) {
+      throw new Error("ids must be an array of strings")
+    }
+    ids = body.ids as string[]
+  } catch {
+    return NextResponse.json(
+      { error: "Body must be { ids: string[] }" },
+      { status: 400, headers: CORS }
+    )
+  }
+
+  if (ids.length === 0) {
+    return NextResponse.json({ updated: 0 }, { headers: CORS })
+  }
+
+  const supabase = createServiceClient()
+  const { error, count } = await supabase
+    .from("announcements")
+    .update({ notified_at: new Date().toISOString() })
+    .in("id", ids)
+    .select("id", { count: "exact", head: true })
+
+  if (error) {
+    return NextResponse.json(
+      { error: error.message },
+      { status: 500, headers: CORS }
+    )
+  }
+
+  return NextResponse.json({ updated: count ?? ids.length }, { headers: CORS })
+}

--- a/apps/portal/app/api/bulletin/mark-notified/route.ts
+++ b/apps/portal/app/api/bulletin/mark-notified/route.ts
@@ -57,11 +57,10 @@ export async function POST(request: NextRequest) {
   }
 
   const supabase = createServiceClient()
-  const { error, count } = await supabase
+  const { error } = await supabase
     .from("announcements")
     .update({ notified_at: new Date().toISOString() })
     .in("id", ids)
-    .select("id", { count: "exact", head: true })
 
   if (error) {
     return NextResponse.json(
@@ -70,5 +69,5 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  return NextResponse.json({ updated: count ?? ids.length }, { headers: CORS })
+  return NextResponse.json({ updated: ids.length }, { headers: CORS })
 }

--- a/apps/portal/app/api/bulletin/unnotified/route.ts
+++ b/apps/portal/app/api/bulletin/unnotified/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { createClient } from "@supabase/supabase-js"
+
+import type { DbAnnouncement } from "@/lib/bulletin/types"
+
+function createServiceClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SECRET_KEY!
+  )
+}
+
+function isAuthorized(request: NextRequest): boolean {
+  const secret = process.env.BULLETIN_API_SECRET
+  if (!secret) return false
+  const auth = request.headers.get("Authorization") ?? ""
+  return auth === `Bearer ${secret}`
+}
+
+const CORS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Content-Type": "application/json; charset=utf-8",
+}
+
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS })
+}
+
+export async function GET(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      { status: 401, headers: CORS }
+    )
+  }
+
+  const supabase = createServiceClient()
+  const { data, error } = await supabase
+    .from("announcements")
+    .select("id, title, content, tags, created_at")
+    .eq("is_published", true)
+    .is("notified_at", null)
+    .order("created_at", { ascending: true })
+
+  if (error) {
+    return NextResponse.json(
+      { error: error.message },
+      { status: 500, headers: CORS }
+    )
+  }
+
+  return NextResponse.json(
+    {
+      announcements: (data ?? []) as Pick<
+        DbAnnouncement,
+        "id" | "title" | "content" | "tags" | "created_at"
+      >[],
+    },
+    { headers: CORS }
+  )
+}

--- a/apps/portal/app/bulletin/[id]/_components/announcement-actions.tsx
+++ b/apps/portal/app/bulletin/[id]/_components/announcement-actions.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Pencil, Trash2 } from "lucide-react"
+import { Bell, BellOff, Pencil, Trash2 } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useState } from "react"
 import { toast } from "sonner"
@@ -20,6 +20,10 @@ export function AnnouncementActions({
   const router = useRouter()
   const [editOpen, setEditOpen] = useState(false)
   const [deleting, setDeleting] = useState(false)
+  const [notified, setNotified] = useState<string | null>(
+    announcement.notifiedAt
+  )
+  const [toggling, setToggling] = useState(false)
 
   const handleDelete = async () => {
     setDeleting(true)
@@ -39,8 +43,46 @@ export function AnnouncementActions({
     }
   }
 
+  const handleToggleNotified = async () => {
+    setToggling(true)
+    const newValue = notified ? null : new Date().toISOString()
+    try {
+      const supabase = createClient()
+      const { error } = await supabase
+        .from("announcements")
+        .update({ notified_at: newValue })
+        .eq("id", announcement.id)
+      if (error) throw error
+      setNotified(newValue)
+      toast.success(newValue ? "已標記為已發信" : "已取消發信標記")
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "更新失敗")
+    } finally {
+      setToggling(false)
+    }
+  }
+
   return (
     <div className="flex shrink-0 items-center gap-1">
+      <Button
+        variant="ghost"
+        size="sm"
+        disabled={toggling}
+        onClick={handleToggleNotified}
+        className="h-7 gap-1 px-2 text-xs"
+        title={
+          notified
+            ? `已於 ${new Date(notified).toLocaleString("zh-TW")} 發信`
+            : "尚未發信通知"
+        }
+      >
+        {notified ? (
+          <Bell className="size-3 text-green-600" />
+        ) : (
+          <BellOff className="size-3 text-muted-foreground" />
+        )}
+        {notified ? "已通知" : "未通知"}
+      </Button>
       <Button
         variant="ghost"
         size="sm"

--- a/apps/portal/lib/bulletin/types.ts
+++ b/apps/portal/lib/bulletin/types.ts
@@ -6,6 +6,7 @@ export interface Announcement {
   pinned: boolean
   createdAt: string
   updatedAt: string
+  notifiedAt: string | null
 }
 
 export interface DbAnnouncement {
@@ -18,6 +19,7 @@ export interface DbAnnouncement {
   created_by: string | null
   created_at: string
   updated_at: string
+  notified_at: string | null
 }
 
 export function toAnnouncement(row: DbAnnouncement): Announcement {
@@ -29,5 +31,6 @@ export function toAnnouncement(row: DbAnnouncement): Announcement {
     pinned: row.pinned,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+    notifiedAt: row.notified_at,
   }
 }

--- a/supabase/migrations/2026-05-09-bulletin-notified.sql
+++ b/supabase/migrations/2026-05-09-bulletin-notified.sql
@@ -1,0 +1,8 @@
+-- Add notified_at to track whether an announcement email has been sent
+ALTER TABLE public.announcements
+  ADD COLUMN IF NOT EXISTS notified_at timestamptz;
+
+-- Index for quick lookup of unnotified published announcements
+CREATE INDEX IF NOT EXISTS announcements_notified_at
+  ON public.announcements (notified_at)
+  WHERE is_published = true;


### PR DESCRIPTION
Closes #94

## Summary
- `announcements` 表新增 `notified_at timestamptz` 欄位，記錄何時發信
- `GET /api/bulletin/unnotified` — 回傳 `is_published=true AND notified_at IS NULL` 的公告，需 `Authorization: Bearer <BULLETIN_API_SECRET>`
- `POST /api/bulletin/mark-notified` — 傳入 `{ ids: string[] }` 批次標記已發信
- 管理員在公告詳情頁看到「已通知 / 未通知」按鈕，可手動切換狀態（Bell icon）

## Google Script (BulletinNotifier.gs)
定時 trigger（每 30 分鐘）呼叫 `checkAndNotifyBulletin()`：
1. `GET /api/bulletin/unnotified` → 取得未發信公告
2. 對每則公告寄出 HTML 通知信到 `ANNOUNCE_EMAIL`
3. `POST /api/bulletin/mark-notified` → 標記已發信

## Setup
1. Vercel 環境變數加 `BULLETIN_API_SECRET`（`openssl rand -hex 32`）
2. Google Apps Script `Config.gs` 填入 `BULLETIN_API_SECRET` 和 `PORTAL_SITE_URL`
3. Apps Script → 觸發器 → 新增 `checkAndNotifyBulletin`，每 30 分鐘執行

## Test plan
- [ ] Apply migration，確認 `announcements.notified_at` 欄位存在
- [ ] 呼叫 `/api/bulletin/unnotified` 不帶 token → 401
- [ ] 呼叫 `/api/bulletin/unnotified` 帶正確 Bearer token → 回傳未發信公告
- [ ] 呼叫 `/api/bulletin/mark-notified` 標記後再查詢 → 已從列表消失
- [ ] 管理員點「未通知」按鈕 → 變為「已通知」，反之亦然
- [ ] 執行 `testBulletinNotifier()` → 收到格式正確的通知信