### PR TITLE
fix(games): snake self-collision tail + 180° reversal via fast keys

### DIFF
--- a/apps/portal/app/games/_components/game-snake.tsx
+++ b/apps/portal/app/games/_components/game-snake.tsx
@@ -43,6 +43,10 @@ export function GameSnake({ onComplete }: GameSnakeProps) {
   const [score, setScore] = useState(0)
 
   const dirRef = useRef<Dir>("right")
+  // Direction the snake actually moved on the last tick. Guards against
+  // queuing two keystrokes inside one tick window (e.g. right → down → left)
+  // which would otherwise let the snake U-turn 180° and crash into itself.
+  const movedDirRef = useRef<Dir>("right")
   const snakeRef = useRef<Pos[]>([])
   const foodRef = useRef<Pos>({ r: 5, c: 15 })
   const startRef = useRef<number | null>(null)
@@ -60,6 +64,7 @@ export function GameSnake({ onComplete }: GameSnakeProps) {
     snakeRef.current = initSnake
     foodRef.current = initFood
     dirRef.current = "right"
+    movedDirRef.current = "right"
     setSnake(initSnake)
     setFood(initFood)
     setDir("right")
@@ -73,17 +78,25 @@ export function GameSnake({ onComplete }: GameSnakeProps) {
 
     const interval = setInterval(() => {
       const d = dirRef.current
+      movedDirRef.current = d
       const delta = DIR_DELTA[d]
       const head = snakeRef.current[0]
       if (!head) return
       const next = { r: head.r + delta.r, c: head.c + delta.c }
+
+      // When the snake doesn't eat this tick, the tail vacates its cell on the
+      // same tick the head moves in. Self-collision must check against the
+      // body *after* removing the tail, otherwise a tight U-turn into the
+      // tail's old cell is wrongly counted as a crash.
+      const ate = next.r === foodRef.current.r && next.c === foodRef.current.c
+      const body = ate ? snakeRef.current : snakeRef.current.slice(0, -1)
 
       if (
         next.r < 0 ||
         next.r >= ROWS ||
         next.c < 0 ||
         next.c >= COLS ||
-        snakeRef.current.some((p) => p.r === next.r && p.c === next.c)
+        body.some((p) => p.r === next.r && p.c === next.c)
       ) {
         if (!completedRef.current) {
           completedRef.current = true
@@ -98,7 +111,6 @@ export function GameSnake({ onComplete }: GameSnakeProps) {
         return
       }
 
-      const ate = next.r === foodRef.current.r && next.c === foodRef.current.c
       const newSnake = ate
         ? [next, ...snakeRef.current]
         : [next, ...snakeRef.current.slice(0, -1)]
@@ -123,7 +135,9 @@ export function GameSnake({ onComplete }: GameSnakeProps) {
       left: "right",
       right: "left",
     }
-    if (next !== opposite[dirRef.current]) {
+    // Guard against the last committed direction, not the last queued one —
+    // otherwise two fast keypresses can chain a 180° reversal inside one tick.
+    if (next !== opposite[movedDirRef.current]) {
       dirRef.current = next
       setDir(next)
     }


### PR DESCRIPTION
Closes #142

Two related snake bugs, same file.

## (1) Tail false-positive on tight U-turn
The tail vacates its cell the same tick the head moves, so a U-turn into the tail's old cell is a valid move. The collision check ran against \`snakeRef.current\` (pre-move, tail still there) and called it a crash.

Fix: compute \`ate\` first, then collision-check against \`ate ? snake : snake.slice(0, -1)\`. Eating keeps the tail so the original behaviour stands when the head lands on food.

## (2) 180° reversal by chaining two keys in one tick
Snake heading right, player taps **down** then **left** before the next tick. Both presses pass the opposite-direction guard because the guard compares to the most recent *queued* direction, not the last *committed* one:
- \`applyDir(down)\`: opposite(right) = left, down ≠ left ✓ → dirRef = down
- \`applyDir(left)\`: opposite(**down**) = up, left ≠ up ✓ → dirRef = left
- Next tick: snake moves left while still positioned as if it had been going right → head walks into the body.

Fix: add \`movedDirRef\`, committed at the start of every tick. \`applyDir\` compares against that, not against the queued direction.

## Test plan
- [x] \`bun run typecheck\` + \`bun run build\` — green
- [ ] Manual: drive the snake into a U-turn and verify it survives
- [ ] Manual: spam ↓ → ← while heading right and verify it just turns down (← is dropped)