### PR TITLE
fix(games): QA pass — cheats, mobile touch, a11y, RLS

### DIFF
--- a/apps/portal/app/games/_components/game-2048.tsx
+++ b/apps/portal/app/games/_components/game-2048.tsx
@@ -95,7 +95,7 @@ function hasMovesLeft(grid: Grid): boolean {
 }
 
 const TILE_COLORS: Record<number, string> = {
-  0: "bg-muted",
+  0: "bg-background/40 dark:bg-background/20",
   2: "bg-zinc-100 dark:bg-zinc-800 text-zinc-800 dark:text-zinc-100",
   4: "bg-zinc-200 dark:bg-zinc-700 text-zinc-800 dark:text-zinc-100",
   8: "bg-orange-200 text-orange-900",
@@ -122,6 +122,7 @@ export function Game2048({ onComplete }: Game2048Props) {
   const [state, setState] = useState<GameState>("idle")
   const startRef = useRef<number | null>(null)
   const completedRef = useRef(false)
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null)
 
   const start = useCallback(() => {
     completedRef.current = false
@@ -158,6 +159,7 @@ export function Game2048({ onComplete }: Game2048Props) {
   )
 
   useEffect(() => {
+    if (state !== "playing") return
     const handler = (e: KeyboardEvent) => {
       const map: Record<string, Dir> = {
         ArrowUp: "up",
@@ -173,7 +175,7 @@ export function Game2048({ onComplete }: Game2048Props) {
     }
     window.addEventListener("keydown", handler)
     return () => window.removeEventListener("keydown", handler)
-  }, [handleMove])
+  }, [state, handleMove])
 
   const maxTile = Math.max(...grid.flat())
 
@@ -188,7 +190,33 @@ export function Game2048({ onComplete }: Game2048Props) {
         </Button>
       </div>
 
-      <div className="grid w-full max-w-xs grid-cols-4 gap-2 rounded-xl bg-muted p-3">
+      <div
+        className="grid w-full max-w-xs touch-none grid-cols-4 gap-2 rounded-xl bg-muted/60 p-3"
+        onTouchStart={(e) => {
+          const t = e.touches[0]
+          if (!t) return
+          touchStartRef.current = { x: t.clientX, y: t.clientY }
+        }}
+        onTouchEnd={(e) => {
+          const startTouch = touchStartRef.current
+          if (!startTouch || state !== "playing") return
+          const t = e.changedTouches[0]
+          if (!t) return
+          const dx = t.clientX - startTouch.x
+          const dy = t.clientY - startTouch.y
+          if (Math.abs(dx) < 24 && Math.abs(dy) < 24) return
+          handleMove(
+            Math.abs(dx) > Math.abs(dy)
+              ? dx > 0
+                ? "right"
+                : "left"
+              : dy > 0
+                ? "down"
+                : "up"
+          )
+          touchStartRef.current = null
+        }}
+      >
         {grid.flat().map((v, i) => (
           <div
             key={i}

--- a/apps/portal/app/games/_components/game-pipes.tsx
+++ b/apps/portal/app/games/_components/game-pipes.tsx
@@ -277,7 +277,7 @@ export function GamePipes({ onComplete }: GamePipesProps) {
             : "點擊管道旋轉，讓所有端點（圓點）連通"}
         </p>
         <Button size="sm" variant="outline" onClick={start}>
-          {gameState === "idle" ? "開始" : "重新"}
+          {gameState === "idle" ? "開始遊戲" : "重新開始"}
         </Button>
       </div>
 
@@ -302,12 +302,17 @@ export function GamePipes({ onComplete }: GamePipesProps) {
                 <button
                   key={`${r},${c}`}
                   onClick={() => handleClick(r, c)}
-                  disabled={isSrc}
+                  disabled={isSrc || gameState !== "playing"}
+                  aria-label={
+                    isSrc
+                      ? "水源"
+                      : `第 ${r + 1} 行第 ${c + 1} 列管道，點擊旋轉`
+                  }
                   className={`rounded transition-colors ${
                     isConn
                       ? "bg-blue-50 dark:bg-blue-950/40"
                       : "bg-muted/40 hover:bg-muted"
-                  }`}
+                  } disabled:cursor-default`}
                   style={{ width: 50, height: 50 }}
                 >
                   <PipeSVG mask={mask} isSource={isSrc} connected={isConn} />

--- a/apps/portal/app/games/_components/game-queens.tsx
+++ b/apps/portal/app/games/_components/game-queens.tsx
@@ -76,7 +76,7 @@ const REGION_COLORS = [
   "bg-yellow-200 dark:bg-yellow-900/60",
 ]
 
-function checkViolation(
+function checkAdjacent(
   placement: boolean[][],
   r: number,
   c: number,
@@ -94,31 +94,57 @@ function checkViolation(
   return false
 }
 
+function computeViolations(
+  placement: boolean[][],
+  regions: number[][],
+  size: number
+): Set<string> {
+  const set = new Set<string>()
+  if (!placement.length) return set
+
+  const byRow = new Map<number, string[]>()
+  const byCol = new Map<number, string[]>()
+  const byRegion = new Map<number, string[]>()
+
+  for (let r = 0; r < size; r++) {
+    for (let c = 0; c < size; c++) {
+      if (!placement[r]?.[c]) continue
+      const key = `${r},${c}`
+      const region = regions[r]![c]!
+      if (!byRow.has(r)) byRow.set(r, [])
+      byRow.get(r)!.push(key)
+      if (!byCol.has(c)) byCol.set(c, [])
+      byCol.get(c)!.push(key)
+      if (!byRegion.has(region)) byRegion.set(region, [])
+      byRegion.get(region)!.push(key)
+
+      if (checkAdjacent(placement, r, c, size)) set.add(key)
+    }
+  }
+
+  for (const group of [byRow, byCol, byRegion]) {
+    for (const keys of group.values()) {
+      if (keys.length > 1) for (const k of keys) set.add(k)
+    }
+  }
+  return set
+}
+
 function isComplete(
   placement: boolean[][],
   regions: number[][],
   size: number
 ): boolean {
-  let total = 0
-  const regionSet = new Set<number>()
-  const rows = new Set<number>()
-  const cols = new Set<number>()
+  const numRegions = new Set(regions.flat()).size
+  if (computeViolations(placement, regions, size).size > 0) return false
 
+  let total = 0
   for (let r = 0; r < size; r++) {
     for (let c = 0; c < size; c++) {
-      if (!placement[r]?.[c]) continue
-      total++
-      if (checkViolation(placement, r, c, size)) return false
-      if (regionSet.has(regions[r]![c]!)) return false
-      regionSet.add(regions[r]![c]!)
-      if (rows.has(r) || cols.has(c)) return false
-      rows.add(r)
-      cols.add(c)
+      if (placement[r]?.[c]) total++
     }
   }
-
-  const numRegions = new Set(regions.flat()).size
-  return total === numRegions && regionSet.size === numRegions
+  return total === numRegions
 }
 
 interface GameQueensProps {
@@ -156,18 +182,10 @@ export function GameQueens({ onComplete }: GameQueensProps) {
     [gameState]
   )
 
-  const violations = useMemo(() => {
-    const set = new Set<string>()
-    if (!placement.length) return set
-    for (let r = 0; r < puzzle.size; r++) {
-      for (let c = 0; c < puzzle.size; c++) {
-        if (placement[r]?.[c] && checkViolation(placement, r, c, puzzle.size)) {
-          set.add(`${r},${c}`)
-        }
-      }
-    }
-    return set
-  }, [placement, puzzle.size])
+  const violations = useMemo(
+    () => computeViolations(placement, puzzle.regions, puzzle.size),
+    [placement, puzzle]
+  )
 
   const won = useMemo(
     () =>
@@ -216,13 +234,15 @@ export function GameQueens({ onComplete }: GameQueensProps) {
 
       <div className="flex w-full max-w-xs items-center justify-between">
         <p className="text-sm text-muted-foreground">
-          {gameState === "playing"
-            ? `已放 ${queenCount} / ${numRegions} 個皇后`
-            : "選擇難度開始"}
+          {gameState === "won"
+            ? `已完成 ${queenCount} / ${numRegions} 個皇后`
+            : gameState === "playing"
+              ? `已放 ${queenCount} / ${numRegions} 個皇后`
+              : "選擇難度開始"}
         </p>
         {gameState !== "idle" && (
           <Button size="sm" variant="outline" onClick={() => start(puzzleIdx)}>
-            重置
+            重新開始
           </Button>
         )}
       </div>
@@ -260,14 +280,23 @@ export function GameQueens({ onComplete }: GameQueensProps) {
                 <button
                   key={`${r},${c}`}
                   onClick={() => handleCellClick(r, c)}
-                  className={`flex cursor-pointer items-center justify-center transition-colors select-none ${colorClass} ${borderTop} ${borderLeft} ${
+                  aria-label={`第 ${r + 1} 行第 ${c + 1} 列，區域 ${regionId + 1}${hasQueen ? "，已放皇后" : ""}${isViolation ? "（違規）" : ""}`}
+                  aria-pressed={hasQueen}
+                  disabled={gameState !== "playing"}
+                  className={`relative flex cursor-pointer items-center justify-center transition-colors select-none ${colorClass} ${borderTop} ${borderLeft} ${
                     isViolation ? "ring-2 ring-destructive ring-inset" : ""
-                  }`}
+                  } disabled:cursor-default`}
                   style={{
                     width: puzzle.size === 6 ? 52 : 62,
                     height: puzzle.size === 6 ? 52 : 62,
                   }}
                 >
+                  <span
+                    aria-hidden
+                    className="absolute top-0.5 left-1 text-[10px] font-semibold text-foreground/40 tabular-nums"
+                  >
+                    {regionId + 1}
+                  </span>
                   {hasQueen && (
                     <span
                       className={`text-2xl leading-none select-none ${isViolation ? "opacity-50" : ""}`}

--- a/apps/portal/app/games/_components/game-snake.tsx
+++ b/apps/portal/app/games/_components/game-snake.tsx
@@ -47,6 +47,7 @@ export function GameSnake({ onComplete }: GameSnakeProps) {
   const foodRef = useRef<Pos>({ r: 5, c: 15 })
   const startRef = useRef<number | null>(null)
   const completedRef = useRef(false)
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null)
 
   const start = useCallback(() => {
     const initSnake = [
@@ -89,7 +90,10 @@ export function GameSnake({ onComplete }: GameSnakeProps) {
           const ms = Date.now() - (startRef.current ?? Date.now())
           const finalScore = snakeRef.current.length - 3
           setState("dead")
-          onComplete({ score: finalScore, finishTimeMs: ms })
+          // Skip leaderboard submission for trivial runs (0 食物 or < 1s)
+          if (finalScore > 0 && ms >= 1000) {
+            onComplete({ score: finalScore, finishTimeMs: ms })
+          }
         }
         return
       }
@@ -112,7 +116,21 @@ export function GameSnake({ onComplete }: GameSnakeProps) {
     return () => clearInterval(interval)
   }, [state, onComplete])
 
+  const applyDir = useCallback((next: Dir) => {
+    const opposite: Record<Dir, Dir> = {
+      up: "down",
+      down: "up",
+      left: "right",
+      right: "left",
+    }
+    if (next !== opposite[dirRef.current]) {
+      dirRef.current = next
+      setDir(next)
+    }
+  }, [])
+
   useEffect(() => {
+    if (state !== "playing") return
     const handler = (e: KeyboardEvent) => {
       const map: Record<string, Dir> = {
         ArrowUp: "up",
@@ -123,20 +141,11 @@ export function GameSnake({ onComplete }: GameSnakeProps) {
       const next = map[e.key]
       if (!next) return
       e.preventDefault()
-      const opposite: Record<Dir, Dir> = {
-        up: "down",
-        down: "up",
-        left: "right",
-        right: "left",
-      }
-      if (next !== opposite[dirRef.current]) {
-        dirRef.current = next
-        setDir(next)
-      }
+      applyDir(next)
     }
     window.addEventListener("keydown", handler)
     return () => window.removeEventListener("keydown", handler)
-  }, [])
+  }, [state, applyDir])
 
   const snakeSet = new Set(snake.map((p) => `${p.r},${p.c}`))
   const isHead = (r: number, c: number) =>
@@ -155,8 +164,28 @@ export function GameSnake({ onComplete }: GameSnakeProps) {
       </div>
 
       <div
-        className="overflow-hidden rounded-xl border"
+        className="max-w-full touch-none overflow-hidden rounded-xl border"
         style={{ width: COLS * 18, height: ROWS * 18 }}
+        onTouchStart={(e) => {
+          const t = e.touches[0]
+          if (!t) return
+          touchStartRef.current = { x: t.clientX, y: t.clientY }
+        }}
+        onTouchEnd={(e) => {
+          const start = touchStartRef.current
+          if (!start || state !== "playing") return
+          const t = e.changedTouches[0]
+          if (!t) return
+          const dx = t.clientX - start.x
+          const dy = t.clientY - start.y
+          if (Math.abs(dx) < 24 && Math.abs(dy) < 24) return
+          if (Math.abs(dx) > Math.abs(dy)) {
+            applyDir(dx > 0 ? "right" : "left")
+          } else {
+            applyDir(dy > 0 ? "down" : "up")
+          }
+          touchStartRef.current = null
+        }}
       >
         <div
           className="relative"

--- a/apps/portal/app/games/_components/game-typing.tsx
+++ b/apps/portal/app/games/_components/game-typing.tsx
@@ -42,20 +42,29 @@ export function GameTyping({ onComplete }: GameTypingProps) {
       if (state !== "playing") return
       const val = e.target.value
 
+      // Reject sudden large inserts (paste, IME drop) — > 4 chars added at once
+      if (val.length - input.length > 4) return
+
       if (!startRef.current) startRef.current = Date.now()
 
       setInput(val)
 
       if (val === target && !completedRef.current) {
         completedRef.current = true
-        const ms = Date.now() - startRef.current
+        const ms = Math.max(Date.now() - startRef.current, 1)
         const words = target.trim().split(/\s+/).length
         const wpm = Math.round((words / ms) * 60000)
         setState("done")
-        setTimeout(() => onComplete({ score: wpm * 10, finishTimeMs: ms }), 100)
+        // Floor at 1s to defeat instant-fill exploits; cap WPM at 300 sanity check
+        if (ms >= 1000 && wpm <= 300) {
+          setTimeout(
+            () => onComplete({ score: wpm * 10, finishTimeMs: ms }),
+            100
+          )
+        }
       }
     },
-    [state, target, onComplete]
+    [state, target, input, onComplete]
   )
 
   const correctCount = input
@@ -109,6 +118,8 @@ export function GameTyping({ onComplete }: GameTypingProps) {
             ref={inputRef}
             value={input}
             onChange={handleChange}
+            onPaste={(e) => e.preventDefault()}
+            onDrop={(e) => e.preventDefault()}
             disabled={state === "done"}
             className="w-full rounded-lg border bg-background px-3 py-2 font-mono text-sm ring-1 ring-muted outline-none focus:ring-primary"
             placeholder="在此輸入..."
@@ -116,6 +127,7 @@ export function GameTyping({ onComplete }: GameTypingProps) {
             autoCorrect="off"
             autoCapitalize="off"
             spellCheck={false}
+            inputMode="text"
           />
         </>
       )}

--- a/apps/portal/app/games/page.tsx
+++ b/apps/portal/app/games/page.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { GameCard } from "./_components/game-card"
 import { GAME_META, GAME_ORDER } from "@/lib/games/constants"
 

--- a/apps/portal/hooks/games/use-scores.ts
+++ b/apps/portal/hooks/games/use-scores.ts
@@ -34,6 +34,17 @@ export function useSubmitScore(gameType: GameType) {
       score: number
       finishTimeMs: number
     }) => {
+      if (
+        !Number.isFinite(score) ||
+        !Number.isFinite(finishTimeMs) ||
+        score < 0 ||
+        score > 1_000_000 ||
+        finishTimeMs < 1 ||
+        finishTimeMs > 24 * 60 * 60 * 1000
+      ) {
+        throw new Error("Invalid score")
+      }
+
       const {
         data: { user },
       } = await supabase.auth.getUser()
@@ -42,8 +53,8 @@ export function useSubmitScore(gameType: GameType) {
       const { error } = await supabase.from("game_scores").insert({
         user_id: user.id,
         game_type: gameType,
-        score,
-        finish_time_ms: finishTimeMs,
+        score: Math.floor(score),
+        finish_time_ms: Math.floor(finishTimeMs),
       })
       if (error) throw error
     },

--- a/supabase/migrations/2026-05-18-game-scores-append-only.sql
+++ b/supabase/migrations/2026-05-18-game-scores-append-only.sql
@@ -1,0 +1,20 @@
+-- Lock down game_scores as append-only.
+-- Existing migrations grant SELECT + INSERT to authenticated.
+-- Postgres RLS denies UPDATE/DELETE by default when no policy matches, but
+-- restrictive policies make the intent explicit and survive future drift
+-- (e.g. an accidental permissive UPDATE policy added later cannot escalate).
+
+create policy "game_scores deny update"
+  on public.game_scores
+  as restrictive
+  for update
+  to authenticated, anon
+  using (false)
+  with check (false);
+
+create policy "game_scores deny delete"
+  on public.game_scores
+  as restrictive
+  for delete
+  to authenticated, anon
+  using (false);


### PR DESCRIPTION
Closes #128

## Summary
Batched fixes from a QA pass on the games feature (playthrough + two code-review agents).

### Anti-cheat & leaderboard integrity
- **Snake**: drop the 0-score auto-submit. A run only counts when the snake ate ≥ 1 food *and* survived ≥ 1s. Stops the leaderboard from filling with 0-pt 1.04s rows when the user blinks.
- **Typing**: `onPaste` and `onDrop` are blocked; sudden inserts > 4 chars are rejected; `finishTimeMs` is floored to 1ms; submission requires ms ≥ 1s and WPM ≤ 300. No more silent 400s from `Infinity` WPM via paste.
- **`use-scores`**: sanity-checks `score`/`finishTimeMs` (finite, in range) before the insert. Final line of defense if a game emits NaN/Infinity/negative.
- **migration `2026-05-18-game-scores-append-only.sql`**: restrictive RLS policies that deny UPDATE/DELETE on `game_scores` even if someone later adds a permissive policy by accident. Already applied to the project.

### Queens
- `computeViolations` now flags row, column, *and* region collisions in addition to adjacency. The red ring you actually need to debug your placement now shows up. (This was the bug from QA.)
- `isComplete` reuses the same helper, so wins still require zero violations.
- Status copy after winning is "已完成 N / N 個皇后" instead of falling through to the idle text.
- "重置" → "重新開始" for copy consistency with the other games.
- Each cell gets an `aria-label` and a faint region number for color-blind / screen-reader users.

### Mobile / touch
- Snake and 2048 boards now respond to swipe gestures (touchstart → touchend delta, 24px threshold). Phones can finally play these.
- Both games scope their `keydown` listener (and `e.preventDefault()`) to `state === "playing"`, so arrow keys don't silently swallow page scroll when the game is idle/won/dead.

### UI polish
- 2048 empty cells now use `bg-background/40` while the board uses `bg-muted/60`, so the 4×4 grid is visible at game start.
- Pipes "開始" / "重新" → "開始遊戲" / "重新開始" to match other games.
- Pipes cells get `aria-label` and are disabled when not playing.
- Typing input has `inputMode="text"` so iOS shows the plain keyboard.

## Test plan
- [x] `bun run typecheck` (portal) — green
- [x] `bun run build` (portal) — green
- [x] Migration applied to project `yissfqcdmzsxwfnzrflz`
- [ ] Manual: Queens — place 2 queens in the same row → both light up red
- [ ] Manual: Snake — load `/games/snake`, click start, immediately crash → no toast, no leaderboard write
- [ ] Manual: Typing — open devtools, paste the passage into the input → input rejects (paste blocked, large delta rejected)
- [ ] Manual: 2048 — open on iPhone/Android, swipe in 4 directions → tiles move