### PR TITLE
feat(receipts): sort pending receipts to the top

### DIFF
--- a/apps/portal/hooks/receipts/use-receipts.ts
+++ b/apps/portal/hooks/receipts/use-receipts.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/receipts/file"
 import {
   RECEIPTS_BUCKET,
+  STATUS_ORDER,
   toReceipt,
   type DatabaseReceiptWithTags,
   type Receipt,
@@ -43,7 +44,13 @@ export function useReceipts() {
         console.error("[receipts] list query failed", error)
         throw new Error(error.message || "讀取收據失敗")
       }
-      return (data as unknown as DatabaseReceiptWithTags[]).map(toReceipt)
+      return (data as unknown as DatabaseReceiptWithTags[])
+        .map(toReceipt)
+        .sort((a, b) => {
+          const byStatus = STATUS_ORDER[a.status] - STATUS_ORDER[b.status]
+          if (byStatus !== 0) return byStatus
+          return b.createdAt.localeCompare(a.createdAt)
+        })
     },
     retry: 2,
   })

--- a/apps/portal/lib/receipts/types.ts
+++ b/apps/portal/lib/receipts/types.ts
@@ -1,5 +1,13 @@
 export type ReceiptStatus = "pending" | "approved" | "rejected"
 
+// Display order: pending first (still needs eyes on it), then approved, then
+// rejected. Same status falls back to newer-first by created_at.
+export const STATUS_ORDER: Record<ReceiptStatus, number> = {
+  pending: 0,
+  approved: 1,
+  rejected: 2,
+}
+
 export type TagVariant = "default" | "secondary" | "outline"
 
 export const TAG_VARIANTS: TagVariant[] = ["default", "secondary", "outline"]


### PR DESCRIPTION
Closes #115

## Summary

- Receipts list now sorts by status first: `pending` (審核中) → `approved` (審核完成) → `rejected` (已拒絕).
- Same-status rows keep `created_at` desc (newest first), so within each bucket the order is unchanged.
- Pure client-side sort in the existing `useReceipts` TanStack Query hook. No schema / RLS / API change.

## Why

Reimbursers want to see "what's still waiting on me" without scrolling. Default ordering by date alone buries pending rows under months of approved history; a sensible status-first sort removes a click in the most common path.

## Implementation

- `lib/receipts/types.ts` — added `STATUS_ORDER: Record<ReceiptStatus, number>`.
- `hooks/receipts/use-receipts.ts` — chained a `.sort()` after `.map(toReceipt)`. Comparator does status priority first, falls back to `createdAt.localeCompare` descending. Stable for ties.

## Test plan

- [x] `bun run lint --filter=portal` — no new warnings
- [x] `bun run typecheck` — clean
- [x] `bun run build --filter=portal` — production build OK
- [ ] Open `/receipts` in dev, confirm pending rows show on top, approved next, rejected last
- [ ] Flip a row's status via the status select, confirm it jumps buckets on next refetch