### PR TITLE
fix(auth): heal cross-account stale tokens, stop scanning storage every render

### DIFF
--- a/apps/portal/components/auth-provider.tsx
+++ b/apps/portal/components/auth-provider.tsx
@@ -27,34 +27,65 @@ export function AuthProvider({
     }
   }
 
-  // Self-heal for stale localStorage. If the server authoritatively says
-  // we're not signed in but there's still an `sb-*` shard in localStorage,
-  // the local state is dead weight — most likely a refresh_token the old
-  // portal left here that's been revoked/rotated since. Leaving it would
-  // kick off @supabase/ssr's auto-refresh timer, which hammers /token
-  // trying to revive a corpse and eventually hits rate-limit 429s.
+  // Self-heal for stale localStorage in two shapes:
   //
-  // signOut({ scope: "local" }) clears storage and stops the timer
-  // without a network call — no rate-limit burn, no cross-device blast.
+  //   1. Server says "not signed in" but localStorage still has `sb-*`
+  //      shards — most likely a revoked/rotated refresh_token the SDK's
+  //      auto-refresh timer would otherwise hammer /token to revive,
+  //      eventually hitting 429s.
+  //
+  //   2. Server says "signed in as B" but localStorage has `sb-*` whose
+  //      embedded `user.id` is A — happens after a Keycloak account
+  //      switch on a shared machine. The SDK's userStorage path can pick
+  //      up A's revoked token and produce the same 429 storm.
+  //
+  // Case 1: signOut({ scope: "local" }) clears storage and stops the
+  // timer without a network call. Case 2: surgically remove only the
+  // mismatched key — don't touch the live session.
   useEffect(() => {
-    if (initialUser) return
-    let hasStaleState = false
+    const stale: string[] = []
     try {
-      hasStaleState = Object.keys(localStorage).some((k) => k.startsWith("sb-"))
+      for (const key of Object.keys(localStorage)) {
+        if (!key.startsWith("sb-")) continue
+        if (!initialUser) {
+          stale.push(key)
+          continue
+        }
+        try {
+          const raw = localStorage.getItem(key)
+          if (!raw) continue
+          const parsed = JSON.parse(raw)
+          const sub: unknown =
+            parsed?.user?.id ?? parsed?.currentSession?.user?.id
+          if (typeof sub === "string" && sub !== initialUser.id) {
+            stale.push(key)
+          }
+        } catch {
+          // Unparseable blob — leave it for client.ts's purge to handle.
+        }
+      }
     } catch {
       return // SSR or private mode — nothing to do
     }
-    if (!hasStaleState) return
 
-    supabase.auth.signOut({ scope: "local" }).catch(() => {
-      try {
-        Object.keys(localStorage)
-          .filter((k) => k.startsWith("sb-"))
-          .forEach((k) => localStorage.removeItem(k))
-      } catch {
-        /* give up silently */
-      }
-    })
+    if (stale.length === 0) return
+
+    if (!initialUser) {
+      supabase.auth.signOut({ scope: "local" }).catch(() => {
+        try {
+          stale.forEach((k) => localStorage.removeItem(k))
+        } catch {
+          /* give up silently */
+        }
+      })
+      return
+    }
+
+    try {
+      stale.forEach((k) => localStorage.removeItem(k))
+    } catch {
+      /* give up silently */
+    }
   }, [initialUser, supabase])
 
   useEffect(() => {

--- a/apps/portal/lib/supabase/client.ts
+++ b/apps/portal/lib/supabase/client.ts
@@ -5,7 +5,14 @@ import { createBrowserClient } from "@supabase/ssr"
 // check the SDK throws "Invalid UTF-8 sequence" and the auth client is left
 // in a broken state. We remove the offending keys before the SDK ever sees
 // them so the user gets a clean login instead of a silent crash.
-function purgeCorruptedAuthStorage() {
+//
+// Runs once per page load — `createBrowserClient` itself is a singleton, so
+// the SDK side already dedupes. Re-scanning localStorage on every hook
+// re-render is just wasted CPU.
+let purged = false
+function purgeCorruptedAuthStorageOnce() {
+  if (purged) return
+  purged = true
   if (typeof localStorage === "undefined") return
   try {
     const decoder = new TextDecoder("utf-8", { fatal: true })
@@ -54,7 +61,7 @@ function purgeCorruptedAuthStorage() {
 }
 
 export function createClient() {
-  purgeCorruptedAuthStorage()
+  purgeCorruptedAuthStorageOnce()
   return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!


### PR DESCRIPTION
Closes #103

Two leftovers from the bento `/token` 429 storm postmortem. Both touch auth storage hygiene, both have the same blast radius — bundled into one PR.

## 1. Self-heal now covers cross-account stale tokens

`AuthProvider`'s self-heal only fired when there was no current session. The hole: log in as A, log out, log in as B, and A's revoked `sb-*` shard still sat in localStorage waiting for the SDK's `userStorage` path to pick it up. That's the same 429 storm we just put out, only triggered by a Keycloak account switch instead of a stale deploy.

Now the guard:

- Walks every `sb-*` key
- If signed in: drops only the keys whose embedded `user.id` doesn't match `initialUser.id` (surgical — live session untouched)
- If signed out: drops everything via `signOut({ scope: "local" })`, same as before (also stops the SDK's auto-refresh timer)

## 2. `purgeCorruptedAuthStorage` runs once per page load, not per render

`createBrowserClient` is already a singleton in the browser ([@supabase/ssr source][1]: returns the cached instance after the first call). But our wrapper ran `purgeCorruptedAuthStorage` *before* the singleton check, so every `useOrders` / `useMenus` / `useApprove` re-render scanned localStorage, parsed JSON, and base64-decoded every `sb-*` token from scratch. Hoisted to a module-level once-flag.

[1]: https://github.com/supabase/ssr/blob/v0.10.2/src/createBrowserClient.ts#L102-L108

## Test plan

- [x] `bun run typecheck --filter=portal` — clean
- [x] `bun run lint --filter=portal` — no new warnings (existing 26 are unrelated `react-hooks/set-state-in-effect` from other files)
- [ ] Manual: log in as A, log out, log in as B; confirm `sb-*` localStorage is replaced with B's, no 429 storm
- [ ] Manual: pop devtools, watch console — `purgeCorruptedAuthStorage` no longer fires per re-render