### PR TITLE
fix(games): gate game_scores writes behind validating RPC

### DIFF
--- a/apps/portal/hooks/games/use-scores.ts
+++ b/apps/portal/hooks/games/use-scores.ts
@@ -41,33 +41,18 @@ export function useSubmitScore(
       score: number
       finishTimeMs: number
     }) => {
-      if (
-        !Number.isFinite(score) ||
-        !Number.isFinite(finishTimeMs) ||
-        score < 0 ||
-        score > 1_000_000 ||
-        finishTimeMs < 1 ||
-        finishTimeMs > 24 * 60 * 60 * 1000
-      ) {
+      if (!Number.isFinite(score) || !Number.isFinite(finishTimeMs)) {
         throw new Error("Invalid score")
       }
 
-      // Use getSession() instead of getUser(): the former reads/verifies the
-      // JWT from localStorage (no network), the latter hits the auth server
-      // (~200-500ms). RLS still gates the insert via auth.uid() server-side,
-      // so token validity is enforced there.
-      const {
-        data: { session },
-      } = await supabase.auth.getSession()
-      const userId = session?.user.id
-      if (!userId) throw new Error("Not authenticated")
-
-      const { error } = await supabase.from("game_scores").insert({
-        user_id: userId,
-        game_type: gameType,
-        score: Math.floor(score),
-        finish_time_ms: Math.floor(finishTimeMs),
-        level: level,
+      // Direct INSERT into game_scores is gated by RLS now; the only write
+      // path is the submit_game_score RPC, which derives user_id from
+      // auth.uid() server-side and validates per-game-type score bounds.
+      const { error } = await supabase.rpc("submit_game_score", {
+        p_game_type: gameType,
+        p_score: Math.floor(score),
+        p_finish_ms: Math.floor(finishTimeMs),
+        p_level: level,
       })
       if (error) throw error
     },

--- a/supabase/migrations/2026-05-18-game-scores-rpc-gate.sql
+++ b/supabase/migrations/2026-05-18-game-scores-rpc-gate.sql
@@ -1,0 +1,125 @@
+-- Replace direct INSERT on game_scores with a SECURITY DEFINER RPC that
+-- validates per-game-type score bounds and enforces a per-user rate limit.
+--
+-- Why: the prior INSERT policy only checked auth.uid() = user_id, so any
+-- logged-in client could call .from('game_scores').insert({...}) with arbitrary
+-- score values (the client-side bounds in useSubmitScore are trivially
+-- bypassable from devtools). Existing leaderboard rows already contained
+-- impossible values (2048: 2_147_483_647, pipes: 99_999_999 / -99, memory: 10).
+--
+-- After this migration, the only path that can write to game_scores is
+-- public.submit_game_score(), which runs SECURITY DEFINER and validates
+-- against per-game-type rules.
+
+-- 1. Revoke direct INSERT.
+drop policy if exists "users can insert own game scores" on public.game_scores;
+
+-- 2. The single write path.
+create or replace function public.submit_game_score(
+  p_game_type public.game_type,
+  p_score     integer,
+  p_finish_ms integer,
+  p_level     smallint default null
+) returns void
+security definer
+set search_path = public
+language plpgsql as $$
+declare
+  v_uid uuid := auth.uid();
+begin
+  if v_uid is null then
+    raise exception 'not authenticated' using errcode = '28000';
+  end if;
+
+  if p_finish_ms < 1 or p_finish_ms > 30 * 60 * 1000 then
+    raise exception 'finish_time_ms out of range (1..1800000)';
+  end if;
+
+  case p_game_type
+    when '2048' then
+      -- Score = highest tile reached, always a power of two; 2^17 is already
+      -- well past any realistic play.
+      if p_score not in (
+        2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048,
+        4096, 8192, 16384, 32768, 65536, 131072
+      ) then
+        raise exception 'invalid 2048 score: %', p_score;
+      end if;
+      if p_level is not null then
+        raise exception '2048 does not use levels';
+      end if;
+
+    when 'memory' then
+      -- 8 pairs, always. finish_time_ms is the real differentiator.
+      if p_score <> 8 then
+        raise exception 'memory score must be 8';
+      end if;
+      if p_level is not null then
+        raise exception 'memory does not use levels';
+      end if;
+
+    when 'typing' then
+      -- WPM * 10. 300 WPM is already world-class.
+      if p_score < 0 or p_score > 3000 then
+        raise exception 'invalid typing score: %', p_score;
+      end if;
+      -- Language id 0..5 acts as the per-leaderboard level.
+      if p_level is null or p_level < 0 or p_level > 5 then
+        raise exception 'typing requires level 0..5';
+      end if;
+
+    when 'snake' then
+      -- 20x20 board minus initial snake length of 3.
+      if p_score < 0 or p_score > 397 then
+        raise exception 'invalid snake score: %', p_score;
+      end if;
+      if p_level is not null then
+        raise exception 'snake does not use levels';
+      end if;
+
+    when 'pipes' then
+      -- 6x6 grid; realistic endpoint count fits easily under 100.
+      if p_score < 0 or p_score > 100 then
+        raise exception 'invalid pipes score: %', p_score;
+      end if;
+      if p_level is null or p_level < 1 or p_level > 100 then
+        raise exception 'pipes requires level 1..100';
+      end if;
+
+    when 'queens' then
+      -- Score = board size, locked by level bucket.
+      if p_level is null or p_level < 1 or p_level > 100 then
+        raise exception 'queens requires level 1..100';
+      end if;
+      if p_level between 1 and 30 and p_score <> 5 then
+        raise exception 'queens level 1..30 score must be 5';
+      elsif p_level between 31 and 60 and p_score <> 6 then
+        raise exception 'queens level 31..60 score must be 6';
+      elsif p_level between 61 and 100 and p_score <> 7 then
+        raise exception 'queens level 61..100 score must be 7';
+      end if;
+
+    when 'kings' then
+      -- Deprecated; the kings enum value remains only because Postgres can't
+      -- drop enum values. New submissions are rejected.
+      raise exception 'kings game type is deprecated';
+  end case;
+
+  -- Naive rate limit: at most one submission per (user, game) every 2 seconds.
+  -- Cheap defence against scripted floods; legitimate plays take far longer.
+  if exists (
+    select 1 from game_scores
+    where user_id = v_uid
+      and game_type = p_game_type
+      and created_at > now() - interval '2 seconds'
+  ) then
+    raise exception 'rate limited';
+  end if;
+
+  insert into game_scores (user_id, game_type, score, finish_time_ms, level)
+  values (v_uid, p_game_type, p_score, p_finish_ms, p_level);
+end $$;
+
+-- 3. Lock execution to authenticated callers.
+revoke all on function public.submit_game_score(public.game_type, integer, integer, smallint) from public;
+grant execute on function public.submit_game_score(public.game_type, integer, integer, smallint) to authenticated;


### PR DESCRIPTION
Closes #150

## Summary

- Drop the permissive INSERT policy on `public.game_scores`.
- Add `public.submit_game_score(game_type, score, finish_time_ms, level)` — `SECURITY DEFINER`, derives `user_id` from `auth.uid()`, validates per-game-type score bounds, caps `finish_time_ms` at 30 min, rate-limits one row per `(user, game)` every 2 seconds.
- Update `useSubmitScore` to call the RPC instead of `.from('game_scores').insert(...)`.

## Why

The publishable key is in every browser bundle by design. The old RLS only checked `auth.uid() = user_id`, so any logged-in user could submit arbitrary scores for themselves from devtools — the client-side bounds in the hook are trivially stripped. The leaderboard already had 2048 scores of `2147483647`, pipes scores of `99999999` / `-99`, and negative `finish_time_ms` values down to `-2147483648`.

## Per-game validation (in the RPC)

| Game | Score bounds | Level |
| --- | --- | --- |
| 2048 | exact powers of two, ≤ 131072 | rejected |
| memory | exactly 8 | rejected |
| typing | 0..3000 (WPM × 10) | required, 0..5 (language id) |
| snake | 0..397 (20×20 − initial length 3) | rejected |
| pipes | 0..100 | required, 1..100 |
| queens | locked to level bucket (5 / 6 / 7) | required, 1..100 |
| kings | rejected (deprecated; enum value can't be dropped) |

Plus `finish_time_ms` clamped to `1..1_800_000`, and a 2-second per-user rate limit per game.

## Test plan

- [ ] Play each game end-to-end on a preview deploy; verify scores still write and the leaderboard updates.
- [ ] In devtools, run `await sb.from('game_scores').insert({ user_id, game_type: 'snake', score: 9999, finish_time_ms: 1, level: null })` — should fail with a policy error.
- [ ] In devtools, call `sb.rpc('submit_game_score', { p_game_type: 'memory', p_score: 999, p_finish_ms: 1000, p_level: null })` — should error with `memory score must be 8`.
- [ ] Verify the existing append-only restrictive UPDATE / DELETE policies still apply (try updating an existing row).

## Follow-up (not in this PR)

There are 8 obviously fake rows from a single user (2026-05-18 14:29-14:38) plus 13 legacy pipes/queens rows where `level IS NULL` (pre-dating `2026-05-18-game-scores-per-level.sql`). Discuss in #150 whether to wipe / backfill.