### PR TITLE
feat(games): per-level leaderboards for pipes / queens

### DIFF
--- a/apps/portal/app/games/_components/game-page.tsx
+++ b/apps/portal/app/games/_components/game-page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, type ReactNode } from "react"
+import { useCallback, useState, type ReactNode } from "react"
 import Link from "next/link"
 import { toast } from "sonner"
 
@@ -11,12 +11,16 @@ import { Scoreboard } from "./scoreboard"
 
 interface GamePageProps {
   gameType: GameType
-  game: (onComplete: (result: GameResult) => void) => ReactNode
+  game: (
+    onComplete: (result: GameResult) => void,
+    onLevelChange: (level: number | null) => void
+  ) => ReactNode
 }
 
 export function GamePage({ gameType, game }: GamePageProps) {
   const meta = GAME_META[gameType]
-  const { mutate: submit } = useSubmitScore(gameType)
+  const [level, setLevel] = useState<number | null>(null)
+  const { mutate: submit } = useSubmitScore(gameType, level)
 
   const handleComplete = useCallback(
     (result: GameResult) => {
@@ -37,6 +41,10 @@ export function GamePage({ gameType, game }: GamePageProps) {
     [submit, meta]
   )
 
+  const handleLevelChange = useCallback((next: number | null) => {
+    setLevel(next)
+  }, [])
+
   return (
     <div className="space-y-10">
       <div className="flex items-center gap-3">
@@ -56,14 +64,14 @@ export function GamePage({ gameType, game }: GamePageProps) {
         <div className="flex flex-col gap-4">
           <h1 className="text-xl font-bold">{meta.title}</h1>
           <p className="text-sm text-muted-foreground">{meta.description}</p>
-          {game(handleComplete)}
+          {game(handleComplete, handleLevelChange)}
         </div>
 
         <div className="space-y-3">
           <h2 className="text-sm font-semibold tracking-wider text-muted-foreground uppercase">
-            排行榜
+            {level !== null ? `排行榜 · 關卡 ${level}` : "排行榜"}
           </h2>
-          <Scoreboard gameType={gameType} />
+          <Scoreboard gameType={gameType} level={level} />
         </div>
       </div>
     </div>

--- a/apps/portal/app/games/_components/game-pipes.tsx
+++ b/apps/portal/app/games/_components/game-pipes.tsx
@@ -111,9 +111,10 @@ function PipeSVG({
 
 interface GamePipesProps {
   onComplete: (result: GameResult) => void
+  onLevelChange?: (level: number | null) => void
 }
 
-export function GamePipes({ onComplete }: GamePipesProps) {
+export function GamePipes({ onComplete, onLevelChange }: GamePipesProps) {
   const [level, setLevel] = useState(1)
   const [current, setCurrent] = useState<number[][]>([])
   const [gameState, setGameState] = useState<"idle" | "playing" | "won">("idle")
@@ -123,14 +124,18 @@ export function GamePipes({ onComplete }: GamePipesProps) {
   // Solved/source/scrambled all come from the deterministic level number.
   const puzzle = useMemo(() => getPuzzle(level), [level])
 
-  const start = useCallback((lvl: number) => {
-    const p = getPuzzle(lvl)
-    completedRef.current = false
-    setLevel(p.level)
-    setCurrent(p.scrambled.map((row) => [...row]))
-    setGameState("playing")
-    startRef.current = Date.now()
-  }, [])
+  const start = useCallback(
+    (lvl: number) => {
+      const p = getPuzzle(lvl)
+      completedRef.current = false
+      setLevel(p.level)
+      onLevelChange?.(p.level)
+      setCurrent(p.scrambled.map((row) => [...row]))
+      setGameState("playing")
+      startRef.current = Date.now()
+    },
+    [onLevelChange]
+  )
 
   const connected = useMemo(() => {
     if (!current.length) return new Set<string>()

--- a/apps/portal/app/games/_components/game-queens.tsx
+++ b/apps/portal/app/games/_components/game-queens.tsx
@@ -102,9 +102,10 @@ function isComplete(
 
 interface GameQueensProps {
   onComplete: (result: GameResult) => void
+  onLevelChange?: (level: number | null) => void
 }
 
-export function GameQueens({ onComplete }: GameQueensProps) {
+export function GameQueens({ onComplete, onLevelChange }: GameQueensProps) {
   const [level, setLevel] = useState(1)
   const [placement, setPlacement] = useState<Placement>([])
   const [gameState, setGameState] = useState<"idle" | "playing" | "won">("idle")
@@ -113,19 +114,23 @@ export function GameQueens({ onComplete }: GameQueensProps) {
 
   const puzzle = useMemo(() => getQueensPuzzle(level), [level])
 
-  const start = useCallback((lvl: number) => {
-    const p = getQueensPuzzle(lvl)
-    completedRef.current = false
-    setLevel(p.level)
-    setPlacement(
-      Array.from(
-        { length: p.size },
-        () => Array<CellState>(p.size).fill(0) as CellState[]
+  const start = useCallback(
+    (lvl: number) => {
+      const p = getQueensPuzzle(lvl)
+      completedRef.current = false
+      setLevel(p.level)
+      onLevelChange?.(p.level)
+      setPlacement(
+        Array.from(
+          { length: p.size },
+          () => Array<CellState>(p.size).fill(0) as CellState[]
+        )
       )
-    )
-    setGameState("playing")
-    startRef.current = Date.now()
-  }, [])
+      setGameState("playing")
+      startRef.current = Date.now()
+    },
+    [onLevelChange]
+  )
 
   const handleCellClick = useCallback(
     (r: number, c: number) => {

--- a/apps/portal/app/games/_components/scoreboard.tsx
+++ b/apps/portal/app/games/_components/scoreboard.tsx
@@ -6,10 +6,11 @@ import type { GameType } from "@/lib/games/types"
 
 interface ScoreboardProps {
   gameType: GameType
+  level?: number | null
 }
 
-export function Scoreboard({ gameType }: ScoreboardProps) {
-  const { data: scores, isLoading } = useLeaderboard(gameType)
+export function Scoreboard({ gameType, level = null }: ScoreboardProps) {
+  const { data: scores, isLoading } = useLeaderboard(gameType, level)
   const meta = GAME_META[gameType]
 
   if (isLoading) {

--- a/apps/portal/app/games/pipes/page.tsx
+++ b/apps/portal/app/games/pipes/page.tsx
@@ -7,7 +7,9 @@ export default function PagePipes() {
   return (
     <GamePage
       gameType="pipes"
-      game={(onComplete) => <GamePipes onComplete={onComplete} />}
+      game={(onComplete, onLevelChange) => (
+        <GamePipes onComplete={onComplete} onLevelChange={onLevelChange} />
+      )}
     />
   )
 }

--- a/apps/portal/app/games/queens/page.tsx
+++ b/apps/portal/app/games/queens/page.tsx
@@ -7,7 +7,9 @@ export default function PageQueens() {
   return (
     <GamePage
       gameType="queens"
-      game={(onComplete) => <GameQueens onComplete={onComplete} />}
+      game={(onComplete, onLevelChange) => (
+        <GameQueens onComplete={onComplete} onLevelChange={onLevelChange} />
+      )}
     />
   )
 }

--- a/apps/portal/hooks/games/query-keys.ts
+++ b/apps/portal/hooks/games/query-keys.ts
@@ -3,6 +3,7 @@ import type { GameType } from "@/lib/games/types"
 export const queryKeys = {
   leaderboard: {
     all: ["games", "leaderboard"] as const,
-    byGame: (game: GameType) => ["games", "leaderboard", game] as const,
+    byGame: (game: GameType, level: number | null = null) =>
+      ["games", "leaderboard", game, level ?? "all"] as const,
   },
 }

--- a/apps/portal/hooks/games/use-scores.ts
+++ b/apps/portal/hooks/games/use-scores.ts
@@ -7,14 +7,18 @@ import { createClient } from "@/lib/supabase/client"
 import type { GameScore, GameType } from "@/lib/games/types"
 import { queryKeys } from "./query-keys"
 
-export function useLeaderboard(gameType: GameType) {
+export function useLeaderboard(
+  gameType: GameType,
+  level: number | null = null
+) {
   const supabase = useMemo(() => createClient(), [])
 
   return useQuery({
-    queryKey: queryKeys.leaderboard.byGame(gameType),
+    queryKey: queryKeys.leaderboard.byGame(gameType, level),
     queryFn: async (): Promise<GameScore[]> => {
       const { data, error } = await supabase.rpc("get_game_leaderboard", {
         p_game_type: gameType,
+        p_level: level,
       })
       if (error) throw error
       return (data ?? []) as GameScore[]
@@ -22,7 +26,10 @@ export function useLeaderboard(gameType: GameType) {
   })
 }
 
-export function useSubmitScore(gameType: GameType) {
+export function useSubmitScore(
+  gameType: GameType,
+  level: number | null = null
+) {
   const supabase = useMemo(() => createClient(), [])
   const queryClient = useQueryClient()
 
@@ -55,12 +62,13 @@ export function useSubmitScore(gameType: GameType) {
         game_type: gameType,
         score: Math.floor(score),
         finish_time_ms: Math.floor(finishTimeMs),
+        level: level,
       })
       if (error) throw error
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: queryKeys.leaderboard.byGame(gameType),
+        queryKey: queryKeys.leaderboard.byGame(gameType, level),
       })
     },
   })

--- a/apps/portal/lib/games/types.ts
+++ b/apps/portal/lib/games/types.ts
@@ -12,6 +12,7 @@ export interface GameScore {
   score: number
   finish_time_ms: number
   achieved_at: string
+  level?: number | null
 }
 
 export interface GameResult {

--- a/supabase/migrations/2026-05-18-game-scores-per-level.sql
+++ b/supabase/migrations/2026-05-18-game-scores-per-level.sql
@@ -1,0 +1,46 @@
+-- Per-level leaderboards for games that ship multiple stages (pipes, queens).
+-- Adds an optional `level` column to game_scores and reworks the leaderboard
+-- RPC so it can filter by level. Games without stages (2048/memory/typing/
+-- snake) write NULL into `level` and pass NULL when reading, getting the
+-- unchanged "overall leaderboard" behaviour.
+
+alter table public.game_scores
+  add column if not exists level smallint;
+
+create index if not exists game_scores_game_level_score_idx
+  on public.game_scores (game_type, level, score desc, finish_time_ms asc);
+
+drop function if exists public.get_game_leaderboard(public.game_type);
+
+create or replace function public.get_game_leaderboard(
+  p_game_type public.game_type,
+  p_level smallint default null
+)
+returns table (
+  user_id uuid,
+  user_name text,
+  score integer,
+  finish_time_ms integer,
+  achieved_at timestamptz
+)
+language sql
+security definer
+set search_path to 'public'
+as $$
+  select user_id, user_name, score, finish_time_ms, achieved_at
+  from (
+    select distinct on (gs.user_id)
+      gs.user_id,
+      coalesce(up.name, 'Anonymous')::text as user_name,
+      gs.score,
+      gs.finish_time_ms,
+      gs.created_at as achieved_at
+    from public.game_scores gs
+    left join public.user_profiles up on gs.user_id = up.id
+    where gs.game_type = p_game_type
+      and (p_level is null or gs.level = p_level)
+    order by gs.user_id, gs.score desc, gs.finish_time_ms asc
+  ) best
+  order by score desc, finish_time_ms asc
+  limit 20;
+$$;


### PR DESCRIPTION
Closes #140

## What
Pipes and queens each ship 100 levels but used to share a single leaderboard, so a 5-second solve on level 1 outranked a 60-second solve on level 100. Now each level has its own leaderboard.

## Schema
- \`game_scores\` gains a nullable \`level smallint\` column
- index \`(game_type, level, score desc, finish_time_ms asc)\` for the typical per-level read
- \`get_game_leaderboard\` takes an optional \`p_level\` (default \`null\`) — null preserves the original "best across all rows" behaviour for the games without stages (2048 / memory / typing / snake)

Migration already applied to project \`yissfqcdmzsxwfnzrflz\`.

## Frontend
- \`useLeaderboard\` / \`useSubmitScore\` both accept an optional \`level\` and thread it through the RPC call and the INSERT
- \`queryKeys.leaderboard.byGame\` keys by level so switching levels invalidates / refetches cleanly
- \`GamePage\` owns the level state; the \`game\` render prop now receives an \`onLevelChange\` callback that pipes / queens fire when they start a new level
- Scoreboard header reads \`排行榜 · 關卡 N\` when a level is set; falls back to \`排行榜\` for the stage-less games

## Test plan
- [x] \`bun run typecheck\` + \`bun run build\` — green
- [x] Migration applied
- [ ] Manual: pipes — finish level 1, watch \`排行榜 · 關卡 1\` populate; switch to level 2, see a different (or empty) leaderboard
- [ ] Manual: queens — same flow
- [ ] Manual: 2048 / snake — leaderboard still shows the overall list (no level filter)

## Follow-up
- typing → 5 language variants (中德法義西 + en) reusing this exact mechanism (language = typing's "level")