### PR TITLE
refactor(receipts): move STATUS_LABELS to lib/receipts/types.ts

### DIFF
--- a/apps/portal/app/receipts/_components/filter-chips.tsx
+++ b/apps/portal/app/receipts/_components/filter-chips.tsx
@@ -3,9 +3,11 @@
 import { Skeleton } from "@workspace/ui/components/skeleton"
 
 import { useTags } from "@/hooks/receipts/use-tags"
-import type { ReceiptStatus, Tag } from "@/lib/receipts/types"
-
-import { STATUS_LABELS } from "./status-select"
+import {
+  STATUS_LABELS,
+  type ReceiptStatus,
+  type Tag,
+} from "@/lib/receipts/types"
 
 const STATUSES: ReceiptStatus[] = ["pending", "approved", "rejected"]
 

--- a/apps/portal/app/receipts/_components/receipts-view.tsx
+++ b/apps/portal/app/receipts/_components/receipts-view.tsx
@@ -14,13 +14,17 @@ import {
 } from "@workspace/ui/components/table"
 
 import { useReceipts } from "@/hooks/receipts/use-receipts"
-import type { Receipt, ReceiptStatus } from "@/lib/receipts/types"
+import {
+  STATUS_LABELS,
+  type Receipt,
+  type ReceiptStatus,
+} from "@/lib/receipts/types"
 
 import { ReceiptsFilterChips } from "./filter-chips"
 import { ReceiptPreviewDialog } from "./receipt-preview-dialog"
 import { ReceiptRowActions } from "./row-actions"
 import { ReceiptsSearchBar } from "./search-bar"
-import { STATUS_LABELS, StatusSelect } from "./status-select"
+import { StatusSelect } from "./status-select"
 import { TagBadge } from "./tag-badge"
 import { TagPickerPopover } from "./tag-picker-popover"
 import { UploadDialog } from "./upload-dialog"

--- a/apps/portal/app/receipts/_components/status-select.tsx
+++ b/apps/portal/app/receipts/_components/status-select.tsx
@@ -12,15 +12,7 @@ import {
 } from "@workspace/ui/components/select"
 
 import { useUpdateReceiptStatus } from "@/hooks/receipts/use-receipts"
-import type { ReceiptStatus } from "@/lib/receipts/types"
-
-export const STATUS_LABELS: Record<ReceiptStatus, string> = {
-  pending: "審核中",
-  approved: "審核完成",
-  rejected: "已拒絕",
-}
-
-const LABELS = STATUS_LABELS
+import { STATUS_LABELS, type ReceiptStatus } from "@/lib/receipts/types"
 
 const VARIANTS: Record<ReceiptStatus, "secondary" | "default" | "destructive"> =
   {
@@ -30,7 +22,7 @@ const VARIANTS: Record<ReceiptStatus, "secondary" | "default" | "destructive"> =
   }
 
 export function ReceiptStatusBadge({ status }: { status: ReceiptStatus }) {
-  return <Badge variant={VARIANTS[status]}>{LABELS[status]}</Badge>
+  return <Badge variant={VARIANTS[status]}>{STATUS_LABELS[status]}</Badge>
 }
 
 export function StatusSelect({
@@ -48,7 +40,7 @@ export function StatusSelect({
       { id, status: next as ReceiptStatus },
       {
         onSuccess: () =>
-          toast.success(`狀態改為「${LABELS[next as ReceiptStatus]}」`),
+          toast.success(`狀態改為「${STATUS_LABELS[next as ReceiptStatus]}」`),
         onError: (err) => toast.error(`改狀態失敗：${err.message}`),
       }
     )
@@ -66,7 +58,7 @@ export function StatusSelect({
       <SelectContent>
         {(["pending", "approved", "rejected"] as ReceiptStatus[]).map((s) => (
           <SelectItem key={s} value={s}>
-            {LABELS[s]}
+            {STATUS_LABELS[s]}
           </SelectItem>
         ))}
       </SelectContent>

--- a/apps/portal/lib/receipts/types.ts
+++ b/apps/portal/lib/receipts/types.ts
@@ -8,6 +8,12 @@ export const STATUS_ORDER: Record<ReceiptStatus, number> = {
   rejected: 2,
 }
 
+export const STATUS_LABELS: Record<ReceiptStatus, string> = {
+  pending: "審核中",
+  approved: "審核完成",
+  rejected: "已拒絕",
+}
+
 export type TagVariant = "default" | "secondary" | "outline"
 
 export const TAG_VARIANTS: TagVariant[] = ["default", "secondary", "outline"]


### PR DESCRIPTION
Closes #117

## Summary

- `STATUS_LABELS` is a pure `Record<ReceiptStatus, string>` consumed by three sibling components — moved out of `app/receipts/_components/status-select.tsx` and into `lib/receipts/types.ts` where it sits next to `STATUS_ORDER`.
- Dropped the redundant `const LABELS = STATUS_LABELS` alias in `status-select.tsx`.

## Why

Aligns with CLAUDE.md's layering rule: `lib/` holds pure functions / types / schemas — no React. Same reasoning that put `STATUS_ORDER` in `types.ts` last PR; this is the follow-up to make the two constants co-locate.

## Test plan

- [x] `bun run lint --filter=portal` — clean (0 errors)
- [x] `bun run typecheck` — clean
- [x] `bun run build --filter=portal` — production build OK
- [x] `grep STATUS_LABELS` confirms every consumer now imports from `@/lib/receipts/types`