### PR TITLE
feat(games): queens tri-state cells + pipes 100 fixed levels

### DIFF
--- a/apps/portal/app/games/_components/game-pipes.tsx
+++ b/apps/portal/app/games/_components/game-pipes.tsx
@@ -3,99 +3,18 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Button } from "@workspace/ui/components/button"
 import type { GameResult } from "@/lib/games/types"
-
-// Bitmask: bit0=top, bit1=right, bit2=bottom, bit3=left
-const TOP = 1,
-  RIGHT = 2,
-  BOTTOM = 4,
-  LEFT = 8
-const GRID = 6
-
-function rotateCW(mask: number, times = 1): number {
-  let m = mask
-  for (let i = 0; i < times; i++) m = ((m << 1) | (m >> 3)) & 0xf
-  return m
-}
-
-function generateSolved(
-  rows: number,
-  cols: number,
-  sr: number,
-  sc: number
-): number[][] {
-  const grid = Array.from({ length: rows }, () => Array<number>(cols).fill(0))
-  const visited = new Set<string>()
-
-  function dfs(r: number, c: number) {
-    visited.add(`${r},${c}`)
-    const dirs = [
-      { dr: -1, dc: 0, from: TOP, to: BOTTOM },
-      { dr: 0, dc: 1, from: RIGHT, to: LEFT },
-      { dr: 1, dc: 0, from: BOTTOM, to: TOP },
-      { dr: 0, dc: -1, from: LEFT, to: RIGHT },
-    ].sort(() => Math.random() - 0.5)
-
-    for (const { dr, dc, from, to } of dirs) {
-      const nr = r + dr,
-        nc = c + dc
-      if (
-        nr >= 0 &&
-        nr < rows &&
-        nc >= 0 &&
-        nc < cols &&
-        !visited.has(`${nr},${nc}`)
-      ) {
-        grid[r]![c]! |= from
-        grid[nr]![nc]! |= to
-        dfs(nr, nc)
-      }
-    }
-  }
-
-  dfs(sr, sc)
-  return grid
-}
-
-function getConnected(
-  masks: number[][],
-  source: [number, number],
-  rows: number,
-  cols: number
-): Set<string> {
-  const [sr, sc] = source
-  const visited = new Set<string>([`${sr},${sc}`])
-  const q: [number, number][] = [[sr, sc]]
-
-  while (q.length) {
-    const [r, c] = q.shift()!
-    const m = masks[r]?.[c] ?? 0
-    const neighbors: [number, number, number, number][] = [
-      [-1, 0, TOP, BOTTOM],
-      [0, 1, RIGHT, LEFT],
-      [1, 0, BOTTOM, TOP],
-      [0, -1, LEFT, RIGHT],
-    ]
-    for (const [dr, dc, cm, nm] of neighbors) {
-      const nr = r + dr,
-        nc = c + dc
-      if (
-        nr >= 0 &&
-        nr < rows &&
-        nc >= 0 &&
-        nc < cols &&
-        m & cm &&
-        (masks[nr]?.[nc] ?? 0) & nm
-      ) {
-        const key = `${nr},${nc}`
-        if (!visited.has(key)) {
-          visited.add(key)
-          q.push([nr, nc])
-        }
-      }
-    }
-  }
-  return visited
-}
+import {
+  BOTTOM,
+  LEFT,
+  PIPES_GRID,
+  PIPES_LEVEL_COUNT,
+  RIGHT,
+  TOP,
+  getConnected,
+  getEndpoints,
+  getPuzzle,
+  rotateCW,
+} from "@/lib/games/pipes-puzzle"
 
 function PipeSVG({
   mask,
@@ -111,8 +30,7 @@ function PipeSVG({
   const numConn = [TOP, RIGHT, BOTTOM, LEFT].filter((b) => mask & b).length
   const isEndpoint = numConn === 1
 
-  // Endpoint dot sits on the closed end of the pipe (opposite the open side),
-  // so the cell reads as "pipe terminates here" instead of overlapping the line.
+  // Endpoint dot sits on the closed end of the pipe (opposite the open side).
   let ex = 20,
     ey = 20
   if (isEndpoint) {
@@ -196,46 +114,33 @@ interface GamePipesProps {
 }
 
 export function GamePipes({ onComplete }: GamePipesProps) {
-  const [solved, setSolved] = useState<number[][]>([])
+  const [level, setLevel] = useState(1)
   const [current, setCurrent] = useState<number[][]>([])
-  const [source, setSource] = useState<[number, number]>([2, 2])
   const [gameState, setGameState] = useState<"idle" | "playing" | "won">("idle")
   const startRef = useRef<number | null>(null)
   const completedRef = useRef(false)
 
-  const start = useCallback(() => {
+  // Solved/source/scrambled all come from the deterministic level number.
+  const puzzle = useMemo(() => getPuzzle(level), [level])
+
+  const start = useCallback((lvl: number) => {
+    const p = getPuzzle(lvl)
     completedRef.current = false
-    const sr = Math.floor(GRID / 2),
-      sc = Math.floor(GRID / 2)
-    const solvedGrid = generateSolved(GRID, GRID, sr, sc)
-    const scrambled = solvedGrid.map((row) =>
-      row.map((mask) =>
-        mask ? rotateCW(mask, Math.floor(Math.random() * 4)) : 0
-      )
-    )
-    setSolved(solvedGrid)
-    setCurrent(scrambled)
-    setSource([sr, sc])
+    setLevel(p.level)
+    setCurrent(p.scrambled.map((row) => [...row]))
     setGameState("playing")
     startRef.current = Date.now()
   }, [])
 
   const connected = useMemo(() => {
     if (!current.length) return new Set<string>()
-    return getConnected(current, source, GRID, GRID)
-  }, [current, source])
+    return getConnected(current, puzzle.source, PIPES_GRID, PIPES_GRID)
+  }, [current, puzzle.source])
 
-  const endpoints = useMemo(() => {
-    const eps: [number, number][] = []
-    solved.forEach((row, r) =>
-      row.forEach((mask, c) => {
-        if (r === source[0] && c === source[1]) return
-        const count = [TOP, RIGHT, BOTTOM, LEFT].filter((b) => mask & b).length
-        if (count === 1) eps.push([r, c])
-      })
-    )
-    return eps
-  }, [solved, source])
+  const endpoints = useMemo(
+    () => getEndpoints(puzzle.solved, puzzle.source),
+    [puzzle]
+  )
 
   const isWon = useMemo(
     () =>
@@ -259,7 +164,10 @@ export function GamePipes({ onComplete }: GamePipesProps) {
 
   const handleClick = useCallback(
     (r: number, c: number) => {
-      if (gameState !== "playing" || (r === source[0] && c === source[1]))
+      if (
+        gameState !== "playing" ||
+        (r === puzzle.source[0] && c === puzzle.source[1])
+      )
         return
       setCurrent((prev) => {
         const next = prev.map((row) => [...row])
@@ -267,62 +175,94 @@ export function GamePipes({ onComplete }: GamePipesProps) {
         return next
       })
     },
-    [gameState, source]
+    [gameState, puzzle.source]
   )
+
+  const goToLevel = (lvl: number) => {
+    const clamped = Math.max(1, Math.min(PIPES_LEVEL_COUNT, lvl))
+    start(clamped)
+  }
 
   return (
     <div className="flex flex-col items-center gap-4">
       <div className="flex w-full max-w-xs items-center justify-between">
         <p className="text-sm text-muted-foreground">
-          {gameState === "playing"
-            ? `連接 ${endpoints.filter(([r, c]) => connected.has(`${r},${c}`)).length} / ${endpoints.length} 個端點`
+          {gameState === "playing" || gameState === "won"
+            ? `關卡 ${level} · 連接 ${endpoints.filter(([r, c]) => connected.has(`${r},${c}`)).length} / ${endpoints.length}`
             : "點擊管道旋轉，讓所有端點（圓點）連通"}
         </p>
-        <Button size="sm" variant="outline" onClick={start}>
+        <Button size="sm" variant="outline" onClick={() => start(level)}>
           {gameState === "idle" ? "開始遊戲" : "重新開始"}
         </Button>
       </div>
 
       {gameState === "idle" ? (
         <p className="py-8 text-center text-sm text-muted-foreground">
-          按下開始，旋轉管道讓水從藍色源頭流到所有端點
+          按下開始，旋轉管道讓水從藍色源頭流到所有端點。共 {PIPES_LEVEL_COUNT}{" "}
+          關。
         </p>
       ) : (
-        <div
-          className="rounded-xl border bg-muted/20 p-2"
-          style={{
-            display: "grid",
-            gridTemplateColumns: `repeat(${GRID}, 50px)`,
-            gap: "2px",
-          }}
-        >
-          {current.map((row, r) =>
-            row.map((mask, c) => {
-              const isSrc = r === source[0] && c === source[1]
-              const isConn = connected.has(`${r},${c}`)
-              return (
-                <button
-                  key={`${r},${c}`}
-                  onClick={() => handleClick(r, c)}
-                  disabled={isSrc || gameState !== "playing"}
-                  aria-label={
-                    isSrc
-                      ? "水源"
-                      : `第 ${r + 1} 行第 ${c + 1} 列管道，點擊旋轉`
-                  }
-                  className={`rounded transition-colors ${
-                    isConn
-                      ? "bg-blue-50 dark:bg-blue-950/40"
-                      : "bg-muted/40 hover:bg-muted"
-                  } disabled:cursor-default`}
-                  style={{ width: 50, height: 50 }}
-                >
-                  <PipeSVG mask={mask} isSource={isSrc} connected={isConn} />
-                </button>
-              )
-            })
-          )}
-        </div>
+        <>
+          <div
+            className="rounded-xl border bg-muted/20 p-2"
+            style={{
+              display: "grid",
+              gridTemplateColumns: `repeat(${PIPES_GRID}, 50px)`,
+              gap: "2px",
+            }}
+          >
+            {current.map((row, r) =>
+              row.map((mask, c) => {
+                const isSrc = r === puzzle.source[0] && c === puzzle.source[1]
+                const isConn = connected.has(`${r},${c}`)
+                return (
+                  <button
+                    key={`${r},${c}`}
+                    onClick={() => handleClick(r, c)}
+                    disabled={isSrc || gameState !== "playing"}
+                    aria-label={
+                      isSrc
+                        ? "水源"
+                        : `第 ${r + 1} 行第 ${c + 1} 列管道，點擊旋轉`
+                    }
+                    className={`rounded transition-colors ${
+                      isConn
+                        ? "bg-blue-50 dark:bg-blue-950/40"
+                        : "bg-muted/40 hover:bg-muted"
+                    } disabled:cursor-default`}
+                    style={{ width: 50, height: 50 }}
+                  >
+                    <PipeSVG mask={mask} isSource={isSrc} connected={isConn} />
+                  </button>
+                )
+              })
+            )}
+          </div>
+
+          <div className="flex items-center gap-2 text-sm">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => goToLevel(level - 1)}
+              disabled={level <= 1}
+              aria-label="上一關"
+            >
+              ←
+            </Button>
+            <span className="min-w-[5rem] text-center text-muted-foreground tabular-nums">
+              {level} / {PIPES_LEVEL_COUNT}
+            </span>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => goToLevel(level + 1)}
+              disabled={level >= PIPES_LEVEL_COUNT}
+              aria-label="下一關"
+            >
+              →
+            </Button>
+          </div>
+        </>
       )}
 
       {gameState === "won" && (

--- a/apps/portal/app/games/_components/game-queens.tsx
+++ b/apps/portal/app/games/_components/game-queens.tsx
@@ -76,8 +76,16 @@ const REGION_COLORS = [
   "bg-yellow-200 dark:bg-yellow-900/60",
 ]
 
+// 0 = empty, 1 = mark (✕ "not a queen" hint), 2 = queen
+type CellState = 0 | 1 | 2
+type Placement = CellState[][]
+
+function isQueen(p: Placement, r: number, c: number): boolean {
+  return p[r]?.[c] === 2
+}
+
 function checkAdjacent(
-  placement: boolean[][],
+  placement: Placement,
   r: number,
   c: number,
   size: number
@@ -87,7 +95,13 @@ function checkAdjacent(
       if (!dr && !dc) continue
       const nr = r + dr,
         nc = c + dc
-      if (nr >= 0 && nr < size && nc >= 0 && nc < size && placement[nr]?.[nc])
+      if (
+        nr >= 0 &&
+        nr < size &&
+        nc >= 0 &&
+        nc < size &&
+        isQueen(placement, nr, nc)
+      )
         return true
     }
   }
@@ -95,7 +109,7 @@ function checkAdjacent(
 }
 
 function computeViolations(
-  placement: boolean[][],
+  placement: Placement,
   regions: number[][],
   size: number
 ): Set<string> {
@@ -108,7 +122,7 @@ function computeViolations(
 
   for (let r = 0; r < size; r++) {
     for (let c = 0; c < size; c++) {
-      if (!placement[r]?.[c]) continue
+      if (!isQueen(placement, r, c)) continue
       const key = `${r},${c}`
       const region = regions[r]![c]!
       if (!byRow.has(r)) byRow.set(r, [])
@@ -131,7 +145,7 @@ function computeViolations(
 }
 
 function isComplete(
-  placement: boolean[][],
+  placement: Placement,
   regions: number[][],
   size: number
 ): boolean {
@@ -141,7 +155,7 @@ function isComplete(
   let total = 0
   for (let r = 0; r < size; r++) {
     for (let c = 0; c < size; c++) {
-      if (placement[r]?.[c]) total++
+      if (isQueen(placement, r, c)) total++
     }
   }
   return total === numRegions
@@ -153,7 +167,7 @@ interface GameQueensProps {
 
 export function GameQueens({ onComplete }: GameQueensProps) {
   const [puzzleIdx, setPuzzleIdx] = useState(0)
-  const [placement, setPlacement] = useState<boolean[][]>([])
+  const [placement, setPlacement] = useState<Placement>([])
   const [gameState, setGameState] = useState<"idle" | "playing" | "won">("idle")
   const startRef = useRef<number | null>(null)
   const completedRef = useRef(false)
@@ -164,7 +178,10 @@ export function GameQueens({ onComplete }: GameQueensProps) {
     const p = PUZZLES[idx]!
     completedRef.current = false
     setPlacement(
-      Array.from({ length: p.size }, () => Array(p.size).fill(false))
+      Array.from(
+        { length: p.size },
+        () => Array<CellState>(p.size).fill(0) as CellState[]
+      )
     )
     setGameState("playing")
     startRef.current = Date.now()
@@ -174,8 +191,9 @@ export function GameQueens({ onComplete }: GameQueensProps) {
     (r: number, c: number) => {
       if (gameState !== "playing") return
       setPlacement((prev) => {
-        const next = prev.map((row) => [...row])
-        next[r]![c] = !next[r]![c]
+        const next = prev.map((row) => [...row]) as Placement
+        const cur = next[r]![c] ?? 0
+        next[r]![c] = ((cur + 1) % 3) as CellState
         return next
       })
     },
@@ -207,7 +225,7 @@ export function GameQueens({ onComplete }: GameQueensProps) {
     }
   }, [won, puzzle.size, onComplete])
 
-  const queenCount = placement.flat().filter(Boolean).length
+  const queenCount = placement.flat().filter((v) => v === 2).length
   const numRegions = new Set(puzzle.regions.flat()).size
 
   return (
@@ -252,6 +270,9 @@ export function GameQueens({ onComplete }: GameQueensProps) {
           <p>每個顏色區域恰好放一個 ♛</p>
           <p>每行每列只能有一個 ♛</p>
           <p>♛ 之間不得相鄰（含對角線）</p>
+          <p className="pt-2 text-xs">
+            點 1 下標 ✕（標非 ♛）／ 2 下放 ♛ ／ 3 下清空
+          </p>
         </div>
       ) : (
         <div
@@ -263,7 +284,9 @@ export function GameQueens({ onComplete }: GameQueensProps) {
         >
           {puzzle.regions.map((row, r) =>
             row.map((regionId, c) => {
-              const hasQueen = placement[r]?.[c] ?? false
+              const cell = placement[r]?.[c] ?? 0
+              const hasMark = cell === 1
+              const hasQueen = cell === 2
               const isViolation = violations.has(`${r},${c}`)
               const colorClass = REGION_COLORS[regionId] ?? "bg-muted"
 
@@ -276,11 +299,17 @@ export function GameQueens({ onComplete }: GameQueensProps) {
                   ? "border-l-2 border-l-foreground/60"
                   : "border-l border-l-foreground/10"
 
+              const stateLabel = hasQueen
+                ? "，已放皇后"
+                : hasMark
+                  ? "，已標記非皇后"
+                  : ""
+
               return (
                 <button
                   key={`${r},${c}`}
                   onClick={() => handleCellClick(r, c)}
-                  aria-label={`第 ${r + 1} 行第 ${c + 1} 列，區域 ${regionId + 1}${hasQueen ? "，已放皇后" : ""}${isViolation ? "（違規）" : ""}`}
+                  aria-label={`第 ${r + 1} 行第 ${c + 1} 列，區域 ${regionId + 1}${stateLabel}${isViolation ? "（違規）" : ""}`}
                   aria-pressed={hasQueen}
                   disabled={gameState !== "playing"}
                   className={`relative flex cursor-pointer items-center justify-center transition-colors select-none ${colorClass} ${borderTop} ${borderLeft} ${
@@ -302,6 +331,14 @@ export function GameQueens({ onComplete }: GameQueensProps) {
                       className={`text-2xl leading-none select-none ${isViolation ? "opacity-50" : ""}`}
                     >
                       ♛
+                    </span>
+                  )}
+                  {hasMark && (
+                    <span
+                      aria-hidden
+                      className="text-lg leading-none text-foreground/40 select-none"
+                    >
+                      ✕
                     </span>
                   )}
                 </button>

--- a/apps/portal/lib/games/pipes-puzzle.ts
+++ b/apps/portal/lib/games/pipes-puzzle.ts
@@ -1,0 +1,150 @@
+// Pipes puzzle generator with deterministic seeding.
+//
+// Each level (1..LEVEL_COUNT) maps to a unique seed via mulberry32 PRNG, so
+// every player gets the same 6×6 grid for the same level number. The grid is
+// always a spanning tree rooted at the center (source), which guarantees the
+// puzzle is solvable — every cell can be rotated back to its solved mask.
+
+export const PIPES_GRID = 6
+export const PIPES_LEVEL_COUNT = 100
+
+export const TOP = 1
+export const RIGHT = 2
+export const BOTTOM = 4
+export const LEFT = 8
+
+export function rotateCW(mask: number, times = 1): number {
+  let m = mask
+  for (let i = 0; i < times; i++) m = ((m << 1) | (m >> 3)) & 0xf
+  return m
+}
+
+function mulberry32(seed: number): () => number {
+  let s = seed | 0
+  return () => {
+    s = (s + 0x6d2b79f5) | 0
+    let t = Math.imul(s ^ (s >>> 15), 1 | s)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+function generateSolved(
+  rows: number,
+  cols: number,
+  sr: number,
+  sc: number,
+  rng: () => number
+): number[][] {
+  const grid: number[][] = Array.from({ length: rows }, () =>
+    Array<number>(cols).fill(0)
+  )
+  const visited = new Set<string>()
+
+  function dfs(r: number, c: number): void {
+    visited.add(`${r},${c}`)
+    const dirs = [
+      { dr: -1, dc: 0, from: TOP, to: BOTTOM },
+      { dr: 0, dc: 1, from: RIGHT, to: LEFT },
+      { dr: 1, dc: 0, from: BOTTOM, to: TOP },
+      { dr: 0, dc: -1, from: LEFT, to: RIGHT },
+    ].sort(() => rng() - 0.5)
+
+    for (const { dr, dc, from, to } of dirs) {
+      const nr = r + dr
+      const nc = c + dc
+      if (
+        nr >= 0 &&
+        nr < rows &&
+        nc >= 0 &&
+        nc < cols &&
+        !visited.has(`${nr},${nc}`)
+      ) {
+        grid[r]![c]! |= from
+        grid[nr]![nc]! |= to
+        dfs(nr, nc)
+      }
+    }
+  }
+
+  dfs(sr, sc)
+  return grid
+}
+
+export interface PipesPuzzle {
+  level: number
+  size: number
+  source: [number, number]
+  solved: number[][]
+  scrambled: number[][]
+}
+
+export function getPuzzle(level: number): PipesPuzzle {
+  const clamped = Math.max(1, Math.min(PIPES_LEVEL_COUNT, level | 0))
+  // seed 0 produces a known-degenerate DFS path on some implementations; shift
+  // so level=1 lands on seed=1.
+  const rng = mulberry32(clamped)
+  const center = Math.floor(PIPES_GRID / 2)
+  const source: [number, number] = [center, center]
+  const solved = generateSolved(PIPES_GRID, PIPES_GRID, center, center, rng)
+  const scrambled = solved.map((row) =>
+    row.map((mask) => (mask ? rotateCW(mask, Math.floor(rng() * 4)) : 0))
+  )
+  return { level: clamped, size: PIPES_GRID, source, solved, scrambled }
+}
+
+export function getConnected(
+  masks: number[][],
+  source: [number, number],
+  rows: number,
+  cols: number
+): Set<string> {
+  const [sr, sc] = source
+  const visited = new Set<string>([`${sr},${sc}`])
+  const q: [number, number][] = [[sr, sc]]
+
+  while (q.length) {
+    const [r, c] = q.shift()!
+    const m = masks[r]?.[c] ?? 0
+    const neighbors: [number, number, number, number][] = [
+      [-1, 0, TOP, BOTTOM],
+      [0, 1, RIGHT, LEFT],
+      [1, 0, BOTTOM, TOP],
+      [0, -1, LEFT, RIGHT],
+    ]
+    for (const [dr, dc, cm, nm] of neighbors) {
+      const nr = r + dr
+      const nc = c + dc
+      if (
+        nr >= 0 &&
+        nr < rows &&
+        nc >= 0 &&
+        nc < cols &&
+        m & cm &&
+        (masks[nr]?.[nc] ?? 0) & nm
+      ) {
+        const key = `${nr},${nc}`
+        if (!visited.has(key)) {
+          visited.add(key)
+          q.push([nr, nc])
+        }
+      }
+    }
+  }
+  return visited
+}
+
+export function getEndpoints(
+  solved: number[][],
+  source: [number, number]
+): [number, number][] {
+  const eps: [number, number][] = []
+  solved.forEach((row, r) =>
+    row.forEach((mask, c) => {
+      if (r === source[0] && c === source[1]) return
+      const count = [TOP, RIGHT, BOTTOM, LEFT].filter((b) => mask & b).length
+      if (count === 1) eps.push([r, c])
+    })
+  )
+  return eps
+}


### PR DESCRIPTION
Closes #134

## Queens — tri-state cells
`placement` is now `(0 | 1 | 2)[][]` instead of `boolean[][]`. Clicking a cell cycles `empty → ✕ mark → ♛ → empty`. The ✕ is a "this is NOT a queen" hint to help with elimination — it never counts as a queen, so violations and the win condition only look at value === 2.

Changes:
- `checkAdjacent` / `computeViolations` / `isComplete` all gate on `isQueen(p, r, c)` (cell === 2)
- `aria-label` reports which of the three states a cell is in
- Idle screen explains the tap pattern: `1 下標 ✕／2 下放 ♛／3 下清空`

## Pipes — 100 fixed levels via seeded PRNG
The old code regenerated a random spanning tree every game, so two runs of the same "puzzle" were never the same and some trees were ugly enough to look unsolvable. Extracted the generator into `lib/games/pipes-puzzle.ts` and plugged in a `mulberry32` PRNG seeded by the level number — `level=1` always returns the same 6×6, `level=2` always returns a different but stable 6×6, and so on up to `PIPES_LEVEL_COUNT = 100`.

Offline verification on all 100 seeds:
- every cell sits in the spanning tree (no \`mask=0\` islands)
- endpoint count 2–7 (avg 4.4)
- every puzzle is provably solvable: every cell's scrambled mask is just a rotation of its solved mask

The component now exposes prev/next level buttons (\`←\` / \`→\` + \`{level} / 100\`). Source stays in the centre; the scrambled state is committed once at start, so rotating one pipe never re-randomises the rest of the board.

## Test plan
- [x] \`bun run typecheck\` (portal) — green
- [x] \`bun run build\` (portal) — green
- [x] All 100 seeds verified offline (endpoint range / no islands)
- [ ] Manual: open Queens, tap a cell three times, verify cycle \`empty → ✕ → ♛ → empty\`
- [ ] Manual: confirm a ✕ on its own (no ♛ in same row/col/region) shows no red ring
- [ ] Manual: open Pipes, walk through levels 1–5 with the arrow buttons, confirm each level deterministically loads the same board on reload