### PR TITLE
perf(games): faster typing completion + skip auth round-trip on score insert

### DIFF
--- a/apps/portal/app/games/_components/game-typing.tsx
+++ b/apps/portal/app/games/_components/game-typing.tsx
@@ -81,10 +81,7 @@ export function GameTyping({ onComplete, onLevelChange }: GameTypingProps) {
         const wpm = Math.round((units / ms) * 60000)
         setState("done")
         if (ms >= 1000 && wpm <= 300) {
-          setTimeout(
-            () => onComplete({ score: wpm * 10, finishTimeMs: ms }),
-            100
-          )
+          onComplete({ score: wpm * 10, finishTimeMs: ms })
         }
       }
     },

--- a/apps/portal/hooks/games/use-scores.ts
+++ b/apps/portal/hooks/games/use-scores.ts
@@ -52,13 +52,18 @@ export function useSubmitScore(
         throw new Error("Invalid score")
       }
 
+      // Use getSession() instead of getUser(): the former reads/verifies the
+      // JWT from localStorage (no network), the latter hits the auth server
+      // (~200-500ms). RLS still gates the insert via auth.uid() server-side,
+      // so token validity is enforced there.
       const {
-        data: { user },
-      } = await supabase.auth.getUser()
-      if (!user) throw new Error("Not authenticated")
+        data: { session },
+      } = await supabase.auth.getSession()
+      const userId = session?.user.id
+      if (!userId) throw new Error("Not authenticated")
 
       const { error } = await supabase.from("game_scores").insert({
-        user_id: user.id,
+        user_id: userId,
         game_type: gameType,
         score: Math.floor(score),
         finish_time_ms: Math.floor(finishTimeMs),


### PR DESCRIPTION
Closes #146

Two small wins on the \"finish a typing run → see leaderboard update\" path, expected total saving ~300-700ms per submission across all games.

## 1. Drop typing's \`setTimeout(100)\`
\`onComplete\` was being fired through \`setTimeout(..., 100)\`. The reason was to let the \`setState(\"done\")\` paint first, but \`onComplete\` only dispatches a tanstack-query mutation — it doesn't block the paint. Calling it synchronously saves 100ms with no visual regression.

## 2. \`getUser()\` → \`getSession()\` in \`useSubmitScore\`
\`supabase.auth.getUser()\` posts to the auth endpoint to verify the JWT every time we insert (~200-500ms over the wire). \`getSession()\` reads the JWT from localStorage and validates the signature locally, no HTTP.

Safety: the insert is still gated server-side by the existing RLS \`with check (auth.uid() = user_id)\` policy, so a forged or expired token gets rejected at the database. We only swap **where** the user id comes from on the client.

## Test plan
- [x] \`bun run typecheck\` + \`bun run build\` — green
- [ ] Manual: finish a typing passage, time the gap between the final keystroke and the success toast — should feel ~half a second shorter
- [ ] Manual: snake / pipes / queens — also benefit from the auth round-trip removal