### PR TITLE
fix(auth): stop nuking valid sb-* tokens with off-by-one base64url padding

### DIFF
--- a/apps/portal/lib/supabase/client.ts
+++ b/apps/portal/lib/supabase/client.ts
@@ -12,9 +12,8 @@ function purgeCorruptedAuthStorage() {
 
     function isValidB64Utf8(b64url: string): boolean {
       try {
-        const padded =
-          b64url.replace(/-/g, "+").replace(/_/g, "/") +
-          "==".slice((b64url.length + 3) % 4)
+        const b64 = b64url.replace(/-/g, "+").replace(/_/g, "/")
+        const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4)
         const bytes = Uint8Array.from(atob(padded), (c) => c.charCodeAt(0))
         decoder.decode(bytes)
         return true


### PR DESCRIPTION
Closes #100

## Summary

`purgeCorruptedAuthStorage` was deleting valid sessions out from under users.
The base64url padding formula was off by one for `length % 4 ∈ {2, 3}`, so
`atob` threw on perfectly valid JWT segments and we marked the entry as
corrupted. Swapped to the canonical `(4 - len % 4) % 4` form.

Only a real symptom on `length % 4 === 2` (mod4=3 happens to survive lenient
atob in some runtimes), but the formula was wrong either way.

## Why this surfaced

Found while debugging a `/token?grant_type=refresh_token` 429 storm on bento.
The storm itself was a teammate's `localhost:3000` dev server hammering prod
auth (handled separately, sessions revoked). This bug was riding shotgun:
silently shredding `sb-*` localStorage on every `createClient()` call.

## Verification

```ts
// before
isValidB64Utf8("eyJzdWIiOiJhYmNkZWYifQ") // mod4=2 → false (BUG: valid JWT)

// after
isValidB64Utf8("eyJzdWIiOiJhYmNkZWYifQ") // mod4=2 → true
isValidB64Utf8("////")                    // garbage → false (still rejected)
```

## Test plan

- [x] Bun-based repro of every `len % 4` case (0/2/3 valid + garbage rejected)
- [ ] Manual: log into portal, confirm `sb-*` localStorage entry survives multiple page loads instead of being silently purged
- [ ] Watch portal auth logs for any uptick in `invalid_grant` (shouldn't happen — fix is strictly more permissive, only towards *valid* tokens)