### PR TITLE
fix(meetings): return 200 with holiday info instead of 404

### DIFF
--- a/apps/portal/app/api/meetings/schedule/route.ts
+++ b/apps/portal/app/api/meetings/schedule/route.ts
@@ -59,7 +59,7 @@ export async function GET(request: NextRequest) {
       .order("group_number"),
   ])
 
-  if (error || !meetingData || (meetingData as DbMeeting).is_holiday) {
+  if (error || !meetingData) {
     return NextResponse.json(
       { error: "No schedule found for this date" },
       { status: 404, headers: CORS }
@@ -67,6 +67,18 @@ export async function GET(request: NextRequest) {
   }
 
   const m = meetingData as DbMeeting
+
+  if (m.is_holiday) {
+    return NextResponse.json(
+      {
+        is_holiday: true,
+        date: m.scheduled_date,
+        week_label: m.week_label ?? null,
+        notes: m.notes ?? null,
+      },
+      { headers: CORS }
+    )
+  }
 
   // Fetch presenter email
   let presenterEmail: string | null = null


### PR DESCRIPTION
Closes #121

## Summary
- `/api/meetings/schedule` 假日（`is_holiday=true`）改回 200，帶 `{ is_holiday, date, week_label, notes }`
- 404 保留給「完全沒有記錄」的日期
- 更新 `ReminderEmail.gs`：下週若為假日，優先顯示 `week_label`，沒有才用 `notes`

## Test plan
- [ ] 查詢假日日期 → 確認回 200 且含 `is_holiday: true`、`week_label`、`notes`
- [ ] 查詢無記錄日期 → 確認回 404
- [ ] 查詢正常會議日期 → 確認完整 schedule 物件不受影響
- [ ] 執行 `testAnnouncementEmail()` → 確認「下週」欄位正常顯示