### PR TITLE
fix(bulletin-chat): float to top-right messenger style + auto-scroll on open

### DIFF
--- a/apps/portal/app/_components/bulletin-chat-client.tsx
+++ b/apps/portal/app/_components/bulletin-chat-client.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { ChevronDown, ChevronUp, Megaphone, Send } from "lucide-react"
+import { MessageSquare, Megaphone, Send, X } from "lucide-react"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { toast } from "sonner"
 
@@ -134,12 +134,16 @@ export function BulletinChatClient({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // Auto-scroll to bottom when messages change
+  // Auto-scroll to bottom: when messages arrive AND when the panel opens.
+  // On open the list element is freshly mounted, so wait one frame for layout.
   useEffect(() => {
-    if (listRef.current) {
-      listRef.current.scrollTop = listRef.current.scrollHeight
-    }
-  }, [messages.length])
+    if (!expanded) return
+    requestAnimationFrame(() => {
+      if (listRef.current) {
+        listRef.current.scrollTop = listRef.current.scrollHeight
+      }
+    })
+  }, [expanded, messages.length])
 
   // ---------------------------------------------------------------------------
   // @mention autocomplete — track the token under the cursor
@@ -237,46 +241,53 @@ export function BulletinChatClient({
   }
 
   return (
-    <section className="flex flex-col gap-3">
-      <button
-        type="button"
-        onClick={toggleExpanded}
-        className="flex items-center justify-between gap-2 rounded-md px-1 py-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
-      >
-        <span className="flex items-center gap-2">
-          聊天室
-          {broadcasts.length > 0 && (
-            <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-950/50 dark:text-amber-300">
-              <Megaphone className="size-2.5" />
-              {broadcasts.length} 則公告
+    <div className="fixed top-3 right-3 z-50 flex flex-col items-end gap-2">
+      {!expanded && (
+        <button
+          type="button"
+          onClick={toggleExpanded}
+          aria-label="開啟聊天室"
+          className="relative flex size-11 items-center justify-center rounded-full border border-border bg-background text-foreground shadow-md transition-colors hover:bg-muted"
+        >
+          <MessageSquare className="size-5" />
+          {unreadCount > 0 ? (
+            <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-medium text-primary-foreground">
+              {unreadCount > 99 ? "99+" : unreadCount}
             </span>
-          )}
-          {!expanded && unreadCount > 0 && (
-            <span className="rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-medium text-primary-foreground">
-              {unreadCount} 則新訊息
+          ) : broadcasts.length > 0 ? (
+            <span className="absolute -top-1 -right-1 flex size-3 items-center justify-center rounded-full bg-amber-500 text-white">
+              <Megaphone className="size-2" />
             </span>
-          )}
-        </span>
-        {expanded ? (
-          <ChevronUp className="size-3" />
-        ) : (
-          <ChevronDown className="size-3" />
-        )}
-      </button>
-
-      {!expanded && broadcasts.length > 0 && (
-        <div className="flex flex-col gap-2">
-          {broadcasts.slice(-2).map((m) => (
-            <BroadcastBanner key={m.id} message={m} />
-          ))}
-        </div>
+          ) : null}
+        </button>
       )}
 
       {expanded && (
-        <>
+        <div className="flex h-[min(560px,calc(100vh-2rem))] w-[min(380px,calc(100vw-1.5rem))] flex-col overflow-hidden rounded-xl border border-border bg-background shadow-xl">
+          <header className="flex items-center justify-between border-b border-border bg-muted/40 px-3 py-2">
+            <div className="flex items-center gap-2">
+              <MessageSquare className="size-4 text-muted-foreground" />
+              <span className="text-sm font-medium">聊天室</span>
+              {broadcasts.length > 0 && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-950/50 dark:text-amber-300">
+                  <Megaphone className="size-2.5" />
+                  {broadcasts.length}
+                </span>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={toggleExpanded}
+              aria-label="收起聊天室"
+              className="flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <X className="size-4" />
+            </button>
+          </header>
+
           <div
             ref={listRef}
-            className="flex max-h-[480px] flex-col gap-3 overflow-y-auto rounded-xl border border-border p-3"
+            className="flex flex-1 flex-col gap-3 overflow-y-auto p-3"
           >
             {broadcasts.map((m) => (
               <BroadcastBanner key={m.id} message={m} />
@@ -297,9 +308,9 @@ export function BulletinChatClient({
             )}
           </div>
 
-          <div className="relative flex flex-col gap-2 rounded-xl border border-border p-2">
+          <div className="relative flex flex-col gap-2 border-t border-border p-2">
             {filteredMembers.length > 0 && (
-              <div className="absolute right-0 bottom-full left-0 mb-1 flex max-h-48 flex-col overflow-y-auto rounded-xl border border-border bg-popover shadow-md">
+              <div className="absolute right-2 bottom-full left-2 mb-1 flex max-h-48 flex-col overflow-y-auto rounded-xl border border-border bg-popover shadow-md">
                 {filteredMembers.map((m) => (
                   <button
                     key={m.id}
@@ -324,7 +335,7 @@ export function BulletinChatClient({
               placeholder={
                 broadcast
                   ? "輸入廣播公告（會寄信給全體成員）…"
-                  : "說點什麼…  輸入 @ 提到別人會寄信通知"
+                  : "說點什麼… 輸入 @ 提到別人會寄信"
               }
               onChange={(e) => handleDraftChange(e.target.value)}
               onKeyDown={handleKeyDown}
@@ -334,7 +345,7 @@ export function BulletinChatClient({
               onCompositionEnd={() => {
                 isComposingRef.current = false
               }}
-              className="resize-none border-0 px-2 shadow-none focus-visible:ring-0"
+              className="min-h-[52px] resize-none border-0 px-2 shadow-none focus-visible:ring-0"
             />
             <div className="flex items-center justify-between gap-2">
               {isAdmin ? (
@@ -346,7 +357,7 @@ export function BulletinChatClient({
                     className="size-3.5"
                   />
                   <Megaphone className="size-3" />
-                  廣播（寄信給全部人）
+                  廣播
                 </label>
               ) : (
                 <span />
@@ -362,9 +373,9 @@ export function BulletinChatClient({
               </Button>
             </div>
           </div>
-        </>
+        </div>
       )}
-    </section>
+    </div>
   )
 }
 


### PR DESCRIPTION
Closes #109

## Summary
聊天室從 inline section 改成 fixed-position 浮動視窗（FB Messenger 風格）。

- 收合時：右上角 size-11 圓形 icon button，未讀數 badge 顯示在右上角；只有公告無未讀時顯示橘色小喇叭點
- 展開時：380×560 浮動面板，header 含「聊天室」+ 公告數 chip + X 關閉按鈕，下方為訊息列、輸入區
- 寬高使用 \`min()\` 對 viewport clamp，行動裝置上自動縮成 \`calc(100vw-1.5rem)\`
- 開啟時用 \`requestAnimationFrame\` 等 mount 完成後立刻 \`scrollTop = scrollHeight\`，看到最新訊息

## 改動範圍
僅 \`apps/portal/app/_components/bulletin-chat-client.tsx\`。資料層、API、Realtime 全部不變，純 UI 重排版。

## Test plan
- [ ] 首頁右上角看到圓形按鈕，平時不擋畫面
- [ ] 點按鈕展開 → 面板從右上角滑出，自動捲到底
- [ ] 點 X 收回 → 面板消失，按鈕回到原位
- [ ] 收到別人新訊息（其他 tab 送）→ badge 數字 +1
- [ ] 中文 IME 選字按 Enter 不會送出（沿用前 PR 三層守門）
- [ ] 行動裝置（< 380px 寬）面板自動縮放不溢出