### PR TITLE
feat(games): typing — 6 languages with per-language leaderboards

### DIFF
--- a/apps/portal/app/games/_components/game-page.tsx
+++ b/apps/portal/app/games/_components/game-page.tsx
@@ -13,13 +13,14 @@ interface GamePageProps {
   gameType: GameType
   game: (
     onComplete: (result: GameResult) => void,
-    onLevelChange: (level: number | null) => void
+    onLevelChange: (level: number | null, displayLabel?: string | null) => void
   ) => ReactNode
 }
 
 export function GamePage({ gameType, game }: GamePageProps) {
   const meta = GAME_META[gameType]
   const [level, setLevel] = useState<number | null>(null)
+  const [levelLabel, setLevelLabel] = useState<string | null>(null)
   const { mutate: submit } = useSubmitScore(gameType, level)
 
   const handleComplete = useCallback(
@@ -41,9 +42,16 @@ export function GamePage({ gameType, game }: GamePageProps) {
     [submit, meta]
   )
 
-  const handleLevelChange = useCallback((next: number | null) => {
-    setLevel(next)
-  }, [])
+  const handleLevelChange = useCallback(
+    (next: number | null, label?: string | null) => {
+      setLevel(next)
+      setLevelLabel(label ?? null)
+    },
+    []
+  )
+
+  const scoreboardTitle =
+    level === null ? "排行榜" : `排行榜 · ${levelLabel ?? `關卡 ${level}`}`
 
   return (
     <div className="space-y-10">
@@ -69,7 +77,7 @@ export function GamePage({ gameType, game }: GamePageProps) {
 
         <div className="space-y-3">
           <h2 className="text-sm font-semibold tracking-wider text-muted-foreground uppercase">
-            {level !== null ? `排行榜 · 關卡 ${level}` : "排行榜"}
+            {scoreboardTitle}
           </h2>
           <Scoreboard gameType={gameType} level={level} />
         </div>

--- a/apps/portal/app/games/_components/game-typing.tsx
+++ b/apps/portal/app/games/_components/game-typing.tsx
@@ -1,26 +1,23 @@
 "use client"
 
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useRef, useState } from "react"
 import { Button } from "@workspace/ui/components/button"
 import type { GameResult } from "@/lib/games/types"
-
-const PASSAGES = [
-  "The quick brown fox jumps over the lazy dog. Pack my box with five dozen liquor jugs. How vexingly quick daft zebras jump.",
-  "Programming is the art of telling another human what one wants the computer to do. Clean code always looks like it was written by someone who cares.",
-  "Science is not only a disciple of reason but also one of romance and passion. The universe is under no obligation to make sense to you.",
-]
-
-function pickPassage(): string {
-  return PASSAGES[Math.floor(Math.random() * PASSAGES.length)] ?? PASSAGES[0]!
-}
+import {
+  TYPING_LANGUAGES,
+  countUnits,
+  getTypingLanguage,
+} from "@/lib/games/typing-passages"
 
 type State = "idle" | "playing" | "done"
 
 interface GameTypingProps {
   onComplete: (result: GameResult) => void
+  onLevelChange?: (level: number | null, displayLabel?: string | null) => void
 }
 
-export function GameTyping({ onComplete }: GameTypingProps) {
+export function GameTyping({ onComplete, onLevelChange }: GameTypingProps) {
+  const [languageId, setLanguageId] = useState(0)
   const [target, setTarget] = useState("")
   const [input, setInput] = useState("")
   const [state, setState] = useState<State>("idle")
@@ -28,14 +25,42 @@ export function GameTyping({ onComplete }: GameTypingProps) {
   const completedRef = useRef(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  const start = useCallback(() => {
-    completedRef.current = false
-    setTarget(pickPassage())
-    setInput("")
-    setState("playing")
-    startRef.current = null
-    setTimeout(() => inputRef.current?.focus(), 50)
+  const language = getTypingLanguage(languageId)
+
+  const pickPassage = useCallback((langId: number): string => {
+    const lang = getTypingLanguage(langId)
+    const pool = lang.passages
+    return pool[Math.floor(Math.random() * pool.length)] ?? pool[0]!
   }, [])
+
+  const start = useCallback(
+    (langId: number = languageId) => {
+      const lang = getTypingLanguage(langId)
+      completedRef.current = false
+      setLanguageId(langId)
+      onLevelChange?.(langId, lang.label)
+      setTarget(pickPassage(langId))
+      setInput("")
+      setState("playing")
+      startRef.current = null
+      setTimeout(() => inputRef.current?.focus(), 50)
+    },
+    [languageId, onLevelChange, pickPassage]
+  )
+
+  const selectLanguage = useCallback(
+    (langId: number) => {
+      // Switching language from idle just updates the preview; from playing
+      // restarts cleanly into the new language.
+      if (state === "idle") {
+        setLanguageId(langId)
+        onLevelChange?.(langId, getTypingLanguage(langId).label)
+      } else {
+        start(langId)
+      }
+    },
+    [state, onLevelChange, start]
+  )
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -52,10 +77,9 @@ export function GameTyping({ onComplete }: GameTypingProps) {
       if (val === target && !completedRef.current) {
         completedRef.current = true
         const ms = Math.max(Date.now() - startRef.current, 1)
-        const words = target.trim().split(/\s+/).length
-        const wpm = Math.round((words / ms) * 60000)
+        const units = countUnits(target, language.code)
+        const wpm = Math.round((units / ms) * 60000)
         setState("done")
-        // Floor at 1s to defeat instant-fill exploits; cap WPM at 300 sanity check
         if (ms >= 1000 && wpm <= 300) {
           setTimeout(
             () => onComplete({ score: wpm * 10, finishTimeMs: ms }),
@@ -64,7 +88,7 @@ export function GameTyping({ onComplete }: GameTypingProps) {
         }
       }
     },
-    [state, target, input, onComplete]
+    [state, target, input, language.code, onComplete]
   )
 
   const correctCount = input
@@ -75,27 +99,49 @@ export function GameTyping({ onComplete }: GameTypingProps) {
 
   return (
     <div className="flex w-full flex-col gap-4">
+      <div className="flex flex-wrap justify-center gap-2">
+        {TYPING_LANGUAGES.map((lang) => (
+          <button
+            key={lang.id}
+            type="button"
+            onClick={() => selectLanguage(lang.id)}
+            disabled={state === "done"}
+            aria-pressed={languageId === lang.id}
+            className={`rounded-lg border px-3 py-1 text-xs font-medium transition-colors ${
+              languageId === lang.id
+                ? "border-foreground bg-foreground text-background"
+                : "border-muted hover:border-foreground"
+            } disabled:opacity-60`}
+          >
+            {lang.label}
+          </button>
+        ))}
+      </div>
+
       <div className="flex items-center justify-between">
         <div className="text-sm text-muted-foreground">
-          準確率{" "}
+          <span className="mr-3">{language.label}</span>準確率{" "}
           <span
             className={`font-bold ${accuracy < 80 ? "text-destructive" : "text-foreground"}`}
           >
             {accuracy}%
           </span>
         </div>
-        <Button size="sm" variant="outline" onClick={start}>
+        <Button size="sm" variant="outline" onClick={() => start(languageId)}>
           {state === "idle" ? "開始遊戲" : "重新開始"}
         </Button>
       </div>
 
       {state === "idle" ? (
         <p className="py-8 text-center text-sm text-muted-foreground">
-          點擊「開始遊戲」，盡快完整輸入以下段落
+          選擇語言後點擊「開始遊戲」，完整輸入下方段落
         </p>
       ) : (
         <>
-          <div className="rounded-xl border bg-muted/30 p-4 font-mono text-sm leading-relaxed select-none">
+          <div
+            lang={language.code}
+            className="rounded-xl border bg-muted/30 p-4 font-mono text-sm leading-relaxed select-none"
+          >
             {target.split("").map((ch, i) => {
               let cls = "text-muted-foreground"
               if (i < input.length) {
@@ -121,6 +167,7 @@ export function GameTyping({ onComplete }: GameTypingProps) {
             onPaste={(e) => e.preventDefault()}
             onDrop={(e) => e.preventDefault()}
             disabled={state === "done"}
+            lang={language.code}
             className="w-full rounded-lg border bg-background px-3 py-2 font-mono text-sm ring-1 ring-muted outline-none focus:ring-primary"
             placeholder="在此輸入..."
             autoComplete="off"

--- a/apps/portal/app/games/typing/page.tsx
+++ b/apps/portal/app/games/typing/page.tsx
@@ -7,7 +7,9 @@ export default function PageTyping() {
   return (
     <GamePage
       gameType="typing"
-      game={(onComplete) => <GameTyping onComplete={onComplete} />}
+      game={(onComplete, onLevelChange) => (
+        <GameTyping onComplete={onComplete} onLevelChange={onLevelChange} />
+      )}
     />
   )
 }

--- a/apps/portal/lib/games/typing-passages.ts
+++ b/apps/portal/lib/games/typing-passages.ts
@@ -1,0 +1,86 @@
+// Typing passages, grouped by language. Each language is a "level" in
+// game_scores so each one keeps its own leaderboard (English vs 繁中 vs … are
+// not directly comparable — different units, different keyboards).
+
+export interface TypingLanguage {
+  id: number
+  label: string
+  code: "en" | "zh-Hant" | "de" | "fr" | "it" | "es"
+  passages: string[]
+}
+
+export const TYPING_LANGUAGES: TypingLanguage[] = [
+  {
+    id: 0,
+    label: "English",
+    code: "en",
+    passages: [
+      "The quick brown fox jumps over the lazy dog. Pack my box with five dozen liquor jugs. How vexingly quick daft zebras jump.",
+      "Programming is the art of telling another human what one wants the computer to do. Clean code always looks like it was written by someone who cares.",
+      "Science is not only a disciple of reason but also one of romance and passion. The universe is under no obligation to make sense to you.",
+    ],
+  },
+  {
+    id: 1,
+    label: "繁體中文",
+    code: "zh-Hant",
+    passages: [
+      "千里之行，始於足下。九層之台，起於累土。天行健，君子以自強不息。",
+      "學而時習之，不亦說乎。有朋自遠方來，不亦樂乎。人不知而不慍，不亦君子乎。",
+      "海內存知己，天涯若比鄰。無為在歧路，兒女共沾巾。莫愁前路無知己，天下誰人不識君。",
+    ],
+  },
+  {
+    id: 2,
+    label: "Deutsch",
+    code: "de",
+    passages: [
+      "Der frühe Vogel fängt den Wurm, doch der zweite bekommt den Käse. Wer rastet, der rostet.",
+      "Wer den Pfennig nicht ehrt, ist des Talers nicht wert. Übung macht den Meister, sagt das Sprichwort.",
+      "Geteiltes Leid ist halbes Leid, geteilte Freude ist doppelte Freude. Was Hänschen nicht lernt, lernt Hans nimmermehr.",
+    ],
+  },
+  {
+    id: 3,
+    label: "Français",
+    code: "fr",
+    passages: [
+      "Un voyage de mille lieues commence toujours par un premier pas, dit le proverbe le plus connu.",
+      "Tous pour un, un pour tous, voilà notre devise. L'union fait la force, telle est notre conviction.",
+      "Bien faire et laisser dire, voilà la sagesse la plus simple du monde. À cœur vaillant rien d'impossible.",
+    ],
+  },
+  {
+    id: 4,
+    label: "Italiano",
+    code: "it",
+    passages: [
+      "Chi va piano va sano e va lontano, dice un antico proverbio italiano molto saggio.",
+      "Ogni medaglia ha il suo rovescio, e ogni successo nasconde una caduta. La fortuna aiuta gli audaci.",
+      "Tra il dire e il fare c'è di mezzo il mare, ricordatelo sempre. Chi cerca trova, chi domanda intende.",
+    ],
+  },
+  {
+    id: 5,
+    label: "Español",
+    code: "es",
+    passages: [
+      "El que persevera alcanza, y quien madruga encuentra el camino abierto al éxito.",
+      "Más vale tarde que nunca, pero también vale más nunca tarde, dice el refrán antiguo.",
+      "Camarón que se duerme se lo lleva la corriente. No por mucho madrugar amanece más temprano.",
+    ],
+  },
+]
+
+export function getTypingLanguage(id: number): TypingLanguage {
+  return TYPING_LANGUAGES[id] ?? TYPING_LANGUAGES[0]!
+}
+
+// Used to compute WPM. English/European languages use whitespace-separated
+// words; Chinese counts CJK characters since it has no word boundaries.
+export function countUnits(text: string, code: TypingLanguage["code"]): number {
+  if (code === "zh-Hant") {
+    return [...text].filter((ch) => /[一-鿿]/.test(ch)).length
+  }
+  return text.trim().split(/\s+/).length
+}


### PR DESCRIPTION
Closes #144

## What
Adds 繁體中文 / Deutsch / Français / Italiano / Español alongside English. Each language has its own leaderboard via the `level` column added in #141 — language id 0–5 maps directly to \`game_scores.level\`, so the per-level infra carries through without schema changes.

## Implementation
- \`lib/games/typing-passages.ts\`: language table (label + BCP-47 code + 3 passages each) plus a \`countUnits(text, code)\` helper that uses whitespace-split word count for European languages and CJK character count for 繁體中文 (Chinese has no word boundaries, words/min is meaningless, chars/min is the right unit).
- \`GameTyping\` shows a horizontal language picker at the top. Selecting while idle just updates the preview; selecting while playing restarts cleanly into the new language.
- \`onLevelChange\` now takes an optional display label. Typing passes the language name (e.g. \`繁體中文\`) so the scoreboard reads \`排行榜 · 繁體中文\` instead of \`排行榜 · 關卡 1\`. Pipes / Queens don't pass a label and keep the \`關卡 N\` fallback.
- Score formula unchanged (\`wpm * 10\`); since each leaderboard is per-language, the cross-language unit difference is irrelevant.

## Test plan
- [x] \`bun run typecheck\` + \`bun run build\` — green
- [ ] Manual: switch through all 6 languages, start each, confirm the passage is in the right language and the scoreboard header switches with it
- [ ] Manual: finish a passage in two different languages, confirm each ends up on the right leaderboard
- [ ] Manual: 繁體中文 typing through IME — passes \`onPaste\` guard, completes when characters match