### PR TITLE
fix(auth): isolate Supabase cookies per service, stop cross-subdomain 500s

### DIFF
--- a/apps/gallery/components/auth-state-reset.tsx
+++ b/apps/gallery/components/auth-state-reset.tsx
@@ -45,7 +45,12 @@ export function AuthStateReset() {
     ]
     for (const entry of document.cookie.split("; ")) {
       const name = entry.split("=")[0]
-      if (!name?.startsWith("sb-")) continue
+      const isSupabaseCookie =
+        name?.startsWith("sb-") ||
+        name === "gallery" ||
+        name?.startsWith("gallery.") ||
+        name?.startsWith("gallery-")
+      if (!isSupabaseCookie) continue
       for (const domain of domains) {
         const domainPart = domain ? `; domain=${domain}` : ""
         document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/${domainPart}`

--- a/apps/gallery/lib/auth/clear-stale-cookies.ts
+++ b/apps/gallery/lib/auth/clear-stale-cookies.ts
@@ -26,7 +26,13 @@ export function clearStaleSupabaseCookiesOnResponse(
   const staleNames = cookieStore
     .getAll()
     .map((c) => c.name)
-    .filter((name) => name.startsWith("sb-"))
+    .filter(
+      (name) =>
+        name.startsWith("sb-") ||
+        name === "gallery" ||
+        name.startsWith("gallery.") ||
+        name.startsWith("gallery-")
+    )
 
   for (const name of staleNames) {
     for (const domain of DOMAINS_TO_CLEAR) {

--- a/apps/gallery/lib/supabase/client.ts
+++ b/apps/gallery/lib/supabase/client.ts
@@ -3,6 +3,7 @@ import { createBrowserClient } from "@supabase/ssr"
 export function createClient() {
   return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    { cookieOptions: { name: "gallery" } }
   )
 }

--- a/apps/gallery/lib/supabase/middleware.ts
+++ b/apps/gallery/lib/supabase/middleware.ts
@@ -23,6 +23,7 @@ export async function updateSession(request: NextRequest) {
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
     {
+      cookieOptions: { name: "gallery" },
       cookies: {
         getAll() {
           return request.cookies.getAll()
@@ -41,13 +42,36 @@ export async function updateSession(request: NextRequest) {
   )
 
   // Do not run code between createServerClient and supabase.auth.getClaims().
-  const { data } = await supabase.auth.getClaims()
-  const user = data?.claims
+
+  // getClaims() may throw (not just return error) when a ghost cookie's value
+  // is in an old/unexpected format. Without this try-catch, the exception
+  // propagates through middleware and Next.js returns a 500.
+  let user
+  try {
+    const { data } = await supabase.auth.getClaims()
+    user = data?.claims
+  } catch {
+    // Treat any parse failure as unauthenticated.
+  }
 
   if (!user && request.nextUrl.pathname.startsWith("/upload")) {
     const url = request.nextUrl.clone()
     url.pathname = "/auth/login"
     return NextResponse.redirect(url)
+  }
+
+  // Proactively sweep ghost .winlab.tw-scoped sb-* cookies on every response.
+  // gallery.winlab.tw can only clear .winlab.tw (parent) and its own host —
+  // portal.winlab.tw cookies are host-only there and are never sent here.
+  for (const { name } of request.cookies.getAll()) {
+    if (!name.startsWith("sb-")) continue
+    for (const domain of [".winlab.tw", "gallery.winlab.tw"]) {
+      supabaseResponse.cookies.set(name, "", {
+        maxAge: 0,
+        path: "/",
+        domain,
+      })
+    }
   }
 
   return supabaseResponse

--- a/apps/gallery/lib/supabase/server.ts
+++ b/apps/gallery/lib/supabase/server.ts
@@ -12,6 +12,7 @@ export async function createClient() {
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
     {
+      cookieOptions: { name: "gallery" },
       cookies: {
         getAll() {
           return cookieStore.getAll()

--- a/apps/portal/components/auth-state-reset.tsx
+++ b/apps/portal/components/auth-state-reset.tsx
@@ -43,7 +43,12 @@ export function AuthStateReset() {
     ]
     for (const entry of document.cookie.split("; ")) {
       const name = entry.split("=")[0]
-      if (!name?.startsWith("sb-")) continue
+      const isSupabaseCookie =
+        name?.startsWith("sb-") ||
+        name === "portal" ||
+        name?.startsWith("portal.") ||
+        name?.startsWith("portal-")
+      if (!isSupabaseCookie) continue
       for (const domain of domains) {
         const domainPart = domain ? `; domain=${domain}` : ""
         document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/${domainPart}`

--- a/apps/portal/lib/auth/clear-stale-cookies.ts
+++ b/apps/portal/lib/auth/clear-stale-cookies.ts
@@ -29,7 +29,13 @@ export function clearStaleSupabaseCookiesOnResponse(
   const staleNames = cookieStore
     .getAll()
     .map((c) => c.name)
-    .filter((name) => name.startsWith("sb-"))
+    .filter(
+      (name) =>
+        name.startsWith("sb-") ||
+        name === "portal" ||
+        name.startsWith("portal.") ||
+        name.startsWith("portal-")
+    )
 
   for (const name of staleNames) {
     for (const domain of DOMAINS_TO_CLEAR) {

--- a/apps/portal/lib/supabase/client.ts
+++ b/apps/portal/lib/supabase/client.ts
@@ -30,7 +30,10 @@ function purgeCorruptedAuthStorageOnce() {
     }
 
     Object.keys(localStorage)
-      .filter((k) => k.startsWith("sb-"))
+      .filter(
+        (k) =>
+          k.startsWith("sb-") || k === "portal" || k === "portal-auth-token"
+      )
       .forEach((k) => {
         try {
           const raw = localStorage.getItem(k)
@@ -64,6 +67,7 @@ export function createClient() {
   purgeCorruptedAuthStorageOnce()
   return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    { cookieOptions: { name: "portal" } }
   )
 }

--- a/apps/portal/lib/supabase/middleware.ts
+++ b/apps/portal/lib/supabase/middleware.ts
@@ -1,6 +1,14 @@
 import { createServerClient } from "@supabase/ssr"
 import { NextResponse, type NextRequest } from "next/server"
 
+// Ghost cookies from the old portal (domain=.winlab.tw) are sent by the
+// browser to every *.winlab.tw subdomain alongside the correct host-only
+// cookies. @supabase/ssr receives duplicate cookie names from getAll() and
+// may pick the ghost value, producing a malformed JWT that can throw instead
+// of returning a graceful error. Clear these on every response so they
+// disappear after the user's first page load on any *.winlab.tw service.
+const GHOST_COOKIE_DOMAINS = [".winlab.tw", "portal.winlab.tw"]
+
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
     request,
@@ -12,6 +20,7 @@ export async function updateSession(request: NextRequest) {
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
     {
+      cookieOptions: { name: "portal" },
       cookies: {
         getAll() {
           return request.cookies.getAll()
@@ -37,8 +46,20 @@ export async function updateSession(request: NextRequest) {
 
   // IMPORTANT: If you remove getClaims() and you use server-side rendering
   // with the Supabase client, your users may be randomly logged out.
-  const { data } = await supabase.auth.getClaims()
-  const user = data?.claims
+
+  // getClaims() may throw (not just return error) when a ghost cookie's value
+  // is in an old/unexpected format that @supabase/ssr can't parse. Without
+  // this try-catch, that exception propagates through the middleware and Next.js
+  // returns a 500 instead of redirecting to login.
+  let user
+  try {
+    const { data } = await supabase.auth.getClaims()
+    user = data?.claims
+  } catch {
+    // Treat any parse failure as unauthenticated — the /auth/login page and
+    // the callback failure path both run clearStaleSupabaseCookiesOnResponse
+    // which will finish the cleanup.
+  }
 
   if (
     !user &&
@@ -63,6 +84,21 @@ export async function updateSession(request: NextRequest) {
   //    return myNewResponse
   // If this is not done, you may be causing the browser and server to go out
   // of sync and terminate the user's session prematurely!
+
+  // Proactively sweep ghost cookies from every response. Users who haven't
+  // visited /auth/login since the old portal was retired still carry
+  // .winlab.tw-scoped sb-* cookies; clearing them here means they're gone
+  // after the first successful page load rather than after the first login.
+  for (const { name } of request.cookies.getAll()) {
+    if (!name.startsWith("sb-")) continue
+    for (const domain of GHOST_COOKIE_DOMAINS) {
+      supabaseResponse.cookies.set(name, "", {
+        maxAge: 0,
+        path: "/",
+        domain,
+      })
+    }
+  }
 
   return supabaseResponse
 }

--- a/apps/portal/lib/supabase/server.ts
+++ b/apps/portal/lib/supabase/server.ts
@@ -12,6 +12,7 @@ export async function createClient() {
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
     {
+      cookieOptions: { name: "portal" },
       cookies: {
         getAll() {
           return cookieStore.getAll()


### PR DESCRIPTION
Closes #123

## Summary
- Add `cookieOptions: { name: "portal" }` / `{ name: "gallery" }` to every `createServerClient` and `createBrowserClient` call so each service gets a unique cookie namespace (`portal.0`, `gallery-code-verifier`, etc.) that cannot collide with any other subdomain
- Wrap `getClaims()` in `try-catch` in both middlewares — malformed ghost cookies now produce a redirect instead of HTTP 500
- Proactively sweep `domain=.winlab.tw`-scoped `sb-*` ghost cookies on every middleware response so users' browsers self-clean on the next page load without needing to hit `/auth/login`
- Update `clearStaleSupabaseCookiesOnResponse` and `AuthStateReset` to recognise both old `sb-*` and new `portal*`/`gallery*` names during the migration window

## Why this fixes it
`www.winlab.tw` has been setting `sb-*` cookies with `domain=.winlab.tw` in production. Those cookies get broadcast to every `*.winlab.tw` subdomain, giving `@supabase/ssr` duplicate entries for the same cookie name. The library picks one (possibly the stale one), fails to parse the JWT, and can throw instead of returning a graceful error — which propagates through the middleware as an unhandled exception → HTTP 500.

## Migration impact
Existing logged-in users appear as "not authenticated" on first load after this deploy. Keycloak SSO silently re-authenticates them (< 1s redirect, no password prompt). After that everything works as before.

## Test plan
- [ ] Log into portal, open gallery in another tab — no 500, transparent Keycloak re-auth
- [ ] Log into www.winlab.tw, then visit portal — no collision, portal session unaffected
- [ ] Check browser DevTools → Application → Cookies: portal cookies start with `portal`, gallery with `gallery`, no `sb-*` with `domain=.winlab.tw`
- [ ] Hard-refresh portal after deploy — session restored via SSO with no user interaction