### PR TITLE
fix(games): mark games page as client component to avoid scoreLabel serialization error

### DIFF
--- a/apps/portal/app/games/page.tsx
+++ b/apps/portal/app/games/page.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { GameCard } from "./_components/game-card"
 import { GAME_META, GAME_ORDER } from "@/lib/games/constants"
 


### PR DESCRIPTION
Closes #125

## Root Cause

`app/games/page.tsx` was a Server Component that passed the full `GameMeta` object (which contains `scoreLabel: (score: number) => string`) as a prop to `<GameCard>` — a `"use client"` component.

Next.js App Router cannot serialize functions across the Server→Client boundary, causing a runtime 500 error on production.

## Fix

Add `"use client"` to `page.tsx`. The page has no server-only operations (no `await`, no cookies, no headers) — it purely renders static game cards from `GAME_META` constants. Making it a Client Component removes the serialization constraint entirely.

## Test plan
- [ ] Visit https://portal.winlab.tw/games — should render game card grid without server error
- [ ] Each game card should link to its individual game page