### PR TITLE
feat(receipts): notify accounting@winlab.tw on upload

### DIFF
--- a/apps/portal/app/api/cron/receipts-emails/route.ts
+++ b/apps/portal/app/api/cron/receipts-emails/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server"
+
+import { drainOutboxBatch } from "@/lib/receipts/email-drain"
+
+// Daily safety-net sweep for receipts_email_outbox. The happy path goes through
+// `after()` in the upload Server Action — this route only catches stragglers
+// that failed their inline attempt (function timeout, Resend hiccup, etc.).
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+export async function GET(request: Request) {
+  const auth = request.headers.get("authorization")
+  if (auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new NextResponse("unauthorized", { status: 401 })
+  }
+
+  try {
+    const result = await drainOutboxBatch()
+    return NextResponse.json(result)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/apps/portal/app/receipts/actions.ts
+++ b/apps/portal/app/receipts/actions.ts
@@ -1,0 +1,32 @@
+"use server"
+
+import { after } from "next/server"
+
+import { createClient } from "@/lib/supabase/server"
+import { drainOutboxBatch } from "@/lib/receipts/email-drain"
+
+// Called by useUploadReceipt's onSuccess from the client. The actual drain
+// runs with the admin client and bypasses RLS, so this gate isn't about data
+// safety — it just keeps unauthenticated / non-receipts-admin callers from
+// poking the queue. Silent returns (no throw) so a notification glitch never
+// surfaces as an upload failure.
+export async function triggerReceiptEmailDrain(): Promise<void> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return
+
+  const { data: ok } = await supabase.rpc("is_receipts_admin")
+  if (!ok) return
+
+  // Fire after the response goes out so the user doesn't wait on Resend.
+  // The daily cron sweep is our safety net for anything this misses.
+  after(async () => {
+    try {
+      await drainOutboxBatch()
+    } catch (err) {
+      console.error("[receipts] after() drain failed", err)
+    }
+  })
+}

--- a/apps/portal/emails/receipts/receipt-uploaded.tsx
+++ b/apps/portal/emails/receipts/receipt-uploaded.tsx
@@ -1,0 +1,181 @@
+import {
+  Body,
+  Button,
+  Container,
+  Font,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Link,
+  Preview,
+  Section,
+  Text,
+} from "@react-email/components"
+
+export type ReceiptUploadedProps = {
+  receiptName: string
+  uploaderName: string
+  uploadedAt: string
+  viewUrl: string
+}
+
+// Portal runs in Geist Mono (see app/layout.tsx + globals.css). Match that
+// in email too; system mono fallback covers clients that skip <Font>.
+const FONT_STACK =
+  '"Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace'
+
+export function ReceiptUploaded({
+  receiptName,
+  uploaderName,
+  uploadedAt,
+  viewUrl,
+}: ReceiptUploadedProps) {
+  return (
+    <Html lang="zh-Hant">
+      <Head>
+        <Font
+          fontFamily="Geist Mono"
+          fallbackFontFamily="monospace"
+          webFont={{
+            url: "https://fonts.gstatic.com/s/geistmono/v3/or3sQ6P-YJ3kg-7SKRMNME-yy4Dt-S1r.woff2",
+            format: "woff2",
+          }}
+          fontWeight={400}
+          fontStyle="normal"
+        />
+      </Head>
+      <Preview>{`${uploaderName} 上傳了收據：${receiptName}`}</Preview>
+      <Body style={body}>
+        <Container style={container}>
+          <Text style={brand}>WinLab Receipts</Text>
+          <Hr style={hr} />
+          <Heading style={h1}>收到新的收據</Heading>
+          <Text style={p}>
+            <strong style={strong}>{uploaderName}</strong> 上傳了一筆收據：
+          </Text>
+          <Section style={docCard}>
+            <Text style={docTitle}>{receiptName}</Text>
+            <Text style={docMeta}>{uploadedAt}</Text>
+          </Section>
+          <Section style={buttonWrap}>
+            <Button href={viewUrl} style={button}>
+              查看收據
+            </Button>
+          </Section>
+          <Hr style={hr} />
+          <Text style={muted}>按鈕無法點擊時，把連結貼到瀏覽器：</Text>
+          <Link href={viewUrl} style={link}>
+            {viewUrl}
+          </Link>
+          <Text style={footer}>portal.winlab.tw</Text>
+        </Container>
+      </Body>
+    </Html>
+  )
+}
+
+export default ReceiptUploaded
+
+// Token map (see packages/ui/src/styles/globals.css — shadcn neutral scale).
+// Email clients can't touch CSS variables so we resolve to hex here.
+const C = {
+  bg: "#ffffff",
+  fg: "#171717",
+  mutedBg: "#f5f5f5",
+  mutedFg: "#737373",
+  border: "#e5e5e5",
+  primary: "#171717",
+  primaryFg: "#fafafa",
+} as const
+
+const body = {
+  backgroundColor: C.bg,
+  color: C.fg,
+  fontFamily: FONT_STACK,
+  margin: 0,
+  padding: 0,
+}
+const container = {
+  maxWidth: "560px",
+  margin: "0 auto",
+  padding: "48px 24px",
+}
+const brand = {
+  fontSize: "12px",
+  fontWeight: 500,
+  color: C.mutedFg,
+  letterSpacing: "0.02em",
+  margin: "0 0 24px 0",
+  textTransform: "uppercase" as const,
+}
+const hr = {
+  borderColor: C.border,
+  borderTop: `1px solid ${C.border}`,
+  borderBottom: "none",
+  margin: "24px 0",
+}
+const h1 = {
+  fontSize: "20px",
+  fontWeight: 600,
+  color: C.fg,
+  lineHeight: "1.4",
+  margin: "0 0 20px 0",
+}
+const p = {
+  fontSize: "14px",
+  color: C.fg,
+  lineHeight: "1.7",
+  margin: "0 0 12px 0",
+}
+const strong = { fontWeight: 600, color: C.fg }
+const docCard = {
+  border: `1px solid ${C.border}`,
+  borderRadius: "10px",
+  backgroundColor: C.mutedBg,
+  padding: "16px 20px",
+  margin: "8px 0 28px 0",
+}
+const docTitle = {
+  fontSize: "14px",
+  fontWeight: 500,
+  color: C.fg,
+  margin: 0,
+  lineHeight: "1.5",
+}
+const docMeta = {
+  fontSize: "12px",
+  color: C.mutedFg,
+  margin: "6px 0 0 0",
+  lineHeight: "1.5",
+}
+const buttonWrap = { margin: "0 0 8px 0" }
+const button = {
+  backgroundColor: C.primary,
+  color: C.primaryFg,
+  padding: "12px 22px",
+  borderRadius: "10px",
+  fontSize: "14px",
+  fontWeight: 500,
+  textDecoration: "none",
+  display: "inline-block",
+  fontFamily: FONT_STACK,
+}
+const muted = {
+  fontSize: "12px",
+  color: C.mutedFg,
+  margin: "0 0 6px 0",
+  lineHeight: "1.5",
+}
+const link = {
+  fontSize: "12px",
+  color: C.mutedFg,
+  textDecoration: "underline",
+  wordBreak: "break-all" as const,
+}
+const footer = {
+  fontSize: "11px",
+  color: C.mutedFg,
+  margin: "40px 0 0 0",
+  letterSpacing: "0.02em",
+}

--- a/apps/portal/hooks/receipts/use-receipts.ts
+++ b/apps/portal/hooks/receipts/use-receipts.ts
@@ -2,6 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 
+import { triggerReceiptEmailDrain } from "@/app/receipts/actions"
 import { createClient } from "@/lib/supabase/client"
 import {
   RECEIPT_FILE_EXT,
@@ -101,6 +102,19 @@ export function useUploadReceipt() {
         await supabase.storage.from(RECEIPTS_BUCKET).remove([path])
         throw error
       }
+
+      // Fire-and-forget — the server action defers the actual drain to
+      // `after()` so this await only costs one round-trip to kick it off.
+      // A notification failure must not surface as an upload failure.
+      try {
+        await triggerReceiptEmailDrain()
+      } catch (err) {
+        console.warn(
+          "[receipts] notify trigger failed (upload still succeeded)",
+          err
+        )
+      }
+
       return toReceipt(data as unknown as DatabaseReceiptWithTags)
     },
     onSuccess: () => {

--- a/apps/portal/lib/receipts/email-drain.ts
+++ b/apps/portal/lib/receipts/email-drain.ts
@@ -1,0 +1,144 @@
+import { render } from "@react-email/render"
+
+import { createAdminClient } from "@/lib/supabase/admin"
+import { getResend, siteUrl } from "@/lib/email/resend"
+import { ReceiptUploaded } from "@/emails/receipts/receipt-uploaded"
+
+// Drains receipts_email_outbox in a single pass. Called from two places:
+//   1. The upload mutation via a Server Action that uses `after()` — fires
+//      right after the user's upload response, so accounting sees the new
+//      receipt within seconds.
+//   2. Vercel Cron once a day — a safety sweep for rows that `after()` missed
+//      (function timeouts, Resend hiccups, whatever). Rows with attempts >= 5
+//      are left alone so we can look at them by hand.
+
+// receipts use their own From identity (kept out of lib/email/resend.ts so the
+// shared module stays single-purpose). Separate inbox folder rules / reply
+// routing for accounting@ stay easy.
+const MAIL_FROM_RECEIPTS = "WinLab Receipts <receipts@notifications.winlab.tw>"
+const ACCOUNTING_EMAIL = "accounting@winlab.tw"
+
+const BATCH = 50
+const MAX_ATTEMPTS = 5
+
+type OutboxRow = {
+  id: string
+  receipt_id: string
+  kind: "receipt-uploaded"
+  attempts: number
+}
+
+export type DrainResult = {
+  picked: number
+  sent: number
+  failed: number
+  skipped: number
+}
+
+export async function drainOutboxBatch(): Promise<DrainResult> {
+  const admin = createAdminClient()
+  const resend = getResend()
+
+  const { data: rows, error } = await admin
+    .from("receipts_email_outbox")
+    .select("id,receipt_id,kind,attempts")
+    .is("sent_at", null)
+    .lt("attempts", MAX_ATTEMPTS)
+    .order("created_at", { ascending: true })
+    .limit(BATCH)
+  if (error) throw new Error(error.message)
+
+  const result: DrainResult = {
+    picked: rows?.length ?? 0,
+    sent: 0,
+    failed: 0,
+    skipped: 0,
+  }
+
+  for (const row of (rows ?? []) as OutboxRow[]) {
+    const outcome = await sendOne(admin, resend, row)
+    result[outcome]++
+  }
+  return result
+}
+
+async function sendOne(
+  admin: ReturnType<typeof createAdminClient>,
+  resend: ReturnType<typeof getResend>,
+  row: OutboxRow
+): Promise<"sent" | "failed" | "skipped"> {
+  try {
+    const { data: receipt, error: receiptErr } = await admin
+      .from("receipts")
+      .select(
+        "id,name,created_at,created_by,uploader:user_profiles!receipts_created_by_fkey(name,email)"
+      )
+      .eq("id", row.receipt_id)
+      .maybeSingle()
+    if (receiptErr) throw new Error(`receipt: ${receiptErr.message}`)
+    if (!receipt) {
+      // Receipt got deleted between enqueue and drain. Cascade should have
+      // killed the outbox row, but be defensive — mark it sent so we don't
+      // burn retries on something that no longer exists.
+      await admin
+        .from("receipts_email_outbox")
+        .update({
+          sent_at: new Date().toISOString(),
+          last_error: "missing receipt",
+        })
+        .eq("id", row.id)
+      return "skipped"
+    }
+
+    const uploader = receipt.uploader as unknown as {
+      name: string | null
+      email: string | null
+    } | null
+    // Legacy rows pre-trigger have null created_by, hence the WinLab fallback.
+    const uploaderName = uploader?.name ?? uploader?.email ?? "WinLab"
+
+    const uploadedAt = new Date(receipt.created_at).toLocaleString("zh-TW", {
+      timeZone: "Asia/Taipei",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    })
+
+    const html = await render(
+      ReceiptUploaded({
+        receiptName: receipt.name,
+        uploaderName,
+        uploadedAt,
+        viewUrl: `${siteUrl()}/receipts`,
+      })
+    )
+
+    const { error: sendErr } = await resend.emails.send({
+      from: MAIL_FROM_RECEIPTS,
+      to: ACCOUNTING_EMAIL,
+      subject: `新收據：${receipt.name}`,
+      html,
+    })
+    if (sendErr) throw new Error(sendErr.message)
+
+    await admin
+      .from("receipts_email_outbox")
+      .update({ sent_at: new Date().toISOString(), last_error: null })
+      .eq("id", row.id)
+    return "sent"
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    await admin
+      .from("receipts_email_outbox")
+      .update({
+        attempts: row.attempts + 1,
+        last_error: message.slice(0, 500),
+      })
+      .eq("id", row.id)
+    console.error("[receipts-emails] send failed", { id: row.id, message })
+    return "failed"
+  }
+}

--- a/supabase/migrations/2026-05-15-receipts-email-outbox.sql
+++ b/supabase/migrations/2026-05-15-receipts-email-outbox.sql
@@ -1,0 +1,73 @@
+-- Outbox for receipts-app upload notifications.
+-- Populated by a trigger on receipts INSERT.
+-- Consumed by a Server Action `after()` hook + a daily Vercel Cron sweep
+-- that both call Resend.
+--
+-- Why outbox instead of firing Resend inside the upload?
+-- 1. The PDF upload + DB insert path stays fast — no waiting on SMTP.
+-- 2. Resend / network failure doesn't roll back the receipt row.
+-- 3. Retries are free: consumer re-reads rows whose sent_at is still null.
+--
+-- (Mirrors approve_email_outbox; if you're touching one, look at the other.)
+
+-- =============================================================================
+-- Cleanup the existing client-write hole: client INSERTs never filled
+-- created_by, so every legacy row is NULL. Backfilling it is a separate job
+-- (we don't have the audit trail to attribute old rows), but from now on the
+-- column gets stamped automatically. SECURITY DEFINER because we read
+-- auth.uid() — keeps behaviour stable even if a future RLS policy locks down
+-- the schema further.
+-- =============================================================================
+
+create or replace function public.receipts_set_created_by()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  if new.created_by is null then
+    new.created_by := auth.uid();
+  end if;
+  return new;
+end $$;
+
+create trigger trg_receipts_set_created_by
+before insert on public.receipts
+for each row execute function public.receipts_set_created_by();
+
+-- =============================================================================
+-- Outbox table
+-- =============================================================================
+
+create table public.receipts_email_outbox (
+  id          uuid primary key default gen_random_uuid(),
+  receipt_id  uuid not null references public.receipts(id) on delete cascade,
+  kind        text not null check (kind in ('receipt-uploaded')),
+  attempts    int  not null default 0,
+  last_error  text,
+  sent_at     timestamptz,
+  created_at  timestamptz not null default now()
+);
+
+-- Hot path for the consumer: oldest unsent rows that haven't burned through retries.
+create index receipts_email_outbox_pending
+  on public.receipts_email_outbox (created_at)
+  where sent_at is null and attempts < 5;
+
+-- Lock down. Only service_role (bypasses RLS) and the SECURITY DEFINER trigger
+-- write/read this table. Receipts admins have no business touching the mail queue —
+-- they care about receipts, not delivery state.
+alter table public.receipts_email_outbox enable row level security;
+
+-- =============================================================================
+-- Enqueue trigger: every new receipt produces one outbox row.
+-- =============================================================================
+
+create or replace function public.receipts_enqueue_upload_email()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  insert into public.receipts_email_outbox (receipt_id, kind)
+  values (new.id, 'receipt-uploaded');
+  return new;
+end $$;
+
+create trigger receipts_enqueue_upload_email
+after insert on public.receipts
+for each row execute function public.receipts_enqueue_upload_email();

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,10 @@
       "schedule": "0 4 * * *"
     },
     {
+      "path": "/api/cron/receipts-emails",
+      "schedule": "15 4 * * *"
+    },
+    {
       "path": "/api/cron/debt-monthly-settlements",
       "schedule": "0 0 10 * *"
     }


### PR DESCRIPTION
Closes #119

## Summary

- New `receipts_email_outbox` table, AFTER INSERT trigger on `receipts` enqueues one `receipt-uploaded` row per upload — mirrors the existing `approve_email_outbox` playbook.
- `lib/receipts/email-drain.ts` drains the outbox via Resend (`from: receipts@notifications.winlab.tw`, `to: accounting@winlab.tw` — hardcoded).
- Server Action `app/receipts/actions.ts` triggers the drain via Next.js `after()` so the upload response isn't blocked by SMTP; `useUploadReceipt` calls it on success and swallows errors so a notification glitch never breaks the upload.
- Daily Vercel Cron at `15 4 * * *` (`/api/cron/receipts-emails`) sweeps stragglers — 15-minute offset from `approve-emails`.
- Drive-by fix: `receipts.created_by` was silently always `NULL` because the client INSERT never set it. New BEFORE INSERT trigger stamps `auth.uid()` so emails know who uploaded what. Legacy rows stay `NULL` (no audit trail to backfill from); drain falls back to "WinLab" for those.

## Why hardcode the recipient

`accounting@winlab.tw` is the only mailbox that wants this. No env var until that changes — easier to read, fewer moving parts in Vercel config.

## Email content

Metadata only — uploader name, receipt name, timestamp (zh-TW, Asia/Taipei), plus a link back to `/receipts`. No PDF attachment, no signed URL. The link is admin-gated by RLS, so it only works if accounting already has the `receipts` admin role.

## Test plan

- [ ] Apply migration on staging Supabase (manual or via CLI). Verify `trg_receipts_set_created_by` BEFORE INSERT and `receipts_enqueue_upload_email` AFTER INSERT triggers both exist on `receipts`.
- [ ] Upload a receipt as a receipts admin on staging. Confirm `receipts_email_outbox` gets one row and `accounting@winlab.tw` receives the mail within seconds (Resend dashboard shows the send).
- [ ] Confirm `receipts.created_by` is now populated on new uploads (was always `NULL` before).
- [ ] Hit `GET /api/cron/receipts-emails` with `Authorization: Bearer $CRON_SECRET` and confirm it returns a `DrainResult` JSON (zero pending rows after the inline drain already ran).
- [ ] Confirm `lint` / `typecheck` / `build` are all green on Vercel preview.