### PR TITLE
fix(games): 2048 ↓ + pipes endpoint dot

### DIFF
--- a/apps/portal/app/games/_components/game-2048.tsx
+++ b/apps/portal/app/games/_components/game-2048.tsx
@@ -71,12 +71,12 @@ function moveGrid(grid: Grid, dir: Dir): { grid: Grid; changed: boolean } {
     }
   } else {
     for (let c = 0; c < 4; c++) {
-      const col = next.map((row) => row[c] ?? 0).reverse()
-      const { row: result, merged } = slideRow(col)
+      const origCol = next.map((row) => row[c] ?? 0)
+      const { row: result, merged } = slideRow([...origCol].reverse())
       const final = result.reverse()
-      if (merged || final.some((v, i) => v !== col[3 - i])) changed = true
+      if (merged || final.some((v, i) => v !== origCol[i])) changed = true
       final.forEach((v, i) => {
-        next[3 - i]![c] = v
+        next[i]![c] = v
       })
     }
   }

--- a/apps/portal/app/games/_components/game-pipes.tsx
+++ b/apps/portal/app/games/_components/game-pipes.tsx
@@ -111,13 +111,15 @@ function PipeSVG({
   const numConn = [TOP, RIGHT, BOTTOM, LEFT].filter((b) => mask & b).length
   const isEndpoint = numConn === 1
 
+  // Endpoint dot sits on the closed end of the pipe (opposite the open side),
+  // so the cell reads as "pipe terminates here" instead of overlapping the line.
   let ex = 20,
     ey = 20
   if (isEndpoint) {
-    if (mask & TOP) ey = 4
-    else if (mask & RIGHT) ex = 36
-    else if (mask & BOTTOM) ey = 36
-    else ex = 4
+    if (mask & TOP) ey = 36
+    else if (mask & RIGHT) ex = 4
+    else if (mask & BOTTOM) ey = 4
+    else ex = 36
   }
 
   return (


### PR DESCRIPTION
Closes #130

## What
Two visual/logic bugs from playthrough:

**2048 ArrowDown**
\`moveGrid\` reversed the column, slid, reversed back, *then* wrote to \`next[3 - i][c]\` — a third reversal. Result was identical to ArrowUp. Switched to \`next[i][c]\` so the merged column lands at the bottom as expected.

\`\`\`
in:  [4, 0, 2, 0]   want: [0, 0, 4, 2]   before fix: [2, 4, 0, 0]   after fix: [0, 0, 4, 2]
\`\`\`

Sanity-checked against 6 fixtures including the tricky ones (\`[2,2,2,2]\` → \`[0,0,4,4]\`, \`[2,4,2,4]\` → unchanged).

**Pipes endpoint dot**
\`PipeSVG\` drew the endpoint dot at the same edge the pipe opens onto, so the dot overlapped the line. Flipped to the opposite edge — now the dot sits on the closed end, making it clear the pipe terminates there.

## Test plan
- [x] \`bun run typecheck\` (portal) — green
- [x] \`bun run build\` (portal) — green
- [x] 6/6 fixtures pass for down-direction logic
- [ ] Manual: open \`/games/2048\`, ↓ once with two equal tiles vertically aligned, confirm they merge at the bottom
- [ ] Manual: open \`/games/pipes\`, find an endpoint cell, confirm the dot is on the opposite edge from where the pipe exits