### PR TITLE
fix(gallery): polish mobile reaction picker UX

### DIFF
--- a/apps/gallery/app/_components/gallery-card.tsx
+++ b/apps/gallery/app/_components/gallery-card.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useTransition } from "react"
+import { useState, useTransition, type Dispatch, type SetStateAction } from "react"
 
 import { IconX } from "@tabler/icons-react"
 
@@ -32,6 +32,53 @@ import {
 } from "@/lib/gallery/reactions"
 import type { GalleryImage } from "@/lib/gallery/types"
 import { getGalleryImageUrl } from "@/lib/gallery/url"
+
+function applyReactionOptimistic(
+  prev: GalleryReaction | null,
+  reaction: GalleryReaction,
+  viewerName: string,
+  setCounts: Dispatch<SetStateAction<ReactionCounts>>,
+  setNamesByReaction: Dispatch<SetStateAction<ReactionNames>>,
+  setMyReaction: Dispatch<SetStateAction<GalleryReaction | null>>
+) {
+  if (prev === reaction) {
+    setCounts((c) => ({
+      ...c,
+      [reaction]: Math.max(0, c[reaction] - 1),
+    }))
+    setNamesByReaction((n) => ({
+      ...n,
+      [reaction]: n[reaction].filter((name) => name !== viewerName),
+    }))
+    setMyReaction(null)
+    return "removed" as const
+  }
+  if (prev) {
+    setCounts((c) => ({
+      ...c,
+      [prev]: Math.max(0, c[prev] - 1),
+      [reaction]: c[reaction] + 1,
+    }))
+    setNamesByReaction((n) => ({
+      ...n,
+      [prev]: n[prev].filter((name) => name !== viewerName),
+      [reaction]: n[reaction].includes(viewerName)
+        ? n[reaction]
+        : [...n[reaction], viewerName],
+    }))
+    setMyReaction(reaction)
+    return "updated" as const
+  }
+  setCounts((c) => ({ ...c, [reaction]: c[reaction] + 1 }))
+  setNamesByReaction((n) => ({
+    ...n,
+    [reaction]: n[reaction].includes(viewerName)
+      ? n[reaction]
+      : [...n[reaction], viewerName],
+  }))
+  setMyReaction(reaction)
+  return "added" as const
+}
 
 export function GalleryCard({
   image,
@@ -72,44 +119,17 @@ export function GalleryCard({
         return
       }
 
-      const prev = myReaction
-      if (prev === reaction) {
-        setCounts((c) => ({
-          ...c,
-          [reaction]: Math.max(0, c[reaction] - 1),
-        }))
-        setNamesByReaction((n) => ({
-          ...n,
-          [reaction]: n[reaction].filter((name) => name !== viewerName),
-        }))
-        setMyReaction(null)
-        toast.success("Reaction removed.")
-      } else if (prev) {
-        setCounts((c) => ({
-          ...c,
-          [prev]: Math.max(0, c[prev] - 1),
-          [reaction]: c[reaction] + 1,
-        }))
-        setNamesByReaction((n) => ({
-          ...n,
-          [prev]: n[prev].filter((name) => name !== viewerName),
-          [reaction]: n[reaction].includes(viewerName)
-            ? n[reaction]
-            : [...n[reaction], viewerName],
-        }))
-        setMyReaction(reaction)
-        toast.success("Reaction updated.")
-      } else {
-        setCounts((c) => ({ ...c, [reaction]: c[reaction] + 1 }))
-        setNamesByReaction((n) => ({
-          ...n,
-          [reaction]: n[reaction].includes(viewerName)
-            ? n[reaction]
-            : [...n[reaction], viewerName],
-        }))
-        setMyReaction(reaction)
-        toast.success("Reaction added.")
-      }
+      const outcome = applyReactionOptimistic(
+        myReaction,
+        reaction,
+        viewerName,
+        setCounts,
+        setNamesByReaction,
+        setMyReaction
+      )
+      if (outcome === "removed") toast.success("Reaction removed.")
+      else if (outcome === "updated") toast.success("Reaction updated.")
+      else toast.success("Reaction added.")
     })
   }
 
@@ -260,7 +280,7 @@ function ReactionSummary({
       <PopoverTrigger asChild>
         <button
           type="button"
-          className="mt-1 flex max-w-full flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground not-italic transition-colors hover:text-foreground md:text-sm"
+          className="mt-1 flex max-w-full flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground not-italic transition-colors select-none hover:text-foreground md:text-sm"
           aria-label="Show who reacted"
         >
           {GALLERY_REACTIONS.filter((r) => counts[r] > 0).map((reaction) => (
@@ -283,7 +303,7 @@ function ReactionSummary({
           {entries.map(({ reaction, name }, idx) => (
             <li
               key={`${reaction}-${name}-${idx}`}
-              className="flex min-w-0 items-center gap-2"
+              className="flex min-w-0 select-none items-center gap-2"
             >
               <ReactionGlyph
                 reaction={reaction}

--- a/apps/gallery/app/_components/reaction-bar.tsx
+++ b/apps/gallery/app/_components/reaction-bar.tsx
@@ -8,6 +8,7 @@ import { ReactionGlyph } from "@/app/_components/reaction-glyph"
 import {
   GALLERY_REACTIONS,
   REACTION_EMOJI,
+  isGalleryReaction,
   totalReactions,
   type GalleryReaction,
   type ReactionCounts,
@@ -15,7 +16,14 @@ import {
 
 const HOVER_SHOW_MS = 400
 const HOVER_HIDE_MS = 250
-const LONG_PRESS_MS = 500
+const LONG_PRESS_MS = 450
+
+function reactionFromPoint(x: number, y: number): GalleryReaction | null {
+  const el = document.elementFromPoint(x, y)
+  const btn = el?.closest<HTMLElement>("[data-reaction]")
+  const value = btn?.dataset.reaction
+  return value && isGalleryReaction(value) ? value : null
+}
 
 export function ReactionBar({
   counts,
@@ -29,11 +37,18 @@ export function ReactionBar({
   onReact: (reaction: GalleryReaction) => void
 }) {
   const [pickerOpen, setPickerOpen] = useState(false)
+  const [hoveredReaction, setHoveredReaction] =
+    useState<GalleryReaction | null>(null)
+
+  const zoneRef = useRef<HTMLDivElement>(null)
   const hoverShowTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const hoverHideTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const longPressTriggered = useRef(false)
+  const longPressOpened = useRef(false)
+  const touchAwaitingPick = useRef(false)
   const suppressClick = useRef(false)
+  const touchPickHandled = useRef(false)
+  const activePointerId = useRef<number | null>(null)
 
   const total = totalReactions(counts)
 
@@ -67,15 +82,31 @@ export function ReactionBar({
   const closePicker = useCallback(() => {
     clearHoverShow()
     clearHoverHide()
+    clearLongPress()
+    longPressOpened.current = false
+    touchAwaitingPick.current = false
+    activePointerId.current = null
+    setHoveredReaction(null)
     setPickerOpen(false)
-  }, [clearHoverShow, clearHoverHide])
+  }, [clearHoverShow, clearHoverHide, clearLongPress])
 
   const scheduleClose = useCallback(() => {
+    if (touchAwaitingPick.current || longPressOpened.current) return
     clearHoverHide()
     hoverHideTimer.current = setTimeout(() => {
       setPickerOpen(false)
+      setHoveredReaction(null)
     }, HOVER_HIDE_MS)
   }, [clearHoverHide])
+
+  const pickReaction = useCallback(
+    (reaction: GalleryReaction) => {
+      onReact(reaction)
+      closePicker()
+      suppressClick.current = true
+    },
+    [closePicker, onReact]
+  )
 
   useEffect(() => {
     return () => {
@@ -85,40 +116,113 @@ export function ReactionBar({
     }
   }, [clearHoverHide, clearHoverShow, clearLongPress])
 
+  // Mobile: after long-press release, dismiss only on emoji tap or outside tap.
+  useEffect(() => {
+    if (!pickerOpen) return
+
+    const onDocPointerDown = (e: PointerEvent) => {
+      if (!touchAwaitingPick.current) return
+      const target = e.target as Node
+      if (!zoneRef.current) return
+
+      if (zoneRef.current.contains(target)) {
+        if ((target as Element).closest?.("[data-reaction]")) return
+        closePicker()
+        suppressClick.current = true
+        return
+      }
+
+      closePicker()
+      suppressClick.current = true
+    }
+
+    document.addEventListener("pointerdown", onDocPointerDown, true)
+    return () => document.removeEventListener("pointerdown", onDocPointerDown, true)
+  }, [pickerOpen, closePicker])
+
   const onZoneEnter = (e: React.PointerEvent) => {
-    if (!canReact || e.pointerType === "touch") return
+    if (
+      !canReact ||
+      e.pointerType === "touch" ||
+      touchAwaitingPick.current
+    )
+      return
     clearHoverHide()
     clearHoverShow()
     hoverShowTimer.current = setTimeout(openPicker, HOVER_SHOW_MS)
   }
 
-  const onZoneLeave = () => {
+  const onZoneLeave = (e: React.PointerEvent) => {
+    if (
+      touchAwaitingPick.current ||
+      longPressOpened.current ||
+      e.pointerType === "touch"
+    )
+      return
     clearHoverShow()
     scheduleClose()
   }
 
-  const onTriggerPointerDown = (e: React.PointerEvent) => {
-    if (!canReact) return
-    longPressTriggered.current = false
-    suppressClick.current = false
+  const onZonePointerDown = (e: React.PointerEvent) => {
+    if (!canReact || e.pointerType !== "touch") return
+    if (e.button !== 0) return
 
-    if (e.pointerType === "touch") {
-      clearLongPress()
-      longPressTimer.current = setTimeout(() => {
-        longPressTriggered.current = true
-        suppressClick.current = true
-        openPicker()
-      }, LONG_PRESS_MS)
+    if (touchAwaitingPick.current) {
+      if ((e.target as Element).closest?.("[data-reaction]")) return
+      closePicker()
+      suppressClick.current = true
+      return
     }
+
+    longPressOpened.current = false
+    suppressClick.current = false
+    activePointerId.current = e.pointerId
+    clearLongPress()
+
+    longPressTimer.current = setTimeout(() => {
+      longPressOpened.current = true
+      openPicker()
+      zoneRef.current?.setPointerCapture(e.pointerId)
+      if (navigator.vibrate) navigator.vibrate(10)
+    }, LONG_PRESS_MS)
   }
 
-  const onTriggerPointerUp = () => {
-    clearLongPress()
+  const onZonePointerMove = (e: React.PointerEvent) => {
+    if (!longPressOpened.current || e.pointerId !== activePointerId.current)
+      return
+    if (touchAwaitingPick.current) return
+    const reaction = reactionFromPoint(e.clientX, e.clientY)
+    setHoveredReaction(reaction)
   }
 
-  const onTriggerPointerCancel = () => {
+  const onZonePointerUp = (e: React.PointerEvent) => {
     clearLongPress()
-    longPressTriggered.current = false
+
+    if (longPressOpened.current && e.pointerId === activePointerId.current) {
+      touchAwaitingPick.current = true
+      longPressOpened.current = false
+      suppressClick.current = true
+      activePointerId.current = null
+      try {
+        zoneRef.current?.releasePointerCapture(e.pointerId)
+      } catch {
+        // already released
+      }
+      return
+    }
+
+    activePointerId.current = null
+  }
+
+  const onZonePointerCancel = (e: React.PointerEvent) => {
+    clearLongPress()
+    if (longPressOpened.current || touchAwaitingPick.current) {
+      closePicker()
+      suppressClick.current = true
+    }
+    if (e.pointerId === activePointerId.current) {
+      activePointerId.current = null
+    }
   }
 
   const onTriggerClick = () => {
@@ -126,7 +230,10 @@ export function ReactionBar({
       suppressClick.current = false
       return
     }
-    // Quick tap: like when empty; remove when you already reacted (FB-style).
+    if (touchAwaitingPick.current) {
+      closePicker()
+      return
+    }
     onReact(myReaction ?? "like")
     closePicker()
   }
@@ -135,34 +242,53 @@ export function ReactionBar({
 
   return (
     <div
-      className="relative shrink-0 not-italic"
+      ref={zoneRef}
+      className="relative shrink-0 touch-manipulation select-none [-webkit-touch-callout:none] not-italic"
       onPointerEnter={onZoneEnter}
       onPointerLeave={onZoneLeave}
+      onPointerDown={onZonePointerDown}
+      onPointerMove={onZonePointerMove}
+      onPointerUp={onZonePointerUp}
+      onPointerCancel={onZonePointerCancel}
     >
       <div
         role="menu"
         aria-label="Choose a reaction"
         aria-hidden={!pickerOpen}
         className={cn(
-          "absolute right-0 bottom-full z-20 mb-2 flex items-center gap-0.5 rounded-full border border-border bg-background px-1.5 py-1 shadow-lg",
+          "absolute right-0 bottom-full z-20 mb-1 flex select-none items-center gap-0.5 rounded-full border border-border bg-background px-1.5 py-1 shadow-lg",
           "transition-all duration-200 ease-out",
           pickerOpen
             ? "pointer-events-auto translate-y-0 scale-100 opacity-100"
             : "pointer-events-none translate-y-1 scale-95 opacity-0"
         )}
-        onPointerEnter={() => canReact && clearHoverHide()}
+        onPointerEnter={() =>
+          canReact && !touchAwaitingPick.current && clearHoverHide()
+        }
       >
         {GALLERY_REACTIONS.map((reaction) => {
           const active = myReaction === reaction
+          const highlighted = hoveredReaction === reaction
           return (
             <button
               key={reaction}
               type="button"
               role="menuitem"
+              data-reaction={reaction}
               disabled={!canReact}
+              onPointerDown={(e) => e.stopPropagation()}
+              onPointerUp={(e) => {
+                if (e.pointerType !== "touch" || !pickerOpen) return
+                e.stopPropagation()
+                touchPickHandled.current = true
+                pickReaction(reaction)
+              }}
               onClick={() => {
-                onReact(reaction)
-                closePicker()
+                if (touchPickHandled.current) {
+                  touchPickHandled.current = false
+                  return
+                }
+                pickReaction(reaction)
               }}
               aria-label={
                 active
@@ -171,11 +297,11 @@ export function ReactionBar({
               }
               aria-pressed={active}
               className={cn(
-                "flex items-center justify-center rounded-full transition-transform hover:scale-110",
+                "flex select-none items-center justify-center rounded-full transition-transform",
                 reaction === "point"
-                  ? "h-10 w-[3.25rem] px-1"
-                  : "h-10 w-10",
-                active && "bg-foreground/10"
+                  ? "h-11 w-[3.25rem] px-1"
+                  : "h-11 w-11",
+                (active || highlighted) && "scale-125 bg-foreground/10"
               )}
             >
               <ReactionGlyph
@@ -191,9 +317,6 @@ export function ReactionBar({
         type="button"
         disabled={!canReact}
         onClick={onTriggerClick}
-        onPointerDown={onTriggerPointerDown}
-        onPointerUp={onTriggerPointerUp}
-        onPointerCancel={onTriggerPointerCancel}
         onContextMenu={(e) => e.preventDefault()}
         aria-label={
           myReaction
@@ -201,7 +324,7 @@ export function ReactionBar({
             : "React. Hold or hover for more"
         }
         className={cn(
-          "inline-flex items-center gap-1 rounded-full border px-2.5 py-1 transition-colors",
+          "inline-flex select-none items-center gap-1 rounded-full border px-2.5 py-1 transition-colors",
           myReaction
             ? "border-foreground/20 bg-foreground/10 text-foreground"
             : "border-foreground/20 bg-background/80 text-foreground hover:bg-foreground/10",

--- a/apps/gallery/app/_components/reaction-glyph.tsx
+++ b/apps/gallery/app/_components/reaction-glyph.tsx
@@ -16,19 +16,25 @@ export function ReactionGlyph({
     return (
       <span
         className={cn(
-          "inline-flex flex-row items-center gap-px leading-none whitespace-nowrap",
+          "inline-flex flex-row items-center gap-px leading-none whitespace-nowrap select-none [-webkit-touch-callout:none]",
           className
         )}
         aria-hidden
       >
-        <span className="inline-block">👉</span>
-        <span className="inline-block">👈</span>
+        <span className="inline-block select-none">👉</span>
+        <span className="inline-block select-none">👈</span>
       </span>
     )
   }
 
   return (
-    <span className={cn("inline-block leading-none", className)} aria-hidden>
+    <span
+      className={cn(
+        "inline-block leading-none select-none [-webkit-touch-callout:none]",
+        className
+      )}
+      aria-hidden
+    >
       {REACTION_EMOJI[reaction]}
     </span>
   )


### PR DESCRIPTION
## Summary

Follow-up UX polish for gallery emoji reactions (after #155).

## Why

Mobile long-press opened the tray but released too early — users could not tap an emoji. Emojis were also selectable as text on some devices.

## What changed

- Long-press: tray stays open after finger lift until emoji tap or outside tap
- Touch: fix pointer handling so emoji picks update local state
- `select-none` + `-webkit-touch-callout: none` on reaction glyphs
- Extract `applyReactionOptimistic` in `gallery-card` (no behavior change for signed-in saves)

## Test plan

- [x] `bun run typecheck --filter=gallery`
- [x] `bun run lint --filter=gallery`
- [x] `bun run build --filter=gallery`
- [x] Mobile: long-press → release → tap emoji → count updates (signed in)
- [x] Tap outside dismisses tray without reacting

## Screenshots

<!-- 可貼手機長按選單截圖 -->

## Breaking changes

無