### PR TITLE
test: close test blind spot (mcp/ui test scripts) + refresh CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,16 @@ bun run dev --filter=portal         # portal only
 turbo run typecheck --filter=portal # bypass the bun wrapper, call turbo directly
 ```
 
-No test runner. Don't add one without asking.
+### Testing
+
+Bun's built-in test runner (`bun test`) — no vitest/jest. Tests are colocated `*.test.ts` next to the code they cover, importing from `bun:test` and the workspace `@/` alias. `bun run test` → `turbo test` fans out to every workspace that defines a `test` script.
+
+```bash
+bun run test                     # all workspaces (turbo test)
+cd apps/portal && bun test       # one workspace
+```
+
+Keep the pure logic in `lib/` (no React, no Supabase I/O) — that's what's unit-testable. RLS / SECURITY DEFINER policies are tested separately against Postgres (pgTAP), not by `bun test`. Strategy + roadmap: `docs/ci-testing-strategy.md`.
 
 ### Git hooks (husky)
 

--- a/apps/mcp/lib/auth/pkce.test.ts
+++ b/apps/mcp/lib/auth/pkce.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test"
+
+import { verifyPkce } from "@/lib/auth/pkce"
+
+// RFC 7636 Appendix B canonical S256 example — locks the exact
+// sha256 + base64url encoding so a digest/encoding regression is caught.
+const RFC_VERIFIER = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+const RFC_CHALLENGE = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+describe("verifyPkce", () => {
+  test("accepts the RFC 7636 verifier/challenge pair", () => {
+    expect(verifyPkce(RFC_VERIFIER, RFC_CHALLENGE)).toBe(true)
+  })
+
+  test("rejects a mismatched challenge", () => {
+    expect(verifyPkce(RFC_VERIFIER, "wrong-challenge")).toBe(false)
+  })
+
+  test("rejects an empty challenge", () => {
+    expect(verifyPkce(RFC_VERIFIER, "")).toBe(false)
+  })
+})

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",
+    "@types/bun": "^1.3.13",
     "@types/node": "^25.1.0",
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19.2.3",

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -9,7 +9,8 @@
     "start": "next start --port 3001",
     "lint": "eslint",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/bun.lock
+++ b/bun.lock
@@ -67,6 +67,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.18",
+        "@types/bun": "^1.3.13",
         "@types/node": "^25.1.0",
         "@types/react": "^19.2.10",
         "@types/react-dom": "^19.2.3",
@@ -156,6 +157,7 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.18",
         "@turbo/gen": "^2.8.1",
+        "@types/bun": "^1.3.13",
         "@types/node": "^25.1.0",
         "@types/react": "^19.2.10",
         "@types/react-dom": "^19.2.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "lint": "eslint",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
   },
   "dependencies": {
     "@tabler/icons-react": "^3.41.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",
     "@turbo/gen": "^2.8.1",
+    "@types/bun": "^1.3.13",
     "@types/node": "^25.1.0",
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19.2.3",

--- a/packages/ui/src/lib/utils.test.ts
+++ b/packages/ui/src/lib/utils.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test"
+
+import { cn } from "./utils"
+
+describe("cn", () => {
+  test("merges conflicting tailwind classes, last wins", () => {
+    expect(cn("p-2", "p-4")).toBe("p-4")
+  })
+
+  test("drops falsy values and keeps the rest", () => {
+    expect(cn("a", false && "b", undefined, "c")).toBe("a c")
+  })
+})


### PR DESCRIPTION
Closes #158

## Summary

`bun test` exits 0 on a workspace with zero test files (verified), and `apps/mcp` + `packages/ui` had no `test` script — so `turbo test` silently skipped them. This brings both into the test graph.

- Add `"test": "bun test"` to `apps/mcp` and `packages/ui`.
- `apps/mcp/lib/auth/pkce.test.ts` — `verifyPkce` against the RFC 7636 Appendix B S256 vector (proves the `@/` alias + runner wiring, locks the PKCE encoding).
- `packages/ui/src/lib/utils.test.ts` — `cn()` tailwind-merge behavior.
- `CLAUDE.md`: replace the stale "No test runner. Don't add one without asking." with the actual Bun-test posture + pointer to `docs/ci-testing-strategy.md`.

Part of the CI testing overhaul (epic #161).

## Test plan
- [x] `bun run test` → 4 workspaces successful (portal 26, gallery, mcp 3, ui 2); mcp + ui now included.