### PR TITLE
fix(gallery): bundle ffmpeg core locally to fix video upload fetch errors

### DIFF
--- a/apps/gallery/app/upload/_components/upload-form.tsx
+++ b/apps/gallery/app/upload/_components/upload-form.tsx
@@ -17,6 +17,7 @@ import {
 import { createClient } from "@/lib/supabase/client"
 import {
   VIDEO_MAX_DURATION_SECONDS,
+  VIDEO_MAX_INPUT_BYTES,
   compressVideo,
   type CompressPhase,
 } from "@/lib/gallery/video-compress"
@@ -178,8 +179,9 @@ export function UploadForm() {
           </p>
         ) : null}
         <p className="text-sm text-muted-foreground italic">
-          Videos: max {VIDEO_MAX_DURATION_SECONDS}s, auto-compressed to 720p mp4
-          in your browser.
+          Videos: max {VIDEO_MAX_DURATION_SECONDS}s and{" "}
+          {VIDEO_MAX_INPUT_BYTES / 1024 / 1024} MB, auto-compressed to 720p mp4
+          in your browser (4K or very long clips may fail).
         </p>
       </div>
       {status.kind === "working" ? (

--- a/apps/gallery/lib/gallery/video-compress.ts
+++ b/apps/gallery/lib/gallery/video-compress.ts
@@ -6,10 +6,18 @@ import { fetchFile, toBlobURL } from "@ffmpeg/util"
 // Single-thread core — works without COOP/COEP / SharedArrayBuffer at the
 // cost of being slower than the MT build. Trade-off we like: zero header
 // gymnastics, ships behind the existing Vercel hosting.
-const FFMPEG_CORE_BASE = "https://unpkg.com/@ffmpeg/core@0.12.10/dist/umd"
+// Served from public/ffmpeg (see scripts/sync-ffmpeg-core.mjs) — avoids CDN
+// "Failed to fetch" when unpkg is blocked or offline.
+function ffmpegCoreBase(): string {
+  if (typeof window === "undefined") {
+    return "https://unpkg.com/@ffmpeg/core@0.12.10/dist/umd"
+  }
+  return `${window.location.origin}/ffmpeg`
+}
 
 export const VIDEO_MAX_DURATION_SECONDS = 60
-export const VIDEO_MAX_INPUT_BYTES = 200 * 1024 * 1024
+/** ST wasm heap is small — large inputs often hit "memory access out of bounds". */
+export const VIDEO_MAX_INPUT_BYTES = 100 * 1024 * 1024
 
 export type CompressPhase = "init" | "probe" | "compress" | "poster"
 
@@ -33,6 +41,11 @@ export type CompressOptions = {
 let ffmpegSingleton: FFmpeg | null = null
 let ffmpegLoadPromise: Promise<FFmpeg> | null = null
 
+function resetFFmpeg() {
+  ffmpegSingleton = null
+  ffmpegLoadPromise = null
+}
+
 async function getFFmpeg(
   onProgress?: CompressOptions["onProgress"]
 ): Promise<FFmpeg> {
@@ -42,9 +55,10 @@ async function getFFmpeg(
   ffmpegLoadPromise = (async () => {
     onProgress?.(0, "init")
     const ffmpeg = new FFmpeg()
+    const base = ffmpegCoreBase()
     const [coreURL, wasmURL] = await Promise.all([
-      toBlobURL(`${FFMPEG_CORE_BASE}/ffmpeg-core.js`, "text/javascript"),
-      toBlobURL(`${FFMPEG_CORE_BASE}/ffmpeg-core.wasm`, "application/wasm"),
+      toBlobURL(`${base}/ffmpeg-core.js`, "text/javascript"),
+      toBlobURL(`${base}/ffmpeg-core.wasm`, "application/wasm"),
     ])
     onProgress?.(0.5, "init")
     await ffmpeg.load({ coreURL, wasmURL })
@@ -56,7 +70,7 @@ async function getFFmpeg(
   try {
     return await ffmpegLoadPromise
   } catch (err) {
-    ffmpegLoadPromise = null
+    resetFFmpeg()
     throw err
   }
 }
@@ -99,6 +113,83 @@ export function probeVideo(
   })
 }
 
+/** Poster via canvas — avoids a second ffmpeg pass that often OOMs in ST wasm. */
+export function captureVideoPoster(
+  file: File,
+  atSeconds: number,
+  maxWidth = 720
+): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file)
+    const video = document.createElement("video")
+    video.preload = "auto"
+    video.muted = true
+    video.playsInline = true
+
+    const cleanup = () => {
+      URL.revokeObjectURL(url)
+      video.removeAttribute("src")
+      video.load()
+    }
+
+    video.onloadeddata = () => {
+      const t = Math.min(
+        Math.max(0, atSeconds),
+        Math.max(0, video.duration - 0.05)
+      )
+      video.currentTime = t
+    }
+    video.onseeked = () => {
+      const scale =
+        video.videoWidth > maxWidth ? maxWidth / video.videoWidth : 1
+      const w = Math.max(1, Math.round(video.videoWidth * scale))
+      const h = Math.max(1, Math.round(video.videoHeight * scale))
+      const canvas = document.createElement("canvas")
+      canvas.width = w
+      canvas.height = h
+      const ctx = canvas.getContext("2d")
+      if (!ctx) {
+        cleanup()
+        reject(new Error("Could not create poster canvas."))
+        return
+      }
+      ctx.drawImage(video, 0, 0, w, h)
+      canvas.toBlob(
+        (blob) => {
+          cleanup()
+          if (blob) resolve(blob)
+          else reject(new Error("Could not encode poster."))
+        },
+        "image/jpeg",
+        0.85
+      )
+    }
+    video.onerror = () => {
+      cleanup()
+      reject(new Error("Browser cannot decode this video for a poster."))
+    }
+
+    video.src = url
+  })
+}
+
+export function formatCompressError(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err)
+  if (/failed to fetch/i.test(raw)) {
+    return (
+      "Could not load the browser encoder — run `bun run sync-ffmpeg` in apps/gallery, " +
+      "restart dev, and check network / ad blockers."
+    )
+  }
+  if (/memory access out of bounds/i.test(raw)) {
+    return (
+      "Browser encoder ran out of memory — try a shorter clip (≤60s), " +
+      `smaller file (≤${VIDEO_MAX_INPUT_BYTES / 1024 / 1024} MB), or 720p/1080p instead of 4K.`
+    )
+  }
+  return raw
+}
+
 export async function compressVideo(
   file: File,
   opts: CompressOptions = {}
@@ -118,12 +209,16 @@ export async function compressVideo(
   }
   opts.onProgress?.(1, "probe")
 
+  const posterAt = probe.durationSeconds > 1.5 ? 1 : 0.1
+  opts.onProgress?.(0, "poster")
+  const poster = await captureVideoPoster(file, posterAt)
+  opts.onProgress?.(1, "poster")
+
   const ffmpeg = await getFFmpeg(opts.onProgress)
   abortIfRequested(opts.signal)
 
   const inputName = `in.${guessInputExt(file)}`
   const outputName = "out.mp4"
-  const posterName = "poster.jpg"
 
   const onCompressProgress = ({ progress }: { progress: number }) => {
     const clamped = Math.max(0, Math.min(1, progress))
@@ -140,7 +235,7 @@ export async function compressVideo(
       "-i",
       inputName,
       "-vf",
-      "scale='if(gt(iw,ih),min(1280,iw),-2)':'if(gt(iw,ih),-2,min(1280,ih))',fps=30",
+      "scale='if(gt(iw,ih),min(720,iw),-2)':'if(gt(iw,ih),-2,min(720,ih))',fps=30",
       "-c:v",
       "libx264",
       "-preset",
@@ -164,47 +259,28 @@ export async function compressVideo(
     abortIfRequested(opts.signal)
     opts.onProgress?.(1, "compress")
 
-    opts.onProgress?.(0, "poster")
-    const posterAt = probe.durationSeconds > 1.5 ? "00:00:01" : "00:00:00.10"
-    await ffmpeg.exec([
-      "-ss",
-      posterAt,
-      "-i",
-      outputName,
-      "-frames:v",
-      "1",
-      "-vf",
-      "scale='if(gt(iw,ih),min(1280,iw),-2)':'if(gt(iw,ih),-2,min(1280,ih))'",
-      "-q:v",
-      "5",
-      posterName,
-    ])
-    opts.onProgress?.(1, "poster")
-    abortIfRequested(opts.signal)
-
     const videoData = await ffmpeg.readFile(outputName)
-    const posterData = await ffmpeg.readFile(posterName)
-
     const videoBytes = toUint8Array(videoData)
-    const posterBytes = toUint8Array(posterData)
 
     return {
       video: new Blob([videoBytes as BlobPart], { type: "video/mp4" }),
       videoMime: "video/mp4",
       videoExt: "mp4",
-      poster: new Blob([posterBytes as BlobPart], { type: "image/jpeg" }),
+      poster,
       posterMime: "image/jpeg",
       posterExt: "jpg",
       durationSeconds: Math.round(probe.durationSeconds),
       width: probe.width,
       height: probe.height,
     }
+  } catch (err) {
+    resetFFmpeg()
+    throw new Error(formatCompressError(err), { cause: err })
   } finally {
     ffmpeg.off("progress", onCompressProgress)
     await Promise.allSettled([
       ffmpeg.deleteFile(inputName),
       ffmpeg.deleteFile(outputName),
-      ffmpeg.deleteFile(posterName),
     ])
   }
 }

--- a/apps/gallery/package.json
+++ b/apps/gallery/package.json
@@ -4,6 +4,9 @@
   "type": "module",
   "private": true,
   "scripts": {
+    "sync-ffmpeg": "node ./scripts/sync-ffmpeg-core.mjs",
+    "predev": "bun run sync-ffmpeg",
+    "prebuild": "bun run sync-ffmpeg",
     "dev": "next dev --turbopack --port 3005",
     "dev:webpack": "next dev --webpack --port 3005",
     "build": "next build",
@@ -14,6 +17,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@ffmpeg/core": "0.12.10",
     "@ffmpeg/ffmpeg": "^0.12.15",
     "@ffmpeg/util": "^0.12.2",
     "@supabase/ssr": "^0.10.2",

--- a/apps/gallery/scripts/sync-ffmpeg-core.mjs
+++ b/apps/gallery/scripts/sync-ffmpeg-core.mjs
@@ -1,0 +1,19 @@
+import { cpSync, existsSync, mkdirSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const galleryRoot = join(dirname(fileURLToPath(import.meta.url)), "..")
+const from = join(galleryRoot, "node_modules", "@ffmpeg", "core", "dist", "umd")
+const to = join(galleryRoot, "public", "ffmpeg")
+
+if (!existsSync(join(from, "ffmpeg-core.js"))) {
+  console.error("sync-ffmpeg-core: @ffmpeg/core umd files not found at", from)
+  console.error("Run `bun install` in apps/gallery first.")
+  process.exit(1)
+}
+
+mkdirSync(to, { recursive: true })
+for (const name of ["ffmpeg-core.js", "ffmpeg-core.wasm"]) {
+  cpSync(join(from, name), join(to, name))
+}
+console.log("sync-ffmpeg-core: copied umd build to public/ffmpeg/")

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
       "name": "gallery",
       "version": "0.0.1",
       "dependencies": {
+        "@ffmpeg/core": "0.12.10",
         "@ffmpeg/ffmpeg": "^0.12.15",
         "@ffmpeg/util": "^0.12.2",
         "@supabase/ssr": "^0.10.2",
@@ -176,7 +177,7 @@
     },
   },
   "overrides": {
-    "fast-uri": "^3.1.2",
+    "tslib": "^2.8.1",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
@@ -350,6 +351,8 @@
     "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@ffmpeg/core": ["@ffmpeg/core@0.12.10", "", {}, "sha512-dzNplnn2Nxle2c2i2rrDhqcB19q9cglCkWnoMTDN9Q9l3PvdjZWd1HfSPjCNWc/p8Q3CT+Es9fWOR0UhAeYQZA=="],
 
     "@ffmpeg/ffmpeg": ["@ffmpeg/ffmpeg@0.12.15", "", { "dependencies": { "@ffmpeg/types": "^0.12.4" } }, "sha512-1C8Obr4GsN3xw+/1Ww6PFM84wSQAGsdoTuTWPOj2OizsRDLT4CXTaVjPhkw6ARyDus1B9X/L2LiXHqYYsGnRFw=="],
 
@@ -1847,7 +1850,7 @@
 
     "tsconfig-paths": ["tsconfig-paths@4.2.0", "", { "dependencies": { "json5": "^2.2.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg=="],
 
-    "tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "turbo": ["turbo@2.9.8", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.8", "@turbo/darwin-arm64": "2.9.8", "@turbo/linux-64": "2.9.8", "@turbo/linux-arm64": "2.9.8", "@turbo/windows-64": "2.9.8", "@turbo/windows-arm64": "2.9.8" }, "bin": { "turbo": "bin/turbo" } }, "sha512-REEB2rVTVDTf4hav1gJ5dIsGylWZrNonvjXFtk1dCi8gND3PhZtnYkyry1bra/Fo+iP6ctTEZbg6vWfdfHq/1A=="],
 
@@ -1967,8 +1970,6 @@
 
     "@dotenvx/dotenvx/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
-    "@emnapi/runtime/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
@@ -2063,18 +2064,6 @@
 
     "@react-email/components/@react-email/render": ["@react-email/render@2.0.6", "", { "dependencies": { "html-to-text": "^9.0.5", "prettier": "^3.5.3" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-xOzaYkH3jLZKqN5MqrTXYnmqBYUnZSVbkxdb5PGGmDcK6sKDVMliaDiSwfXajRC9JtSHTcGc2tmGLHWuCgVpog=="],
 
-    "@supabase/auth-js/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "@supabase/functions-js/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "@supabase/postgrest-js/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "@supabase/realtime-js/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "@supabase/storage-js/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "@swc/helpers/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
@@ -2098,10 +2087,6 @@
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
     "ajv-formats/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
-
-    "aria-hidden/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "ast-types/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "cli-truncate/string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
 
@@ -2147,16 +2132,6 @@
 
     "radix-ui/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
-    "react-remove-scroll/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "react-remove-scroll-bar/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "react-rnd/tslib": ["tslib@2.6.2", "", {}, "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="],
-
-    "react-style-singleton/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "recast/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
@@ -2170,10 +2145,6 @@
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
     "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "use-callback-ref/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "use-sidecar/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "apps/*",
     "packages/*"
   ],
+  "overrides": {
+    "tslib": "^2.8.1"
+  },
   "dependencies": {
     "@tanstack/react-query": "^5.99.2",
     "date-fns": "^4.1.0",


### PR DESCRIPTION
Closes #<issue-number>

## Summary
- Copy `@ffmpeg/core` to `public/ffmpeg/` via `sync-ffmpeg-core.mjs` (runs on predev/prebuild)
- Load encoder from same origin instead of unpkg (fixes `Failed to fetch`)
- Generate poster with canvas (one fewer wasm pass, less OOM)
- Tighten video input limits and clarify upload hints
- Root `tslib` override for Radix/shadcn popover build on Bun

## Test plan
- [ ] `cd apps/gallery && bun install && bun run dev`
- [ ] Open http://localhost:3005/ffmpeg/ffmpeg-core.wasm (not 404)
- [ ] Upload a short mp4 on /upload — compresses and appears on home
- [ ] `bun run typecheck --filter=gallery` passes