### PR TITLE
feat(bento): soft-disable restaurants via is_active flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ npm-debug.log*
 
 # Supabase CLI scratch
 supabase/.temp/
+
+# Local-only design docs and plans (superpowers brainstorming output)
+docs/superpowers/

--- a/apps/portal/app/bento/_components/restaurant-card.tsx
+++ b/apps/portal/app/bento/_components/restaurant-card.tsx
@@ -1,12 +1,18 @@
 "use client"
 
-import { ExternalLink, Trash2 } from "lucide-react"
+import { Ban, CheckCircle2, ExternalLink, Trash2 } from "lucide-react"
 import { toast } from "sonner"
 
+import { Badge } from "@workspace/ui/components/badge"
 import { Button } from "@workspace/ui/components/button"
 import { Skeleton } from "@workspace/ui/components/skeleton"
+import { cn } from "@workspace/ui/lib/utils"
 
-import { useDeleteMenu, useMenuItemCounts } from "@/hooks/bento/use-menus"
+import {
+  useDeleteMenu,
+  useMenuItemCounts,
+  useToggleMenuActive,
+} from "@/hooks/bento/use-menus"
 
 import { ConfirmDialog } from "./confirm-dialog"
 import { EditRestaurantDialog } from "./edit-restaurant-dialog"
@@ -18,6 +24,7 @@ interface Restaurant {
   google_map_link?: string | null
   created_at: string
   additional?: string[] | null
+  is_active?: boolean
 }
 
 type MenuItemRow = {
@@ -45,8 +52,10 @@ export function RestaurantCard({
     restaurant.id
   )
   const deleteMenu = useDeleteMenu(restaurant.id)
+  const toggleActive = useToggleMenuActive()
 
   const loading = statsLoading
+  const isActive = restaurant.is_active !== false
 
   const handleDelete = async () => {
     try {
@@ -58,11 +67,37 @@ export function RestaurantCard({
     }
   }
 
+  const handleToggleActive = async () => {
+    const nextActive = !isActive
+    try {
+      await toggleActive.mutateAsync({ id: restaurant.id, nextActive })
+      toast.success(nextActive ? "店家已啟用" : "店家已停用")
+    } catch (error) {
+      const err =
+        error instanceof Error
+          ? error
+          : new Error(nextActive ? "啟用失敗" : "停用失敗")
+      toast.error(err.message)
+    }
+  }
+
   return (
-    <div className="flex flex-col gap-4 rounded-xl border border-border bg-card p-5">
+    <div
+      className={cn(
+        "flex flex-col gap-4 rounded-xl border border-border bg-card p-5 transition-opacity",
+        !isActive && "opacity-60"
+      )}
+    >
       <div className="flex items-start justify-between gap-4">
         <div className="flex flex-col gap-1">
-          <span className="text-sm font-medium">{restaurant.name}</span>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-medium">{restaurant.name}</span>
+            {!isActive && (
+              <Badge variant="secondary" className="text-[10px]">
+                已停用
+              </Badge>
+            )}
+          </div>
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
             {restaurant.google_map_link && (
               <a
@@ -91,6 +126,38 @@ export function RestaurantCard({
             <EditRestaurantDialog
               restaurant={restaurant}
               menuItems={menuItems}
+            />
+            <ConfirmDialog
+              trigger={
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={toggleActive.isPending}
+                >
+                  {isActive ? (
+                    <Ban className="mr-1 h-3.5 w-3.5" />
+                  ) : (
+                    <CheckCircle2 className="mr-1 h-3.5 w-3.5" />
+                  )}
+                  {toggleActive.isPending
+                    ? "處理中..."
+                    : isActive
+                      ? "停用"
+                      : "啟用"}
+                </Button>
+              }
+              title={
+                isActive
+                  ? `停用「${restaurant.name}」？`
+                  : `啟用「${restaurant.name}」？`
+              }
+              description={
+                isActive
+                  ? "停用後，這間店家將不會出現在新增訂單與店家列表中。已存在的訂單不受影響。"
+                  : "啟用後，這間店家會重新出現在訂單與店家列表中。"
+              }
+              confirmText={isActive ? "停用" : "啟用"}
+              onConfirm={handleToggleActive}
             />
             <ConfirmDialog
               trigger={

--- a/apps/portal/app/bento/_components/restaurant-list.tsx
+++ b/apps/portal/app/bento/_components/restaurant-list.tsx
@@ -4,10 +4,12 @@ import { Search } from "lucide-react"
 import { useState } from "react"
 
 import { Input } from "@workspace/ui/components/input"
+import { Label } from "@workspace/ui/components/label"
 import { Skeleton } from "@workspace/ui/components/skeleton"
+import { Switch } from "@workspace/ui/components/switch"
 
 import { useAdmin } from "@/hooks/bento/use-admin"
-import { useMenus } from "@/hooks/bento/use-menus"
+import { useDisabledMenuCount, useMenus } from "@/hooks/bento/use-menus"
 
 import { CreateRestaurantDialog } from "./create-restaurant-dialog"
 import { RestaurantCard } from "./restaurant-card"
@@ -26,12 +28,17 @@ type RestaurantRow = {
   google_map_link?: string | null
   created_at: string
   additional?: string[] | null
+  is_active: boolean
   menu_items: MenuItemRow[]
 }
 
 export function RestaurantList() {
   const { isAdmin } = useAdmin()
-  const { data: restaurants, isLoading } = useMenus()
+  const [showInactive, setShowInactive] = useState(false)
+  const { data: restaurants, isLoading } = useMenus({
+    includeInactive: isAdmin && showInactive,
+  })
+  const { data: disabledCount = 0 } = useDisabledMenuCount()
   const [search, setSearch] = useState("")
 
   const filtered = ((restaurants ?? []) as RestaurantRow[]).filter((r) =>
@@ -54,12 +61,31 @@ export function RestaurantList() {
 
   return (
     <div className="flex flex-col gap-10">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex flex-col gap-1">
           <h1 className="font-medium">Menus</h1>
           <p className="text-sm text-muted-foreground">店家列表與菜單管理。</p>
         </div>
-        {isAdmin && <CreateRestaurantDialog />}
+        {isAdmin && (
+          <div className="flex flex-wrap items-center gap-4">
+            {disabledCount > 0 && (
+              <div className="flex items-center gap-2">
+                <Switch
+                  id="show-inactive"
+                  checked={showInactive}
+                  onCheckedChange={setShowInactive}
+                />
+                <Label
+                  htmlFor="show-inactive"
+                  className="cursor-pointer text-xs text-muted-foreground"
+                >
+                  顯示已停用 ({disabledCount})
+                </Label>
+              </div>
+            )}
+            <CreateRestaurantDialog />
+          </div>
+        )}
       </div>
 
       <div className="flex flex-col gap-4">

--- a/apps/portal/hooks/bento/use-menus.ts
+++ b/apps/portal/hooks/bento/use-menus.ts
@@ -6,19 +6,73 @@ import { createClient } from "@/lib/supabase/client"
 
 import { queryKeys } from "./query-keys"
 
-export function useMenus() {
+interface UseMenusOptions {
+  includeInactive?: boolean
+}
+
+export function useMenus(opts: UseMenusOptions = {}) {
+  const { includeInactive = false } = opts
   const supabase = createClient()
 
   return useQuery({
-    queryKey: queryKeys.menus.all,
+    queryKey: [...queryKeys.menus.all, { includeInactive }] as const,
     queryFn: async () => {
-      const { data, error } = await supabase
+      let query = supabase
         .from("bento_menus")
         .select("*, menu_items:bento_menu_items(*)")
+        .order("is_active", { ascending: false })
         .order("name")
+
+      if (!includeInactive) {
+        query = query.eq("is_active", true)
+      }
+
+      const { data, error } = await query
 
       if (error) throw error
       return data
+    },
+  })
+}
+
+export function useDisabledMenuCount() {
+  const supabase = createClient()
+
+  return useQuery({
+    queryKey: [...queryKeys.menus.all, "disabled-count"] as const,
+    queryFn: async () => {
+      const { count, error } = await supabase
+        .from("bento_menus")
+        .select("id", { count: "exact", head: true })
+        .eq("is_active", false)
+
+      if (error) throw error
+      return count ?? 0
+    },
+  })
+}
+
+export function useToggleMenuActive() {
+  const supabase = createClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (params: { id: string; nextActive: boolean }) => {
+      const { data, error } = await supabase
+        .from("bento_menus")
+        .update({
+          is_active: params.nextActive,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", params.id)
+        .select()
+        .single()
+
+      if (error) throw error
+      return data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.menus.all })
     },
   })
 }

--- a/packages/ui/src/components/switch.tsx
+++ b/packages/ui/src/components/switch.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "@workspace/ui/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border-2 transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-5 data-[size=default]:w-11 data-[size=sm]:h-4 data-[size=sm]:w-7 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-unchecked:border-transparent data-unchecked:bg-input/90 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block rounded-full bg-background shadow-sm ring-0 transition-transform not-dark:bg-clip-padding group-data-[size=default]/switch:h-4 group-data-[size=default]/switch:w-6 group-data-[size=sm]/switch:h-3 group-data-[size=sm]/switch:w-4 data-checked:translate-x-[calc(100%-8px)] dark:data-checked:bg-primary-foreground data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/supabase/migrations/2026-05-21-bento-menus-is-active.sql
+++ b/supabase/migrations/2026-05-21-bento-menus-is-active.sql
@@ -1,0 +1,66 @@
+-- Soft-disable for bento restaurants: add an is_active flag so admins can
+-- "ban" a restaurant without deleting it. Deleting would break the foreign
+-- key from bento_orders.restaurant_id and erase historical orders.
+--
+-- After this migration:
+--   * Clients that filter is_active = true hide disabled restaurants from
+--     "new order" pickers and the public /bento/menus list.
+--   * The create_bento_order RPC rejects disabled restaurants at the server
+--     so a stale client (or direct API call) cannot bypass the filter.
+--   * Existing orders for a now-disabled restaurant continue to work — the
+--     row is still there, only the flag changed.
+
+-- 1. Soft-disable flag. Defaults to true so existing 10 restaurants stay active.
+alter table public.bento_menus
+  add column if not exists is_active boolean not null default true;
+
+-- 2. Partial index on the hot path (active restaurants).
+create index if not exists bento_menus_is_active_idx
+  on public.bento_menus (is_active)
+  where is_active = true;
+
+-- 3. Reject disabled restaurants inside create_bento_order. Guard sits after
+--    the admin check so the "disabled" message never leaks to non-admins, and
+--    before the duplicate-id check so the error message is the most relevant.
+create or replace function public.create_bento_order(
+  p_restaurant_id uuid,
+  p_order_date    date,
+  p_auto_close_at timestamp with time zone default null::timestamp with time zone
+)
+returns bento_orders
+language plpgsql
+security definer
+as $function$
+declare
+  v_order_id text;
+  v_order    bento_orders;
+begin
+  -- Check admin
+  if not has_role(auth.uid(), 'bento', 'admin') then
+    raise exception 'Forbidden: Admin access required';
+  end if;
+
+  -- Reject disabled restaurants
+  if not exists (
+    select 1 from public.bento_menus
+    where id = p_restaurant_id and is_active = true
+  ) then
+    raise exception '店家已停用，無法建立訂單' using errcode = 'P0001';
+  end if;
+
+  -- Generate date-based ID
+  v_order_id := to_char(p_order_date, 'YYYYMMDD');
+
+  -- Check duplicate
+  if exists (select 1 from bento_orders where id = v_order_id) then
+    raise exception '日期 % 已經有訂單了，請使用現有的訂單', v_order_id;
+  end if;
+
+  -- Insert
+  insert into bento_orders (id, restaurant_id, status, created_by, auto_close_at)
+  values (v_order_id, p_restaurant_id, 'active', auth.uid(), p_auto_close_at)
+  returning * into v_order;
+
+  return v_order;
+end;
+$function$;


### PR DESCRIPTION
Closes #152

## Summary

Adds a "停用 / 啟用" toggle so bento admins can ban a restaurant from new orders without deleting it. Disabled restaurants disappear from the order picker and the public menu list; admins can opt into seeing them via a "顯示已停用 (N)" switch on `/bento/menus`. Existing orders for a now-disabled restaurant continue to work normally.

## Surfaces affected

- **DB**: `bento_menus.is_active boolean NOT NULL DEFAULT true` with a partial index on the active path; `create_bento_order` RPC now rejects disabled restaurants between the admin check and the dup check (so the "disabled" message never leaks to non-admins).
- **Hook** (`apps/portal/hooks/bento/use-menus.ts`):
  - `useMenus({ includeInactive? })` — defaults to active-only; admin toggle flips it.
  - `useDisabledMenuCount()` — count-only query that drives the toggle badge.
  - `useToggleMenuActive()` — one-shot mutation that invalidates `queryKeys.menus.all`.
- **UI**:
  - `restaurant-list.tsx` — admin-only `Switch` + `Label` "顯示已停用 (N)".
  - `restaurant-card.tsx` — `ConfirmDialog`-gated stop/start button, `opacity-60` and "已停用" `Badge` on disabled cards.
- **shadcn**: added `packages/ui/src/components/switch.tsx`.

## Defense in depth

Even if a stale client (cached `useMenus` data) tries to pick a disabled restaurant, the `create_bento_order` RPC raises `店家已停用，無法建立訂單`. UI surfaces this through the existing toast.

## What's intentionally out of scope

- Audit fields (`disabled_at`, `disabled_by`).
- Bulk disable.
- Blocking close/reopen for existing orders whose restaurant got disabled — those flows still work because we don't want a ban to brick in-flight bookkeeping.

## Test plan

- [ ] Apply migration (already done in prod via Supabase MCP; the file in `supabase/migrations/` is the canonical record for new environments).
- [ ] `bun run typecheck` — ✅ green
- [ ] `bun run lint` — ✅ 0 errors (pre-existing 32 warnings unrelated)
- [ ] Admin: visit `/bento/menus`, see "顯示已停用 (N)" toggle on the right when at least one restaurant is disabled. Toggle reveals greyed cards with a "已停用" badge.
- [ ] Admin: click "停用" on a card → confirm dialog → toast "店家已停用". Card disappears from default list, appears under toggle.
- [ ] Admin: click "啟用" on a disabled card → confirm → toast "店家已啟用". Card returns to default list.
- [ ] Admin: open "新增訂單" — disabled restaurants don't appear in the picker.
- [ ] Non-admin: visit `/bento/menus` — only active restaurants visible, no toggle.
- [ ] Existing active orders for a restaurant that was disabled while open continue to accept items, close, and reopen normally.