### PR TITLE
fix(games): pipes — don't scramble the source cell

### DIFF
--- a/apps/portal/lib/games/pipes-puzzle.ts
+++ b/apps/portal/lib/games/pipes-puzzle.ts
@@ -87,8 +87,14 @@ export function getPuzzle(level: number): PipesPuzzle {
   const center = Math.floor(PIPES_GRID / 2)
   const source: [number, number] = [center, center]
   const solved = generateSolved(PIPES_GRID, PIPES_GRID, center, center, rng)
-  const scrambled = solved.map((row) =>
-    row.map((mask) => (mask ? rotateCW(mask, Math.floor(rng() * 4)) : 0))
+  // The source cell is rendered with a disabled button (the player can't
+  // rotate it), so its scrambled mask MUST match the solved orientation —
+  // otherwise the puzzle is unsolvable.
+  const scrambled = solved.map((row, r) =>
+    row.map((mask, c) => {
+      if (r === source[0] && c === source[1]) return mask
+      return mask ? rotateCW(mask, Math.floor(rng() * 4)) : 0
+    })
   )
   return { level: clamped, size: PIPES_GRID, source, solved, scrambled }
 }


### PR DESCRIPTION
Closes #138

## What broke
\`getPuzzle\` randomised every non-zero cell when producing the scrambled grid — including the source. The UI then renders the source button with \`disabled\`, so the player can't rotate it. About 75% of levels (the random rotation ≠ 0) start with the source pointing the wrong direction and are literally unsolvable.

Level 1 hit this: \`solved[3][3] = 0b0001\` (TOP), \`scrambled[3][3] = 0b0010\` (RIGHT).

## Fix
Skip the source cell when scrambling so its mask matches the solved orientation.

\`\`\`ts
const scrambled = solved.map((row, r) =>
  row.map((mask, c) => {
    if (r === source[0] && c === source[1]) return mask
    return mask ? rotateCW(mask, Math.floor(rng() * 4)) : 0
  })
)
\`\`\`

## Why the earlier proof missed it
The earlier verifier checked \`scrambled[r][c] === rotateCW(solved[r][c], k)\` for some k. Mathematically every cell is a rotation of solved — but for the source cell the only valid k under the UI's disabled button is k=0. The solver didn't model the UI constraint, so the "100/100 solvable" proof was technically true but operationally meaningless.

Re-verified all 100 levels with that constraint included — 0 failures.

## Test plan
- [x] \`bun run typecheck\` + \`bun run build\` (portal) — green
- [x] All 100 levels pass the strengthened verifier (source-unchanged + every cell is a rotation + solved-state connects all endpoints)
- [ ] Manual: open /games/pipes level 1, confirm the source mask renders the same orientation before and after pressing start, and that rotating the surrounding pipes can connect every endpoint