### PR TITLE
test: P1 pure-logic unit tests (354 cases) + extract security guards for testability

### DIFF
--- a/apps/gallery/app/upload/actions.ts
+++ b/apps/gallery/app/upload/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache"
 
-import { ALLOWED_MIME, inferMimeFromFilename } from "@/lib/gallery/mime"
+import { isValidClientObjectPath } from "@/lib/gallery/object-path"
 import { createClient } from "@/lib/supabase/server"
 
 export type ActionResult = { ok: true } | { ok: false; error: string }
@@ -167,26 +167,4 @@ export async function renameGalleryImage(
   revalidatePath("/")
   revalidatePath("/upload")
   return { ok: true }
-}
-
-const UUID_FILE_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.([a-z0-9]{2,5})$/i
-
-function isValidClientObjectPath(
-  path: string,
-  userId: string,
-  opts: { imageOnly?: boolean } = {}
-): boolean {
-  if (!path.startsWith(`${userId}/`)) return false
-  const rest = path.slice(userId.length + 1)
-  if (!rest || rest.includes("/") || rest.includes("..")) return false
-
-  const m = rest.match(UUID_FILE_RE)
-  if (!m?.[1]) return false
-  const ext = m[1].toLowerCase()
-  const pseudoMime =
-    ext === "jpg" ? "image/jpeg" : inferMimeFromFilename(`x.${ext}`)
-  if (!pseudoMime || !ALLOWED_MIME.has(pseudoMime)) return false
-  if (opts.imageOnly && !pseudoMime.startsWith("image/")) return false
-  return true
 }

--- a/apps/gallery/lib/gallery/object-path.test.ts
+++ b/apps/gallery/lib/gallery/object-path.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test"
+
+import { isValidClientObjectPath } from "@/lib/gallery/object-path"
+
+const UID = "11111111-1111-4111-8111-111111111111"
+const OTHER = "22222222-2222-4222-8222-222222222222"
+const FILE_UUID = "0a1b2c3d-4e5f-4a6b-8c7d-9e0f1a2b3c4d"
+
+describe("isValidClientObjectPath", () => {
+  test("accepts a real <ownUid>/<uuid>.<ext> under the caller's id", () => {
+    expect(isValidClientObjectPath(`${UID}/${FILE_UUID}.jpg`, UID)).toBe(true)
+    expect(isValidClientObjectPath(`${UID}/${FILE_UUID}.png`, UID)).toBe(true)
+    expect(isValidClientObjectPath(`${UID}/${FILE_UUID}.mp4`, UID)).toBe(true)
+  })
+
+  test("rejects a path under another user's prefix", () => {
+    expect(isValidClientObjectPath(`${OTHER}/${FILE_UUID}.jpg`, UID)).toBe(
+      false
+    )
+  })
+
+  test("rejects a bare path with no leading <uid>/ prefix", () => {
+    expect(isValidClientObjectPath(`${FILE_UUID}.jpg`, UID)).toBe(false)
+  })
+
+  test("rejects '..' traversal inside the filename segment", () => {
+    expect(isValidClientObjectPath(`${UID}/..`, UID)).toBe(false)
+    expect(isValidClientObjectPath(`${UID}/..${FILE_UUID}.jpg`, UID)).toBe(
+      false
+    )
+  })
+
+  test("rejects a nested '/' path (more than one segment after the prefix)", () => {
+    expect(isValidClientObjectPath(`${UID}/sub/${FILE_UUID}.jpg`, UID)).toBe(
+      false
+    )
+  })
+
+  test("rejects an empty segment after the prefix", () => {
+    expect(isValidClientObjectPath(`${UID}/`, UID)).toBe(false)
+  })
+
+  test("rejects a filename that is not a uuid shape", () => {
+    expect(isValidClientObjectPath(`${UID}/not-a-uuid.jpg`, UID)).toBe(false)
+    expect(isValidClientObjectPath(`${UID}/${FILE_UUID}xx.jpg`, UID)).toBe(
+      false
+    )
+  })
+
+  test("rejects a uuid with no extension", () => {
+    expect(isValidClientObjectPath(`${UID}/${FILE_UUID}`, UID)).toBe(false)
+  })
+
+  test("rejects a uuid with a disallowed extension", () => {
+    expect(isValidClientObjectPath(`${UID}/${FILE_UUID}.exe`, UID)).toBe(false)
+    expect(isValidClientObjectPath(`${UID}/${FILE_UUID}.mp3`, UID)).toBe(false)
+  })
+
+  test("imageOnly accepts an image extension", () => {
+    expect(
+      isValidClientObjectPath(`${UID}/${FILE_UUID}.png`, UID, {
+        imageOnly: true,
+      })
+    ).toBe(true)
+  })
+
+  test("imageOnly rejects a video extension that is otherwise allowed", () => {
+    expect(isValidClientObjectPath(`${UID}/${FILE_UUID}.mp4`, UID)).toBe(true)
+    expect(
+      isValidClientObjectPath(`${UID}/${FILE_UUID}.mp4`, UID, {
+        imageOnly: true,
+      })
+    ).toBe(false)
+  })
+})

--- a/apps/gallery/lib/gallery/object-path.ts
+++ b/apps/gallery/lib/gallery/object-path.ts
@@ -1,0 +1,29 @@
+import { ALLOWED_MIME, inferMimeFromFilename } from "@/lib/gallery/mime"
+
+const UUID_FILE_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.([a-z0-9]{2,5})$/i
+
+/**
+ * Guards a browser-supplied storage object path before we trust it server-side:
+ * it must live under the caller's own `${userId}/` prefix, be a single path
+ * segment (no nested dirs, no `..` traversal), match the `<uuid>.<ext>` shape
+ * the client writes, and carry an allowed media extension.
+ */
+export function isValidClientObjectPath(
+  path: string,
+  userId: string,
+  opts: { imageOnly?: boolean } = {}
+): boolean {
+  if (!path.startsWith(`${userId}/`)) return false
+  const rest = path.slice(userId.length + 1)
+  if (!rest || rest.includes("/") || rest.includes("..")) return false
+
+  const m = rest.match(UUID_FILE_RE)
+  if (!m?.[1]) return false
+  const ext = m[1].toLowerCase()
+  const pseudoMime =
+    ext === "jpg" ? "image/jpeg" : inferMimeFromFilename(`x.${ext}`)
+  if (!pseudoMime || !ALLOWED_MIME.has(pseudoMime)) return false
+  if (opts.imageOnly && !pseudoMime.startsWith("image/")) return false
+  return true
+}

--- a/apps/gallery/lib/gallery/reactions-aggregate.test.ts
+++ b/apps/gallery/lib/gallery/reactions-aggregate.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  aggregateReactions,
+  EMPTY_REACTION_COUNTS,
+  EMPTY_REACTION_NAMES,
+} from "@/lib/gallery/reactions"
+
+type VoteRow = { image_id: string; user_id: string; reaction: string }
+
+describe("aggregateReactions", () => {
+  test("returns empty maps for no rows", () => {
+    const { countsByImage, namesByImage } = aggregateReactions([], new Map())
+    expect(countsByImage.size).toBe(0)
+    expect(namesByImage.size).toBe(0)
+  })
+
+  test("counts a single reaction and records the voter name", () => {
+    const rows: VoteRow[] = [
+      { image_id: "img1", user_id: "u1", reaction: "like" },
+    ]
+    const names = new Map([["u1", "Alice"]])
+    const { countsByImage, namesByImage } = aggregateReactions(rows, names)
+
+    expect(countsByImage.get("img1")).toEqual({
+      ...EMPTY_REACTION_COUNTS,
+      like: 1,
+    })
+    expect(namesByImage.get("img1")).toEqual({
+      ...EMPTY_REACTION_NAMES,
+      like: ["Alice"],
+    })
+  })
+
+  test("accumulates multiple voters for the same image + reaction", () => {
+    const rows: VoteRow[] = [
+      { image_id: "img1", user_id: "u1", reaction: "love" },
+      { image_id: "img1", user_id: "u2", reaction: "love" },
+    ]
+    const names = new Map([
+      ["u1", "Alice"],
+      ["u2", "Bob"],
+    ])
+    const { countsByImage, namesByImage } = aggregateReactions(rows, names)
+
+    expect(countsByImage.get("img1")?.love).toBe(2)
+    expect(namesByImage.get("img1")?.love).toEqual(["Alice", "Bob"])
+  })
+
+  test("preserves voter-name order as rows are seen", () => {
+    const rows: VoteRow[] = [
+      { image_id: "img1", user_id: "u2", reaction: "haha" },
+      { image_id: "img1", user_id: "u1", reaction: "haha" },
+    ]
+    const names = new Map([
+      ["u1", "Alice"],
+      ["u2", "Bob"],
+    ])
+    const { namesByImage } = aggregateReactions(rows, names)
+
+    expect(namesByImage.get("img1")?.haha).toEqual(["Bob", "Alice"])
+  })
+
+  test("separates counts and names across different images", () => {
+    const rows: VoteRow[] = [
+      { image_id: "img1", user_id: "u1", reaction: "like" },
+      { image_id: "img2", user_id: "u2", reaction: "wow" },
+    ]
+    const names = new Map([
+      ["u1", "Alice"],
+      ["u2", "Bob"],
+    ])
+    const { countsByImage, namesByImage } = aggregateReactions(rows, names)
+
+    expect(countsByImage.size).toBe(2)
+    expect(countsByImage.get("img1")?.like).toBe(1)
+    expect(countsByImage.get("img2")?.wow).toBe(1)
+    expect(namesByImage.get("img1")?.like).toEqual(["Alice"])
+    expect(namesByImage.get("img2")?.wow).toEqual(["Bob"])
+  })
+
+  test("separates counts across different reactions on one image", () => {
+    const rows: VoteRow[] = [
+      { image_id: "img1", user_id: "u1", reaction: "like" },
+      { image_id: "img1", user_id: "u2", reaction: "angry" },
+      { image_id: "img1", user_id: "u3", reaction: "point" },
+    ]
+    const names = new Map([
+      ["u1", "Alice"],
+      ["u2", "Bob"],
+      ["u3", "Carol"],
+    ])
+    const { countsByImage, namesByImage } = aggregateReactions(rows, names)
+
+    expect(countsByImage.get("img1")).toEqual({
+      ...EMPTY_REACTION_COUNTS,
+      like: 1,
+      angry: 1,
+      point: 1,
+    })
+    expect(namesByImage.get("img1")?.like).toEqual(["Alice"])
+    expect(namesByImage.get("img1")?.angry).toEqual(["Bob"])
+    expect(namesByImage.get("img1")?.point).toEqual(["Carol"])
+  })
+
+  test("skips unknown reactions entirely (no map entry created)", () => {
+    const rows: VoteRow[] = [
+      { image_id: "img1", user_id: "u1", reaction: "fire" },
+    ]
+    const names = new Map([["u1", "Alice"]])
+    const { countsByImage, namesByImage } = aggregateReactions(rows, names)
+
+    expect(countsByImage.has("img1")).toBe(false)
+    expect(namesByImage.has("img1")).toBe(false)
+    expect(countsByImage.size).toBe(0)
+    expect(namesByImage.size).toBe(0)
+  })
+
+  test("keeps valid reactions while dropping unknown ones on the same image", () => {
+    const rows: VoteRow[] = [
+      { image_id: "img1", user_id: "u1", reaction: "like" },
+      { image_id: "img1", user_id: "u2", reaction: "fire" },
+      { image_id: "img1", user_id: "u3", reaction: "sad" },
+    ]
+    const names = new Map([
+      ["u1", "Alice"],
+      ["u2", "Bob"],
+      ["u3", "Carol"],
+    ])
+    const { countsByImage, namesByImage } = aggregateReactions(rows, names)
+
+    expect(countsByImage.get("img1")).toEqual({
+      ...EMPTY_REACTION_COUNTS,
+      like: 1,
+      sad: 1,
+    })
+    expect(namesByImage.get("img1")?.like).toEqual(["Alice"])
+    expect(namesByImage.get("img1")?.sad).toEqual(["Carol"])
+    // Bob's unknown "fire" leaves no trace anywhere
+    expect(namesByImage.get("img1")?.angry).toEqual([])
+  })
+
+  test("falls back to 'Unknown' when the voter id is missing from the name map", () => {
+    const rows: VoteRow[] = [
+      { image_id: "img1", user_id: "ghost", reaction: "love" },
+    ]
+    const { countsByImage, namesByImage } = aggregateReactions(rows, new Map())
+
+    expect(countsByImage.get("img1")?.love).toBe(1)
+    expect(namesByImage.get("img1")?.love).toEqual(["Unknown"])
+  })
+
+  test("mixes known and unknown voter names in the same reaction list", () => {
+    const rows: VoteRow[] = [
+      { image_id: "img1", user_id: "u1", reaction: "wow" },
+      { image_id: "img1", user_id: "ghost", reaction: "wow" },
+    ]
+    const names = new Map([["u1", "Alice"]])
+    const { namesByImage } = aggregateReactions(rows, names)
+
+    expect(namesByImage.get("img1")?.wow).toEqual(["Alice", "Unknown"])
+  })
+
+  test("name list length tracks the count for that reaction", () => {
+    const rows: VoteRow[] = [
+      { image_id: "img1", user_id: "u1", reaction: "like" },
+      { image_id: "img1", user_id: "u2", reaction: "like" },
+      { image_id: "img1", user_id: "u3", reaction: "like" },
+    ]
+    const names = new Map([
+      ["u1", "Alice"],
+      ["u2", "Bob"],
+      ["u3", "Carol"],
+    ])
+    const { countsByImage, namesByImage } = aggregateReactions(rows, names)
+
+    const count = countsByImage.get("img1")!.like
+    expect(count).toBe(3)
+    expect(namesByImage.get("img1")!.like).toHaveLength(count)
+  })
+
+  test("counts the same user twice if they appear in two rows (no dedupe)", () => {
+    const rows: VoteRow[] = [
+      { image_id: "img1", user_id: "u1", reaction: "like" },
+      { image_id: "img1", user_id: "u1", reaction: "like" },
+    ]
+    const names = new Map([["u1", "Alice"]])
+    const { countsByImage, namesByImage } = aggregateReactions(rows, names)
+
+    expect(countsByImage.get("img1")?.like).toBe(2)
+    expect(namesByImage.get("img1")?.like).toEqual(["Alice", "Alice"])
+  })
+
+  test("does not mutate the shared EMPTY_REACTION_COUNTS / EMPTY_REACTION_NAMES singletons", () => {
+    const rows: VoteRow[] = [
+      { image_id: "img1", user_id: "u1", reaction: "like" },
+    ]
+    aggregateReactions(rows, new Map([["u1", "Alice"]]))
+
+    expect(EMPTY_REACTION_COUNTS.like).toBe(0)
+    expect(EMPTY_REACTION_NAMES.like).toEqual([])
+  })
+})

--- a/apps/gallery/lib/gallery/rotation.test.ts
+++ b/apps/gallery/lib/gallery/rotation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+
+import { getRotation } from "./rotation"
+
+describe("getRotation", () => {
+  test("is deterministic — same id, same angle (hydration-stable)", () => {
+    expect(getRotation("abc")).toBe(getRotation("abc"))
+    const uuid = "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+    expect(getRotation(uuid)).toBe(getRotation(uuid))
+  })
+
+  test("stays within ±5 degrees across a sample of ids", () => {
+    const ids = [
+      "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+      "00000000-0000-0000-0000-000000000000",
+      "ffffffff-ffff-ffff-ffff-ffffffffffff",
+      "deadbeef-cafe-babe-0000-000000000000",
+    ]
+    for (const id of ids) {
+      expect(Math.abs(getRotation(id))).toBeLessThanOrEqual(5)
+    }
+  })
+
+  test("a fully non-hex id exercises the fallback hash and stays finite & in range", () => {
+    const r = getRotation("gggggggg")
+    expect(Number.isFinite(r)).toBe(true)
+    expect(Math.abs(r)).toBeLessThanOrEqual(5)
+  })
+
+  test("rounds to at most two decimal places", () => {
+    const r = getRotation("3f2504e0-4f89-41d3-9a0c-0305e82c3301")
+    expect(Number(r.toFixed(2))).toBe(r)
+  })
+})

--- a/apps/mcp/lib/auth/oauth-clients.test.ts
+++ b/apps/mcp/lib/auth/oauth-clients.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  getOAuthClient,
+  getRedirectUriMatch,
+  registerOAuthClient,
+  type OAuthClientRow,
+  type OAuthClientStore,
+} from "@/lib/auth/oauth-clients"
+
+function fakeStore(seed: OAuthClientRow[] = []) {
+  const rows: OAuthClientRow[] = [...seed]
+  const store: OAuthClientStore = {
+    async insert(row) {
+      rows.push(row)
+    },
+    async selectById(clientId) {
+      return rows.find((r) => r.client_id === clientId) ?? null
+    },
+  }
+  return { store, rows }
+}
+
+const sampleClient: OAuthClientRow = {
+  client_id: "client-abc",
+  client_name: "Test Client",
+  redirect_uris: ["https://app.example.com/callback"],
+  grant_types: ["authorization_code"],
+  response_types: ["code"],
+}
+
+describe("registerOAuthClient", () => {
+  test("forces token_endpoint_auth_method to 'none' (public client)", async () => {
+    const { store } = fakeStore()
+    const client = await registerOAuthClient(
+      { redirect_uris: ["https://app.example.com/callback"] },
+      store
+    )
+    expect(client.token_endpoint_auth_method).toBe("none")
+  })
+
+  test("defaults grant_types, response_types and client_name", async () => {
+    const { store } = fakeStore()
+    const client = await registerOAuthClient(
+      { redirect_uris: ["https://app.example.com/callback"] },
+      store
+    )
+
+    expect(client.grant_types).toEqual(["authorization_code", "refresh_token"])
+    expect(client.response_types).toEqual(["code"])
+    expect(client.client_name).toBe("MCP Client")
+  })
+
+  test("generates a UUID client_id", async () => {
+    const { store } = fakeStore()
+    const client = await registerOAuthClient(
+      { redirect_uris: ["https://app.example.com/callback"] },
+      store
+    )
+    expect(client.client_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    )
+  })
+
+  test("honours an explicit client_name and grant_types", async () => {
+    const { store } = fakeStore()
+    const client = await registerOAuthClient(
+      {
+        client_name: "My App",
+        redirect_uris: ["https://app.example.com/callback"],
+        grant_types: ["authorization_code"],
+      },
+      store
+    )
+    expect(client.client_name).toBe("My App")
+    expect(client.grant_types).toEqual(["authorization_code"])
+  })
+
+  test("persists the client (with created_at) via the store", async () => {
+    const { store, rows } = fakeStore()
+    const client = await registerOAuthClient(
+      { redirect_uris: ["https://app.example.com/callback"] },
+      store
+    )
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.client_id).toBe(client.client_id)
+    expect(typeof rows[0]!.created_at).toBe("string")
+  })
+
+  test("returned object does not carry created_at (only the stored row does)", async () => {
+    const { store } = fakeStore()
+    const client = await registerOAuthClient(
+      { redirect_uris: ["https://app.example.com/callback"] },
+      store
+    )
+    expect("created_at" in client).toBe(false)
+  })
+
+  test("rejects registration with no redirect_uris", async () => {
+    const { store } = fakeStore()
+    await expect(
+      registerOAuthClient({ redirect_uris: [] }, store)
+    ).rejects.toThrow()
+  })
+
+  test("rejects a non-URL redirect_uri", async () => {
+    const { store } = fakeStore()
+    await expect(
+      registerOAuthClient({ redirect_uris: ["not-a-url"] }, store)
+    ).rejects.toThrow()
+  })
+})
+
+describe("getOAuthClient", () => {
+  test("returns the row from the store when present", async () => {
+    const { store } = fakeStore([sampleClient])
+    const client = await getOAuthClient("client-abc", store)
+    expect(client?.client_id).toBe("client-abc")
+  })
+
+  test("returns null when the client is unknown", async () => {
+    const { store } = fakeStore([sampleClient])
+    expect(await getOAuthClient("nope", store)).toBeNull()
+  })
+})
+
+describe("getRedirectUriMatch", () => {
+  test("returns the redirect_uri on an exact allowlist match", async () => {
+    const { store } = fakeStore([sampleClient])
+    const match = await getRedirectUriMatch(
+      "client-abc",
+      "https://app.example.com/callback",
+      store
+    )
+    expect(match).toBe("https://app.example.com/callback")
+  })
+
+  test("returns null on a trailing-slash mismatch (exact match only)", async () => {
+    const { store } = fakeStore([sampleClient])
+    const match = await getRedirectUriMatch(
+      "client-abc",
+      "https://app.example.com/callback/",
+      store
+    )
+    expect(match).toBeNull()
+  })
+
+  test("returns null when the client is unknown", async () => {
+    const { store } = fakeStore([sampleClient])
+    const match = await getRedirectUriMatch(
+      "missing",
+      "https://app.example.com/callback",
+      store
+    )
+    expect(match).toBeNull()
+  })
+})

--- a/apps/mcp/lib/auth/oauth-metadata.test.ts
+++ b/apps/mcp/lib/auth/oauth-metadata.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test"
+
+import { getOAuthMetadata } from "@/lib/auth/oauth-metadata"
+import { getProtectedResourceMetadata } from "@/lib/auth/protected-resource-metadata"
+
+describe("getOAuthMetadata", () => {
+  const meta = getOAuthMetadata("https://mcp.winlab.tw")
+
+  test("issuer is the base url", () => {
+    expect(meta.issuer).toBe("https://mcp.winlab.tw")
+  })
+
+  test("derives the endpoints from the base url", () => {
+    expect(meta.authorization_endpoint).toBe(
+      "https://mcp.winlab.tw/oauth/authorize"
+    )
+    expect(meta.token_endpoint).toBe("https://mcp.winlab.tw/oauth/token")
+    expect(meta.registration_endpoint).toBe(
+      "https://mcp.winlab.tw/oauth/register"
+    )
+  })
+
+  test("advertises S256 as the only PKCE challenge method", () => {
+    expect(meta.code_challenge_methods_supported).toEqual(["S256"])
+  })
+
+  test("advertises 'none' as the only token endpoint auth method", () => {
+    expect(meta.token_endpoint_auth_methods_supported).toEqual(["none"])
+  })
+
+  test("advertises code response type and authz_code + refresh grants", () => {
+    expect(meta.response_types_supported).toEqual(["code"])
+    expect(meta.grant_types_supported).toEqual([
+      "authorization_code",
+      "refresh_token",
+    ])
+  })
+})
+
+describe("getProtectedResourceMetadata", () => {
+  const prm = getProtectedResourceMetadata("https://mcp.winlab.tw")
+
+  test("resource points at the /mcp resource url", () => {
+    expect(prm.resource).toBe("https://mcp.winlab.tw/mcp")
+  })
+
+  test("authorization_servers lists the base url", () => {
+    expect(prm.authorization_servers).toEqual(["https://mcp.winlab.tw"])
+  })
+
+  test("bearer tokens are accepted via the Authorization header", () => {
+    expect(prm.bearer_methods_supported).toEqual(["header"])
+  })
+})

--- a/apps/mcp/lib/auth/oauth-request.test.ts
+++ b/apps/mcp/lib/auth/oauth-request.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, test } from "bun:test"
+
+import type { OAuthClientRow, OAuthClientStore } from "@/lib/auth/oauth-clients"
+import {
+  parseAuthorizeRequest,
+  parseTokenAuthorizationCodeRequest,
+  validateOAuthClientRequest,
+} from "@/lib/auth/oauth-request"
+
+function fakeStore(rows: OAuthClientRow[]): OAuthClientStore {
+  return {
+    async insert() {},
+    async selectById(clientId) {
+      return rows.find((r) => r.client_id === clientId) ?? null
+    },
+  }
+}
+
+const baseClient: OAuthClientRow = {
+  client_id: "client-abc",
+  client_name: "Test Client",
+  redirect_uris: ["https://app.example.com/callback"],
+  grant_types: ["authorization_code"],
+  response_types: ["code"],
+}
+
+describe("parseAuthorizeRequest", () => {
+  test("maps snake_case params to camelCase fields", () => {
+    const params = new URLSearchParams({
+      client_id: "client-abc",
+      redirect_uri: "https://app.example.com/callback",
+      response_type: "code",
+      code_challenge: "abc123",
+      code_challenge_method: "S256",
+      resource: "https://mcp.winlab.tw/mcp",
+      state: "xyz",
+    })
+
+    expect(parseAuthorizeRequest(params)).toEqual({
+      clientId: "client-abc",
+      redirectUri: "https://app.example.com/callback",
+      responseType: "code",
+      codeChallenge: "abc123",
+      codeChallengeMethod: "S256",
+      resource: "https://mcp.winlab.tw/mcp",
+      state: "xyz",
+    })
+  })
+
+  test("resource and state are optional", () => {
+    const params = new URLSearchParams({
+      client_id: "client-abc",
+      redirect_uri: "https://app.example.com/callback",
+      response_type: "code",
+      code_challenge: "abc123",
+      code_challenge_method: "S256",
+    })
+
+    const result = parseAuthorizeRequest(params)
+    expect(result.resource).toBeUndefined()
+    expect(result.state).toBeUndefined()
+  })
+
+  test("rejects a response_type downgrade away from 'code'", () => {
+    const params = new URLSearchParams({
+      client_id: "client-abc",
+      redirect_uri: "https://app.example.com/callback",
+      response_type: "token",
+      code_challenge: "abc123",
+      code_challenge_method: "S256",
+    })
+
+    expect(() => parseAuthorizeRequest(params)).toThrow()
+  })
+
+  test("rejects a code_challenge_method downgrade away from 'S256'", () => {
+    const params = new URLSearchParams({
+      client_id: "client-abc",
+      redirect_uri: "https://app.example.com/callback",
+      response_type: "code",
+      code_challenge: "abc123",
+      code_challenge_method: "plain",
+    })
+
+    expect(() => parseAuthorizeRequest(params)).toThrow()
+  })
+
+  test("rejects a non-URL redirect_uri", () => {
+    const params = new URLSearchParams({
+      client_id: "client-abc",
+      redirect_uri: "not-a-url",
+      response_type: "code",
+      code_challenge: "abc123",
+      code_challenge_method: "S256",
+    })
+
+    expect(() => parseAuthorizeRequest(params)).toThrow()
+  })
+
+  test("rejects an empty code_challenge", () => {
+    const params = new URLSearchParams({
+      client_id: "client-abc",
+      redirect_uri: "https://app.example.com/callback",
+      response_type: "code",
+      code_challenge: "",
+      code_challenge_method: "S256",
+    })
+
+    expect(() => parseAuthorizeRequest(params)).toThrow()
+  })
+})
+
+describe("parseTokenAuthorizationCodeRequest", () => {
+  function form(fields: Record<string, string>): FormData {
+    const fd = new FormData()
+    for (const [k, v] of Object.entries(fields)) fd.set(k, v)
+    return fd
+  }
+
+  test("maps form fields to camelCase, resource omitted -> undefined", () => {
+    const result = parseTokenAuthorizationCodeRequest(
+      form({
+        code: "auth-code",
+        code_verifier: "verifier",
+        client_id: "client-abc",
+        redirect_uri: "https://app.example.com/callback",
+      })
+    )
+
+    expect(result).toEqual({
+      code: "auth-code",
+      codeVerifier: "verifier",
+      clientId: "client-abc",
+      redirectUri: "https://app.example.com/callback",
+      resource: undefined,
+    })
+  })
+
+  test("carries resource through when present", () => {
+    const result = parseTokenAuthorizationCodeRequest(
+      form({
+        code: "auth-code",
+        code_verifier: "verifier",
+        client_id: "client-abc",
+        redirect_uri: "https://app.example.com/callback",
+        resource: "https://mcp.winlab.tw/mcp",
+      })
+    )
+
+    expect(result.resource).toBe("https://mcp.winlab.tw/mcp")
+  })
+
+  test("rejects a missing required field", () => {
+    expect(() =>
+      parseTokenAuthorizationCodeRequest(
+        form({
+          code: "auth-code",
+          client_id: "client-abc",
+          redirect_uri: "https://app.example.com/callback",
+        })
+      )
+    ).toThrow()
+  })
+
+  test("rejects a non-URL redirect_uri", () => {
+    expect(() =>
+      parseTokenAuthorizationCodeRequest(
+        form({
+          code: "auth-code",
+          code_verifier: "verifier",
+          client_id: "client-abc",
+          redirect_uri: "nope",
+        })
+      )
+    ).toThrow()
+  })
+})
+
+describe("validateOAuthClientRequest", () => {
+  test("returns the client when client_id, redirect_uri and resource all match", async () => {
+    const client = await validateOAuthClientRequest(
+      {
+        clientId: "client-abc",
+        redirectUri: "https://app.example.com/callback",
+        resource: "https://mcp.winlab.tw/mcp",
+      },
+      {
+        expectedResource: "https://mcp.winlab.tw/mcp",
+        store: fakeStore([baseClient]),
+      }
+    )
+
+    expect(client.client_id).toBe("client-abc")
+  })
+
+  test("throws Unknown client_id when the store has no such client", async () => {
+    await expect(
+      validateOAuthClientRequest(
+        {
+          clientId: "missing",
+          redirectUri: "https://app.example.com/callback",
+        },
+        { expectedResource: "https://mcp.winlab.tw/mcp", store: fakeStore([]) }
+      )
+    ).rejects.toThrow("Unknown client_id")
+  })
+
+  test("throws Invalid redirect_uri when redirect is not in the allowlist", async () => {
+    await expect(
+      validateOAuthClientRequest(
+        {
+          clientId: "client-abc",
+          redirectUri: "https://evil.example.com/callback",
+        },
+        {
+          expectedResource: "https://mcp.winlab.tw/mcp",
+          store: fakeStore([baseClient]),
+        }
+      )
+    ).rejects.toThrow("Invalid redirect_uri")
+  })
+
+  test("throws Invalid resource when resource does not match expectedResource", async () => {
+    await expect(
+      validateOAuthClientRequest(
+        {
+          clientId: "client-abc",
+          redirectUri: "https://app.example.com/callback",
+          resource: "https://other.example.com/mcp",
+        },
+        {
+          expectedResource: "https://mcp.winlab.tw/mcp",
+          store: fakeStore([baseClient]),
+        }
+      )
+    ).rejects.toThrow("Invalid resource")
+  })
+
+  test("skips the resource check when no resource is supplied", async () => {
+    const client = await validateOAuthClientRequest(
+      {
+        clientId: "client-abc",
+        redirectUri: "https://app.example.com/callback",
+      },
+      {
+        expectedResource: "https://mcp.winlab.tw/mcp",
+        store: fakeStore([baseClient]),
+      }
+    )
+
+    expect(client.client_id).toBe("client-abc")
+  })
+
+  test("redirect_uri match is exact — a trailing slash is rejected", async () => {
+    await expect(
+      validateOAuthClientRequest(
+        {
+          clientId: "client-abc",
+          redirectUri: "https://app.example.com/callback/",
+        },
+        {
+          expectedResource: "https://mcp.winlab.tw/mcp",
+          store: fakeStore([baseClient]),
+        }
+      )
+    ).rejects.toThrow("Invalid redirect_uri")
+  })
+})

--- a/apps/mcp/lib/auth/urls.test.ts
+++ b/apps/mcp/lib/auth/urls.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+
+import {
+  getBaseUrl,
+  getMcpResourceUrl,
+  getProtectedResourceMetadataUrl,
+} from "@/lib/auth/urls"
+
+const DEFAULT_BASE_URL = "https://mcp.winlab.tw"
+
+describe("getBaseUrl", () => {
+  let original: string | undefined
+
+  beforeEach(() => {
+    original = process.env.NEXT_PUBLIC_BASE_URL
+  })
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.NEXT_PUBLIC_BASE_URL
+    else process.env.NEXT_PUBLIC_BASE_URL = original
+  })
+
+  test("falls back to the default base url when env is unset", () => {
+    delete process.env.NEXT_PUBLIC_BASE_URL
+    expect(getBaseUrl()).toBe(DEFAULT_BASE_URL)
+  })
+
+  test("reads NEXT_PUBLIC_BASE_URL when set", () => {
+    process.env.NEXT_PUBLIC_BASE_URL = "https://staging.example.com"
+    expect(getBaseUrl()).toBe("https://staging.example.com")
+  })
+
+  test("strips a single trailing slash", () => {
+    process.env.NEXT_PUBLIC_BASE_URL = "https://staging.example.com/"
+    expect(getBaseUrl()).toBe("https://staging.example.com")
+  })
+
+  test("empty env value falls back to the default", () => {
+    process.env.NEXT_PUBLIC_BASE_URL = ""
+    expect(getBaseUrl()).toBe(DEFAULT_BASE_URL)
+  })
+})
+
+describe("getMcpResourceUrl", () => {
+  test("appends /mcp to the supplied base url", () => {
+    expect(getMcpResourceUrl("https://example.com")).toBe(
+      "https://example.com/mcp"
+    )
+  })
+
+  test("defaults to the resolved base url", () => {
+    const original = process.env.NEXT_PUBLIC_BASE_URL
+    delete process.env.NEXT_PUBLIC_BASE_URL
+    try {
+      expect(getMcpResourceUrl()).toBe(`${DEFAULT_BASE_URL}/mcp`)
+    } finally {
+      if (original === undefined) delete process.env.NEXT_PUBLIC_BASE_URL
+      else process.env.NEXT_PUBLIC_BASE_URL = original
+    }
+  })
+})
+
+describe("getProtectedResourceMetadataUrl", () => {
+  test("builds the .well-known PRM url under the base url", () => {
+    expect(getProtectedResourceMetadataUrl("https://example.com")).toBe(
+      "https://example.com/.well-known/oauth-protected-resource/mcp"
+    )
+  })
+})

--- a/apps/portal/app/approve/actions.ts
+++ b/apps/portal/app/approve/actions.ts
@@ -9,6 +9,8 @@ import type { FieldCategory } from "@/lib/approve/types"
 import { validateForSubmit } from "@/lib/approve/validation"
 import { APPROVE_BUCKET, documentStoragePath } from "@/lib/approve/storage"
 import { drainOutboxBatch } from "@/lib/approve/email-drain"
+import { validateUploadPayload } from "@/lib/approve/upload"
+import { computeOrphanedSigners } from "@/lib/approve/signers"
 
 // Fire the outbox drain after the response is sent to the browser. Using
 // `after()` keeps the submit flow fast (user doesn't wait on Resend) while
@@ -32,12 +34,9 @@ async function requireUser() {
 
 export async function uploadPdf(formData: FormData): Promise<void> {
   const user = await requireUser()
-  const documentId = formData.get("documentId")
-  const file = formData.get("file")
-  if (typeof documentId !== "string" || !(file instanceof File)) {
-    throw new Error("bad payload")
-  }
-  if (file.size > 50 * 1024 * 1024) throw new Error("PDF too large (>50MB)")
+  const parsed = validateUploadPayload(formData)
+  if ("error" in parsed) throw new Error(parsed.error)
+  const { documentId, file } = parsed
 
   const supabase = await createClient()
   const { data: doc, error: docErr } = await supabase
@@ -165,9 +164,10 @@ export async function syncSigners(documentId: string): Promise<void> {
     .eq("document_id", documentId)
   if (signersErr) throw new Error(signersErr.message)
 
-  const toRemove = (signers ?? [])
-    .map((s) => s.signer_id)
-    .filter((id) => !stillUsed.has(id))
+  const toRemove = computeOrphanedSigners(
+    [...stillUsed],
+    (signers ?? []).map((s) => s.signer_id)
+  )
 
   if (toRemove.length) {
     const { error } = await supabase

--- a/apps/portal/lib/approve/field-categories.test.ts
+++ b/apps/portal/lib/approve/field-categories.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  FIELD_CATEGORIES,
+  getCategoryDef,
+  isPredefined,
+} from "@/lib/approve/field-categories"
+import type { FieldCategory } from "@/lib/approve/types"
+
+describe("getCategoryDef", () => {
+  test("returns the matching definition for each known category", () => {
+    for (const def of FIELD_CATEGORIES) {
+      expect(getCategoryDef(def.id)).toBe(def)
+    }
+  })
+
+  test("returns a def carrying id, label, icon, predefined, and defaultSize", () => {
+    const def = getCategoryDef("signature")
+    expect(def.id).toBe("signature")
+    expect(def.label).toBe("簽名")
+    expect(def.predefined).toBe(true)
+    expect(def.defaultSize).toEqual({ width: 0.2, height: 0.08 })
+    expect(typeof def.icon).toBe("object")
+  })
+
+  test("throws for an unknown category id", () => {
+    expect(() => getCategoryDef("nope" as FieldCategory)).toThrow(
+      "Unknown field category: nope"
+    )
+  })
+})
+
+describe("isPredefined", () => {
+  test("returns true for every non-other category", () => {
+    const predefined: FieldCategory[] = [
+      "signature",
+      "contact_address",
+      "household_address",
+      "id_number",
+      "phone",
+    ]
+    for (const id of predefined) {
+      expect(isPredefined(id)).toBe(true)
+    }
+  })
+
+  test("returns false only for other", () => {
+    expect(isPredefined("other")).toBe(false)
+  })
+
+  test("agrees with each category def's predefined flag", () => {
+    for (const def of FIELD_CATEGORIES) {
+      expect(isPredefined(def.id)).toBe(def.predefined)
+    }
+  })
+
+  test("other is the only category flagged non-predefined", () => {
+    const nonPredefined = FIELD_CATEGORIES.filter((c) => !c.predefined)
+    expect(nonPredefined.map((c) => c.id)).toEqual(["other"])
+  })
+})

--- a/apps/portal/lib/approve/signers.test.ts
+++ b/apps/portal/lib/approve/signers.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test"
+
+import { computeOrphanedSigners } from "@/lib/approve/signers"
+
+describe("computeOrphanedSigners", () => {
+  test("returns registered signers no longer backed by any field", () => {
+    const fieldSignerIds = ["a", "b"]
+    const registered = ["a", "b", "c", "d"]
+    expect(computeOrphanedSigners(fieldSignerIds, registered)).toEqual([
+      "c",
+      "d",
+    ])
+  })
+
+  test("returns empty when every registered signer is still used", () => {
+    expect(computeOrphanedSigners(["a", "b"], ["a", "b"])).toEqual([])
+  })
+
+  test("returns all registered when no field uses any signer", () => {
+    expect(computeOrphanedSigners([], ["a", "b"])).toEqual(["a", "b"])
+  })
+
+  test("returns empty for an empty registered list", () => {
+    expect(computeOrphanedSigners(["a"], [])).toEqual([])
+  })
+
+  test("preserves the order of the registered list", () => {
+    expect(computeOrphanedSigners(["b"], ["c", "a", "b", "d"])).toEqual([
+      "c",
+      "a",
+      "d",
+    ])
+  })
+
+  test("keeps duplicate orphans (no dedupe on the registered side)", () => {
+    expect(computeOrphanedSigners([], ["a", "a", "b"])).toEqual(["a", "a", "b"])
+  })
+
+  test("ignores extra used ids that are not registered", () => {
+    expect(computeOrphanedSigners(["a", "x", "y"], ["a", "b"])).toEqual(["b"])
+  })
+})

--- a/apps/portal/lib/approve/signers.ts
+++ b/apps/portal/lib/approve/signers.ts
@@ -1,0 +1,12 @@
+/**
+ * Returns the registered signer ids that no longer back any field — the
+ * orphaned `approve_signers` rows that syncSigners should prune. Set-diff:
+ * registered minus still-in-use.
+ */
+export function computeOrphanedSigners(
+  fieldSignerIds: string[],
+  registeredSignerIds: string[]
+): string[] {
+  const stillUsed = new Set(fieldSignerIds)
+  return registeredSignerIds.filter((id) => !stillUsed.has(id))
+}

--- a/apps/portal/lib/approve/upload.test.ts
+++ b/apps/portal/lib/approve/upload.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test"
+
+import { validateUploadPayload } from "@/lib/approve/upload"
+
+function form(entries: Record<string, string | Blob>): FormData {
+  const fd = new FormData()
+  for (const [k, v] of Object.entries(entries)) fd.append(k, v)
+  return fd
+}
+
+describe("validateUploadPayload", () => {
+  test("rejects a missing documentId", () => {
+    const fd = form({ file: new File(["%PDF"], "a.pdf") })
+    expect(validateUploadPayload(fd)).toEqual({ error: "bad payload" })
+  })
+
+  test("rejects a non-File file value (e.g. a plain string field)", () => {
+    const fd = form({ documentId: "doc-1", file: "not-a-file" })
+    expect(validateUploadPayload(fd)).toEqual({ error: "bad payload" })
+  })
+
+  test("rejects a missing file", () => {
+    const fd = form({ documentId: "doc-1" })
+    expect(validateUploadPayload(fd)).toEqual({ error: "bad payload" })
+  })
+
+  test("rejects a file over the 50MB cap (51MB)", () => {
+    const big = new File([new Uint8Array(51 * 1024 * 1024)], "big.pdf")
+    const fd = form({ documentId: "doc-1", file: big })
+    expect(validateUploadPayload(fd)).toEqual({
+      error: "PDF too large (>50MB)",
+    })
+  })
+
+  test("accepts a file exactly at the 50MB boundary (not over)", () => {
+    const exact = new File([new Uint8Array(50 * 1024 * 1024)], "edge.pdf")
+    const fd = form({ documentId: "doc-1", file: exact })
+    const result = validateUploadPayload(fd)
+    expect("error" in result).toBe(false)
+    if (!("error" in result)) {
+      expect(result.documentId).toBe("doc-1")
+      expect(result.file).toBeInstanceOf(File)
+      expect(result.file.size).toBe(50 * 1024 * 1024)
+    }
+  })
+
+  test("returns { documentId, file } for a valid payload", () => {
+    const file = new File(["%PDF-1.4"], "form.pdf", {
+      type: "application/pdf",
+    })
+    const fd = form({ documentId: "doc-42", file })
+    const result = validateUploadPayload(fd)
+    expect("error" in result).toBe(false)
+    if (!("error" in result)) {
+      expect(result.documentId).toBe("doc-42")
+      expect(result.file).toBeInstanceOf(File)
+      expect(result.file.name).toBe("form.pdf")
+    }
+  })
+})

--- a/apps/portal/lib/approve/upload.ts
+++ b/apps/portal/lib/approve/upload.ts
@@ -1,0 +1,24 @@
+export type ValidatedUploadPayload =
+  | { documentId: string; file: File }
+  | { error: string }
+
+const MAX_PDF_BYTES = 50 * 1024 * 1024
+
+/**
+ * Pure parse + size cap for the uploadPdf action's FormData. Returns the
+ * extracted `{ documentId, file }` on success or `{ error }` for a bad payload
+ * / oversized file. The DB ownership + draft-status check stays in the action.
+ */
+export function validateUploadPayload(
+  formData: FormData
+): ValidatedUploadPayload {
+  const documentId = formData.get("documentId")
+  const file = formData.get("file")
+  if (typeof documentId !== "string" || !(file instanceof File)) {
+    return { error: "bad payload" }
+  }
+  if (file.size > MAX_PDF_BYTES) {
+    return { error: "PDF too large (>50MB)" }
+  }
+  return { documentId, file }
+}

--- a/apps/portal/lib/bento/menu.test.ts
+++ b/apps/portal/lib/bento/menu.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test"
+
+import { groupMenuItems, sortMenuItemsByType } from "@/lib/bento/menu"
+
+type Item = { name: string; type?: string | null }
+type PricedItem = Item & { price: number | string }
+
+describe("groupMenuItems", () => {
+  test("groups items by their type", () => {
+    const groups = groupMenuItems<Item>([
+      { name: "a", type: "主食" },
+      { name: "b", type: "飲料" },
+      { name: "c", type: "主食" },
+    ])
+    expect(groups.map((g) => g.type)).toEqual(["主食", "飲料"])
+    expect(groups[0]!.items.map((i) => i.name)).toEqual(["a", "c"])
+    expect(groups[1]!.items.map((i) => i.name)).toEqual(["b"])
+  })
+
+  test("missing, null, or whitespace-only type all fall into 其他", () => {
+    const groups = groupMenuItems<Item>([
+      { name: "a" },
+      { name: "b", type: null },
+      { name: "c", type: "   " },
+      { name: "d", type: "" },
+    ])
+    expect(groups).toHaveLength(1)
+    expect(groups[0]!.type).toBe("其他")
+    expect(groups[0]!.items.map((i) => i.name)).toEqual(["a", "b", "c", "d"])
+  })
+
+  test("trims surrounding whitespace from the type key", () => {
+    const groups = groupMenuItems<Item>([
+      { name: "a", type: "  主食  " },
+      { name: "b", type: "主食" },
+    ])
+    expect(groups).toHaveLength(1)
+    expect(groups[0]!.type).toBe("主食")
+  })
+
+  test("pins 其他 last regardless of localeCompare ordering", () => {
+    const groups = groupMenuItems<Item>([
+      { name: "x", type: "其他" },
+      { name: "y", type: "甜點" },
+      { name: "z", type: "主食" },
+    ])
+    expect(groups.map((g) => g.type)).toEqual(["主食", "甜點", "其他"])
+  })
+
+  test("orders non-其他 groups by localeCompare", () => {
+    const groups = groupMenuItems<Item>([
+      { name: "1", type: "banana" },
+      { name: "2", type: "apple" },
+      { name: "3", type: "cherry" },
+    ])
+    expect(groups.map((g) => g.type)).toEqual(["apple", "banana", "cherry"])
+  })
+
+  test("sorts items inside each group by name via localeCompare", () => {
+    const groups = groupMenuItems<Item>([
+      { name: "charlie", type: "主食" },
+      { name: "alpha", type: "主食" },
+      { name: "bravo", type: "主食" },
+    ])
+    expect(groups[0]!.items.map((i) => i.name)).toEqual([
+      "alpha",
+      "bravo",
+      "charlie",
+    ])
+  })
+
+  test("does not mutate the input array", () => {
+    const input: Item[] = [
+      { name: "b", type: "主食" },
+      { name: "a", type: "主食" },
+    ]
+    groupMenuItems(input)
+    expect(input.map((i) => i.name)).toEqual(["b", "a"])
+  })
+
+  test("returns an empty array for empty input", () => {
+    expect(groupMenuItems<Item>([])).toEqual([])
+  })
+})
+
+describe("sortMenuItemsByType", () => {
+  test("orders by type via localeCompare before price", () => {
+    const sorted = sortMenuItemsByType<PricedItem>([
+      { name: "a", type: "banana", price: 1 },
+      { name: "b", type: "apple", price: 99 },
+    ])
+    expect(sorted.map((i) => i.name)).toEqual(["b", "a"])
+  })
+
+  test("sorts by price ascending within the same type", () => {
+    const sorted = sortMenuItemsByType<PricedItem>([
+      { name: "expensive", type: "主食", price: 100 },
+      { name: "cheap", type: "主食", price: 20 },
+      { name: "mid", type: "主食", price: 50 },
+    ])
+    expect(sorted.map((i) => i.name)).toEqual(["cheap", "mid", "expensive"])
+  })
+
+  test("places empty/missing-type items after typed items", () => {
+    const sorted = sortMenuItemsByType<PricedItem>([
+      { name: "untyped", price: 5 },
+      { name: "typed", type: "主食", price: 999 },
+    ])
+    expect(sorted.map((i) => i.name)).toEqual(["typed", "untyped"])
+  })
+
+  test("treats whitespace-only type as empty (sorts after typed)", () => {
+    const sorted = sortMenuItemsByType<PricedItem>([
+      { name: "blank", type: "   ", price: 1 },
+      { name: "typed", type: "z", price: 1 },
+    ])
+    expect(sorted.map((i) => i.name)).toEqual(["typed", "blank"])
+  })
+
+  test("compares by price when both types are empty", () => {
+    const sorted = sortMenuItemsByType<PricedItem>([
+      { name: "hi", price: 80 },
+      { name: "lo", price: 10 },
+    ])
+    expect(sorted.map((i) => i.name)).toEqual(["lo", "hi"])
+  })
+
+  test("parses numeric string prices for comparison", () => {
+    const sorted = sortMenuItemsByType<PricedItem>([
+      { name: "a", type: "主食", price: "100" },
+      { name: "b", type: "主食", price: "20" },
+    ])
+    expect(sorted.map((i) => i.name)).toEqual(["b", "a"])
+  })
+
+  test("parseFloat reads the leading number of a mixed string price", () => {
+    const sorted = sortMenuItemsByType<PricedItem>([
+      { name: "a", type: "主食", price: "12.5元" },
+      { name: "b", type: "主食", price: "3元" },
+    ])
+    expect(sorted.map((i) => i.name)).toEqual(["b", "a"])
+  })
+
+  test("falls back to 0 for an unparseable string price", () => {
+    const sorted = sortMenuItemsByType<PricedItem>([
+      { name: "garbage", type: "主食", price: "free" },
+      { name: "paid", type: "主食", price: 5 },
+    ])
+    expect(sorted.map((i) => i.name)).toEqual(["garbage", "paid"])
+  })
+
+  test("does not pin 其他 last (unlike groupMenuItems)", () => {
+    const sorted = sortMenuItemsByType<PricedItem>([
+      { name: "other-item", type: "其他", price: 1 },
+      { name: "main-item", type: "甜點", price: 1 },
+    ])
+    expect(sorted.map((i) => i.name)).toEqual(["other-item", "main-item"])
+  })
+
+  test("does not mutate the input array", () => {
+    const input: PricedItem[] = [
+      { name: "b", type: "主食", price: 99 },
+      { name: "a", type: "主食", price: 1 },
+    ]
+    sortMenuItemsByType(input)
+    expect(input.map((i) => i.name)).toEqual(["b", "a"])
+  })
+
+  test("returns an empty array for empty input", () => {
+    expect(sortMenuItemsByType<PricedItem>([])).toEqual([])
+  })
+})

--- a/apps/portal/lib/bulletin/types.test.ts
+++ b/apps/portal/lib/bulletin/types.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test"
+
+import { parseMentions } from "@/lib/bulletin/types"
+
+describe("parseMentions", () => {
+  test("extracts the names from a simple two-mention message", () => {
+    expect(parseMentions("hi @alice and @bob")).toEqual(["alice", "bob"])
+  })
+
+  test("dedups repeated mentions, keeping first-seen order", () => {
+    expect(parseMentions("@alice @bob @alice again @bob")).toEqual([
+      "alice",
+      "bob",
+    ])
+  })
+
+  test("matches CJK names via \\p{L}", () => {
+    expect(parseMentions("@小明 says hi")).toEqual(["小明"])
+    expect(parseMentions("hi @小明 and @大華")).toEqual(["小明", "大華"])
+  })
+
+  test("accepts letters, digits, dots, hyphens, and underscores in a name", () => {
+    expect(parseMentions("@bob-smith.jr_2")).toEqual(["bob-smith.jr_2"])
+  })
+
+  test("stops the name at the first disallowed character", () => {
+    expect(parseMentions("@alice!")).toEqual(["alice"])
+    expect(parseMentions("(@bob)")).toEqual(["bob"])
+    expect(parseMentions("@alice, @bob; @carol")).toEqual([
+      "alice",
+      "bob",
+      "carol",
+    ])
+  })
+
+  test("ignores a bare '@' with nothing matchable after it", () => {
+    expect(parseMentions("@ alone")).toEqual([])
+    expect(parseMentions("just an @ here")).toEqual([])
+    expect(parseMentions("")).toEqual([])
+  })
+
+  test("still captures the first real mention after a bare '@'", () => {
+    expect(parseMentions("hi @ @alice")).toEqual(["alice"])
+  })
+
+  test("caps the captured name at 40 characters", () => {
+    const name = "a".repeat(45)
+    const result = parseMentions(`@${name}`)
+    expect(result).toEqual(["a".repeat(40)])
+    expect(result[0]).toHaveLength(40)
+  })
+
+  test("has no leading word boundary, so it matches email-like text", () => {
+    // `.` is in the character class, so the name runs through `alice.com`.
+    expect(parseMentions("mail foo@alice.com")).toEqual(["alice.com"])
+  })
+})

--- a/apps/portal/lib/games/constants.test.ts
+++ b/apps/portal/lib/games/constants.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test"
+
+import { formatTime } from "@/lib/games/constants"
+
+describe("formatTime", () => {
+  test("zero renders as seconds with padded centiseconds and trailing s", () => {
+    expect(formatTime(0)).toBe("0.00s")
+  })
+
+  test("sub-second value renders centiseconds only", () => {
+    expect(formatTime(50)).toBe("0.05s")
+    expect(formatTime(990)).toBe("0.99s")
+  })
+
+  test("truncates to centiseconds (floor, no rounding)", () => {
+    expect(formatTime(999)).toBe("0.99s")
+    expect(formatTime(1009)).toBe("1.00s")
+  })
+
+  test("single-digit seconds are NOT zero-padded in the seconds branch", () => {
+    expect(formatTime(5000)).toBe("5.00s")
+    expect(formatTime(9990)).toBe("9.99s")
+  })
+
+  test("two-digit seconds under a minute stay in the seconds branch", () => {
+    expect(formatTime(59000)).toBe("59.00s")
+    expect(formatTime(59990)).toBe("59.99s")
+  })
+
+  test("crossing one minute switches to M:SS.CC format", () => {
+    expect(formatTime(60000)).toBe("1:00.00")
+  })
+
+  test("minute branch zero-pads seconds to two digits", () => {
+    expect(formatTime(65000)).toBe("1:05.00")
+    expect(formatTime(65430)).toBe("1:05.43")
+  })
+
+  test("minute branch zero-pads centiseconds to two digits", () => {
+    expect(formatTime(60050)).toBe("1:00.05")
+  })
+
+  test("multiple minutes are not zero-padded", () => {
+    expect(formatTime(125000)).toBe("2:05.00")
+    expect(formatTime(600000)).toBe("10:00.00")
+  })
+
+  test("seconds wrap correctly at minute boundaries", () => {
+    expect(formatTime(119990)).toBe("1:59.99")
+    expect(formatTime(3599990)).toBe("59:59.99")
+  })
+
+  test("centiseconds derive from the millisecond remainder, independent of seconds", () => {
+    expect(formatTime(61120)).toBe("1:01.12")
+  })
+})

--- a/apps/portal/lib/games/pipes-puzzle.test.ts
+++ b/apps/portal/lib/games/pipes-puzzle.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  BOTTOM,
+  getConnected,
+  getEndpoints,
+  getPuzzle,
+  LEFT,
+  PIPES_GRID,
+  PIPES_LEVEL_COUNT,
+  rotateCW,
+  RIGHT,
+  TOP,
+} from "@/lib/games/pipes-puzzle"
+
+describe("direction bit constants", () => {
+  test("TOP/RIGHT/BOTTOM/LEFT are the four single bits in CW order", () => {
+    expect([TOP, RIGHT, BOTTOM, LEFT]).toEqual([1, 2, 4, 8])
+  })
+
+  test("grid is 6x6 with 100 levels", () => {
+    expect(PIPES_GRID).toBe(6)
+    expect(PIPES_LEVEL_COUNT).toBe(100)
+  })
+})
+
+describe("rotateCW", () => {
+  test("rotates one bit clockwise by default (times = 1)", () => {
+    // The mask layout is a 4-bit ring TOP(1)->RIGHT(2)->BOTTOM(4)->LEFT(8).
+    // A clockwise rotation is therefore a left shift within those 4 bits.
+    expect(rotateCW(TOP)).toBe(RIGHT)
+    expect(rotateCW(RIGHT)).toBe(BOTTOM)
+    expect(rotateCW(BOTTOM)).toBe(LEFT)
+  })
+
+  test("wraps LEFT back to TOP (the high bit feeds the low bit)", () => {
+    expect(rotateCW(LEFT)).toBe(TOP)
+  })
+
+  test("explicit times rotates that many steps", () => {
+    expect(rotateCW(TOP, 1)).toBe(RIGHT)
+    expect(rotateCW(TOP, 2)).toBe(BOTTOM)
+    expect(rotateCW(TOP, 3)).toBe(LEFT)
+  })
+
+  test("rotates compound masks as a whole ring", () => {
+    // TOP|RIGHT (an elbow) rotated once becomes RIGHT|BOTTOM.
+    expect(rotateCW(TOP | RIGHT)).toBe(RIGHT | BOTTOM)
+    // TOP|BOTTOM (a straight) rotated once becomes RIGHT|LEFT.
+    expect(rotateCW(TOP | BOTTOM)).toBe(RIGHT | LEFT)
+    // A straight pipe has period 2 under rotation.
+    expect(rotateCW(TOP | BOTTOM, 2)).toBe(TOP | BOTTOM)
+  })
+
+  test("is a 4-bit rotation: rotateCW(m, 4) === m for every mask 0..15", () => {
+    for (let m = 0; m <= 0xf; m++) {
+      expect(rotateCW(m, 4)).toBe(m)
+    }
+  })
+
+  test("rotateCW(m, 8) === m (two full turns) for every mask", () => {
+    for (let m = 0; m <= 0xf; m++) {
+      expect(rotateCW(m, 8)).toBe(m)
+    }
+  })
+
+  test("never leaves the low 4 bits", () => {
+    for (let m = 0; m <= 0xf; m++) {
+      for (let t = 0; t < 4; t++) {
+        expect(rotateCW(m, t)).toBeLessThanOrEqual(0xf)
+        expect(rotateCW(m, t)).toBeGreaterThanOrEqual(0)
+      }
+    }
+  })
+})
+
+describe("getPuzzle determinism", () => {
+  test("same level produces a deep-equal puzzle every time", () => {
+    expect(getPuzzle(1)).toEqual(getPuzzle(1))
+    expect(getPuzzle(42)).toEqual(getPuzzle(42))
+    expect(getPuzzle(PIPES_LEVEL_COUNT)).toEqual(getPuzzle(PIPES_LEVEL_COUNT))
+  })
+
+  test("different levels generally produce different scrambled grids", () => {
+    const a = getPuzzle(1)
+    const b = getPuzzle(2)
+    expect(a.scrambled).not.toEqual(b.scrambled)
+  })
+})
+
+describe("getPuzzle level clamping", () => {
+  test("clamps levels below 1 up to 1", () => {
+    expect(getPuzzle(0).level).toBe(1)
+    expect(getPuzzle(-3).level).toBe(1)
+    expect(getPuzzle(-9999).level).toBe(1)
+  })
+
+  test("clamps levels above the count down to the max", () => {
+    expect(getPuzzle(101).level).toBe(PIPES_LEVEL_COUNT)
+    expect(getPuzzle(999).level).toBe(PIPES_LEVEL_COUNT)
+  })
+
+  test("keeps in-range levels untouched", () => {
+    expect(getPuzzle(1).level).toBe(1)
+    expect(getPuzzle(50).level).toBe(50)
+    expect(getPuzzle(PIPES_LEVEL_COUNT).level).toBe(PIPES_LEVEL_COUNT)
+  })
+
+  test("truncates fractional levels toward zero (| 0)", () => {
+    expect(getPuzzle(3.9).level).toBe(3)
+    expect(getPuzzle(1.999).level).toBe(1)
+  })
+
+  test("an out-of-range level is equivalent to its clamped level", () => {
+    expect(getPuzzle(0)).toEqual(getPuzzle(1))
+    expect(getPuzzle(150)).toEqual(getPuzzle(PIPES_LEVEL_COUNT))
+  })
+})
+
+describe("getPuzzle shape", () => {
+  test("source is the grid center and size is PIPES_GRID", () => {
+    const center = Math.floor(PIPES_GRID / 2)
+    const p = getPuzzle(1)
+    expect(p.size).toBe(PIPES_GRID)
+    expect(p.source).toEqual([center, center])
+  })
+
+  test("solved and scrambled are square grids of size PIPES_GRID", () => {
+    const p = getPuzzle(13)
+    expect(p.solved).toHaveLength(PIPES_GRID)
+    expect(p.scrambled).toHaveLength(PIPES_GRID)
+    for (const row of p.solved) expect(row).toHaveLength(PIPES_GRID)
+    for (const row of p.scrambled) expect(row).toHaveLength(PIPES_GRID)
+  })
+})
+
+describe("solved grid invariants", () => {
+  test("every solved grid is a fully connected spanning tree from the source", () => {
+    for (let lv = 1; lv <= PIPES_LEVEL_COUNT; lv++) {
+      const p = getPuzzle(lv)
+      const reached = getConnected(p.solved, p.source, p.size, p.size)
+      expect(reached.size).toBe(p.size * p.size)
+    }
+  })
+
+  test("no solved cell is empty (the tree touches every cell)", () => {
+    for (let lv = 1; lv <= PIPES_LEVEL_COUNT; lv++) {
+      const p = getPuzzle(lv)
+      for (const row of p.solved) {
+        for (const mask of row) {
+          expect(mask).toBeGreaterThan(0)
+          expect(mask).toBeLessThanOrEqual(0xf)
+        }
+      }
+    }
+  })
+
+  test("connections are symmetric: a cell pointing at a neighbor is pointed back", () => {
+    const p = getPuzzle(23)
+    const { solved, size } = p
+    for (let r = 0; r < size; r++) {
+      for (let c = 0; c < size; c++) {
+        const m = solved[r]![c]!
+        if (m & TOP) expect(solved[r - 1]?.[c]! & BOTTOM).toBeTruthy()
+        if (m & BOTTOM) expect(solved[r + 1]?.[c]! & TOP).toBeTruthy()
+        if (m & LEFT) expect(solved[r]![c - 1]! & RIGHT).toBeTruthy()
+        if (m & RIGHT) expect(solved[r]![c + 1]! & LEFT).toBeTruthy()
+      }
+    }
+  })
+
+  test("a spanning tree on N cells has exactly N-1 edges", () => {
+    const p = getPuzzle(31)
+    let bits = 0
+    for (const row of p.solved) {
+      for (const mask of row) {
+        bits += [TOP, RIGHT, BOTTOM, LEFT].filter((b) => mask & b).length
+      }
+    }
+    // Each undirected edge is counted twice (once from each endpoint).
+    const edges = bits / 2
+    expect(edges).toBe(p.size * p.size - 1)
+  })
+})
+
+describe("solvability contract (scrambled <-> solved)", () => {
+  test("the source cell's scrambled mask matches its solved mask", () => {
+    // The source button is disabled in the UI, so it must already be solved.
+    for (let lv = 1; lv <= PIPES_LEVEL_COUNT; lv++) {
+      const p = getPuzzle(lv)
+      const [sr, sc] = p.source
+      expect(p.scrambled[sr]![sc]).toBe(p.solved[sr]![sc])
+    }
+  })
+
+  test("every scrambled cell is some CW rotation of its solved cell", () => {
+    // This is what makes the puzzle solvable: rotating each cell back into
+    // place recovers the solved grid.
+    for (let lv = 1; lv <= PIPES_LEVEL_COUNT; lv++) {
+      const p = getPuzzle(lv)
+      for (let r = 0; r < p.size; r++) {
+        for (let c = 0; c < p.size; c++) {
+          const solvedMask = p.solved[r]![c]!
+          const scrambledMask = p.scrambled[r]![c]!
+          const rotations = [0, 1, 2, 3].map((t) => rotateCW(solvedMask, t))
+          expect(rotations).toContain(scrambledMask)
+        }
+      }
+    }
+  })
+
+  test("rotating each scrambled cell back to a rotation of solved reaches full connectivity", () => {
+    // Concrete solvability proof: replace scrambled with solved and confirm
+    // the whole grid lights up from the source.
+    const p = getPuzzle(64)
+    const reached = getConnected(p.solved, p.source, p.size, p.size)
+    expect(reached.size).toBe(p.size * p.size)
+  })
+})
+
+describe("getConnected", () => {
+  test("includes the source itself even with no connections", () => {
+    const empty = Array.from({ length: 2 }, () => [0, 0])
+    const reached = getConnected(empty, [0, 0], 2, 2)
+    expect([...reached]).toEqual(["0,0"])
+  })
+
+  test("only follows mutual connections, not one-sided masks", () => {
+    // (0,0) points RIGHT at (0,1) but (0,1) does not point LEFT back.
+    const masks = [
+      [RIGHT, 0],
+      [0, 0],
+    ]
+    const reached = getConnected(masks, [0, 0], 2, 2)
+    expect(reached.has("0,1")).toBe(false)
+    expect(reached.size).toBe(1)
+  })
+
+  test("follows a chain of mutually connected cells", () => {
+    // (0,0) <-> (0,1) <-> (0,2) all linked along the row.
+    const masks = [[RIGHT, RIGHT | LEFT, LEFT]]
+    const reached = getConnected(masks, [0, 0], 1, 3)
+    expect(reached.size).toBe(3)
+    expect(reached.has("0,2")).toBe(true)
+  })
+
+  test("does not walk off the grid bounds", () => {
+    // Source at the corner points TOP and LEFT into out-of-bounds; stays put.
+    const masks = [[TOP | LEFT | RIGHT, LEFT]]
+    const reached = getConnected(masks, [0, 0], 1, 2)
+    expect(reached.has("0,1")).toBe(true)
+    expect(reached.size).toBe(2)
+  })
+})
+
+describe("getEndpoints", () => {
+  test("returns degree-1 cells of the solved tree, excluding the source", () => {
+    const p = getPuzzle(7)
+    const eps = getEndpoints(p.solved, p.source)
+    for (const [r, c] of eps) {
+      // never the source
+      expect(r === p.source[0] && c === p.source[1]).toBe(false)
+      // exactly one connection bit set
+      const mask = p.solved[r]![c]!
+      const degree = [TOP, RIGHT, BOTTOM, LEFT].filter((b) => mask & b).length
+      expect(degree).toBe(1)
+    }
+    // a 36-cell spanning tree always has at least 2 leaves
+    expect(eps.length).toBeGreaterThanOrEqual(2)
+  })
+
+  test("is deterministic for a given level", () => {
+    expect(getEndpoints(getPuzzle(7).solved, getPuzzle(7).source)).toEqual(
+      getEndpoints(getPuzzle(7).solved, getPuzzle(7).source)
+    )
+  })
+})

--- a/apps/portal/lib/games/queens-puzzles.test.ts
+++ b/apps/portal/lib/games/queens-puzzles.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test"
+
+import { getQueensPuzzle, QUEENS_LEVEL_COUNT } from "@/lib/games/queens-puzzles"
+
+// Size bands per the encoding header: 1-30 = 5x5, 31-60 = 6x6, 61-100 = 7x7.
+function expectedSize(level: number): number {
+  if (level <= 30) return 5
+  if (level <= 60) return 6
+  return 7
+}
+
+describe("getQueensPuzzle level count", () => {
+  test("ships exactly 100 encoded puzzles", () => {
+    expect(QUEENS_LEVEL_COUNT).toBe(100)
+  })
+})
+
+describe("decoded shape + validity invariant (all levels)", () => {
+  for (let level = 1; level <= QUEENS_LEVEL_COUNT; level++) {
+    const size = expectedSize(level)
+
+    test(`level ${level} is a valid ${size}x${size} puzzle`, () => {
+      const puzzle = getQueensPuzzle(level)
+
+      // level / size echoed straight from the encoded entry.
+      expect(puzzle.level).toBe(level)
+      expect(puzzle.size).toBe(size)
+
+      // regions decode to a size x size row-major grid.
+      expect(puzzle.regions.length).toBe(size)
+      for (const row of puzzle.regions) {
+        expect(row.length).toBe(size)
+        for (const id of row) {
+          expect(Number.isInteger(id)).toBe(true)
+          expect(id).toBeGreaterThanOrEqual(0)
+          expect(id).toBeLessThanOrEqual(size - 1)
+        }
+      }
+
+      // queens: one column index per row, length === size.
+      expect(puzzle.queens.length).toBe(size)
+
+      const seenCols = new Set<number>()
+      const seenRegions = new Set<number>()
+      for (let r = 0; r < size; r++) {
+        const col = puzzle.queens[r]!
+
+        // column in range.
+        expect(Number.isInteger(col)).toBe(true)
+        expect(col).toBeGreaterThanOrEqual(0)
+        expect(col).toBeLessThan(size)
+
+        seenCols.add(col)
+        seenRegions.add(puzzle.regions[r]![col]!)
+      }
+
+      // one queen per column: all distinct (rows already distinct by index).
+      expect(seenCols.size).toBe(size)
+
+      // one queen per region: the regions the queens land on are all distinct.
+      expect(seenRegions.size).toBe(size)
+
+      // region ids form a contiguous 0..size-1 set, so "one per region"
+      // means every region is covered exactly once.
+      const allRegionIds = new Set<number>()
+      for (const row of puzzle.regions)
+        for (const id of row) allRegionIds.add(id)
+      expect(allRegionIds.size).toBe(size)
+      expect([...allRegionIds].sort((a, b) => a - b)).toEqual(
+        Array.from({ length: size }, (_, i) => i)
+      )
+    })
+  }
+})
+
+describe("level clamping", () => {
+  test("level 0 clamps up to level 1", () => {
+    expect(getQueensPuzzle(0)).toEqual(getQueensPuzzle(1))
+  })
+
+  test("negative levels clamp up to level 1", () => {
+    expect(getQueensPuzzle(-5)).toEqual(getQueensPuzzle(1))
+  })
+
+  test("levels above the max clamp down to the last level", () => {
+    expect(getQueensPuzzle(QUEENS_LEVEL_COUNT + 1)).toEqual(
+      getQueensPuzzle(QUEENS_LEVEL_COUNT)
+    )
+    expect(getQueensPuzzle(99999)).toEqual(getQueensPuzzle(QUEENS_LEVEL_COUNT))
+  })
+
+  test("fractional levels are truncated toward zero (| 0)", () => {
+    expect(getQueensPuzzle(3.9)).toEqual(getQueensPuzzle(3))
+    expect(getQueensPuzzle(1.1)).toEqual(getQueensPuzzle(1))
+  })
+
+  test("the last in-range level decodes the last encoded puzzle", () => {
+    const last = getQueensPuzzle(QUEENS_LEVEL_COUNT)
+    expect(last.level).toBe(QUEENS_LEVEL_COUNT)
+    expect(last.size).toBe(7)
+  })
+})

--- a/apps/portal/lib/games/typing-passages.test.ts
+++ b/apps/portal/lib/games/typing-passages.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  countUnits,
+  getTypingLanguage,
+  TYPING_LANGUAGES,
+} from "@/lib/games/typing-passages"
+
+describe("getTypingLanguage", () => {
+  test("returns the language at the given id", () => {
+    expect(getTypingLanguage(0).code).toBe("en")
+    expect(getTypingLanguage(1).code).toBe("zh-Hant")
+    expect(getTypingLanguage(5).code).toBe("es")
+  })
+
+  test("id matches the entry's own id field", () => {
+    for (const lang of TYPING_LANGUAGES) {
+      expect(getTypingLanguage(lang.id)).toBe(lang)
+    }
+  })
+
+  test("falls back to English (index 0) for an out-of-range id", () => {
+    expect(getTypingLanguage(99)).toBe(TYPING_LANGUAGES[0]!)
+    expect(getTypingLanguage(99).code).toBe("en")
+  })
+
+  test("falls back to English for a negative id", () => {
+    expect(getTypingLanguage(-1)).toBe(TYPING_LANGUAGES[0]!)
+  })
+})
+
+describe("countUnits — latin (whitespace-separated words)", () => {
+  test("counts space-separated words", () => {
+    expect(countUnits("the quick brown fox", "en")).toBe(4)
+  })
+
+  test("collapses runs of whitespace into a single separator", () => {
+    expect(countUnits("the   quick\tbrown\nfox", "en")).toBe(4)
+  })
+
+  test("trims leading and trailing whitespace before splitting", () => {
+    expect(countUnits("   hello world   ", "en")).toBe(2)
+  })
+
+  test("a single word counts as one", () => {
+    expect(countUnits("hello", "en")).toBe(1)
+  })
+
+  test("punctuation does not split words (counts tokens, not words)", () => {
+    expect(countUnits("e tu, Brute?", "en")).toBe(3)
+  })
+
+  test("empty and whitespace-only strings count as 1 (split returns one empty token)", () => {
+    expect(countUnits("", "en")).toBe(1)
+    expect(countUnits("   ", "en")).toBe(1)
+  })
+
+  test("non-zh-Hant codes all take the word-count branch", () => {
+    for (const code of ["de", "fr", "it", "es"] as const) {
+      expect(countUnits("uno due tre", code)).toBe(3)
+    }
+  })
+})
+
+describe("countUnits — zh-Hant (CJK character count)", () => {
+  test("counts CJK ideographs", () => {
+    expect(countUnits("山不在高", "zh-Hant")).toBe(4)
+  })
+
+  test("ignores fullwidth punctuation, only counting ideographs", () => {
+    expect(countUnits("千里之行，始於足下。", "zh-Hant")).toBe(8)
+  })
+
+  test("ignores ASCII and whitespace mixed into CJK text", () => {
+    expect(countUnits("山 high 水 deep", "zh-Hant")).toBe(2)
+  })
+
+  test("empty string counts as 0 in the CJK branch", () => {
+    expect(countUnits("", "zh-Hant")).toBe(0)
+  })
+
+  test("CJK Unified Ideographs block boundaries U+4E00 and U+9FFF are counted", () => {
+    expect(countUnits("一鿿", "zh-Hant")).toBe(2)
+  })
+
+  test("characters just outside the block are not counted", () => {
+    // U+3007 (〇) below the block, U+A000 just above it
+    expect(countUnits("〇ꀀ", "zh-Hant")).toBe(0)
+  })
+})

--- a/apps/portal/lib/profile/stats.test.ts
+++ b/apps/portal/lib/profile/stats.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  formatBytes,
+  formatDelay,
+  leaveFlavor,
+  spendInReference,
+} from "@/lib/profile/stats"
+
+describe("formatBytes", () => {
+  test("zero bytes stays in the B bucket", () => {
+    expect(formatBytes(0)).toBe("0 B")
+  })
+
+  test("just under 1 KiB reports raw bytes", () => {
+    expect(formatBytes(1023)).toBe("1023 B")
+  })
+
+  test("exactly 1024 crosses into KB (1.0)", () => {
+    expect(formatBytes(1024)).toBe("1.0 KB")
+  })
+
+  test("KB rounds to one decimal", () => {
+    expect(formatBytes(1536)).toBe("1.5 KB")
+  })
+
+  test("just under 1 MiB stays KB", () => {
+    expect(formatBytes(1024 * 1024 - 1)).toBe("1024.0 KB")
+  })
+
+  test("exactly 1 MiB crosses into MB (1.0)", () => {
+    expect(formatBytes(1024 * 1024)).toBe("1.0 MB")
+  })
+
+  test("MB rounds to one decimal", () => {
+    expect(formatBytes(1024 * 1024 * 1.5)).toBe("1.5 MB")
+  })
+
+  test("just under 1 GiB stays MB", () => {
+    expect(formatBytes(1024 * 1024 * 1024 - 1)).toBe("1024.0 MB")
+  })
+
+  test("exactly 1 GiB crosses into GB with two decimals", () => {
+    expect(formatBytes(1024 * 1024 * 1024)).toBe("1.00 GB")
+  })
+
+  test("GB rounds to two decimals", () => {
+    expect(formatBytes(1024 * 1024 * 1024 * 2.5)).toBe("2.50 GB")
+  })
+})
+
+describe("formatDelay", () => {
+  test("zero seconds renders the em dash", () => {
+    expect(formatDelay(0)).toBe("—")
+  })
+
+  test("negative seconds renders the em dash", () => {
+    expect(formatDelay(-100)).toBe("—")
+  })
+
+  test("under an hour reports rounded minutes", () => {
+    // 1800s = 30 min, hours = 0.5 < 1
+    expect(formatDelay(1800)).toBe("30 分")
+  })
+
+  test("minutes are rounded, not floored", () => {
+    // 90s / 60 = 1.5 -> Math.round -> 2
+    expect(formatDelay(90)).toBe("2 分")
+  })
+
+  test("just under an hour still reports minutes", () => {
+    // 3599s -> 59.98 min -> round 60
+    expect(formatDelay(3599)).toBe("60 分")
+  })
+
+  test("exactly one hour crosses into the 小時 bucket", () => {
+    // hours = 1, not < 1, and < 48
+    expect(formatDelay(3600)).toBe("1.0 小時")
+  })
+
+  test("hours render with one decimal", () => {
+    // 5400s = 1.5h
+    expect(formatDelay(5400)).toBe("1.5 小時")
+  })
+
+  test("just under 48 hours stays in the 小時 bucket", () => {
+    // 47.99h
+    expect(formatDelay(172800 - 3600)).toBe("47.0 小時")
+  })
+
+  test("exactly 48 hours crosses into the 天 bucket", () => {
+    // hours = 48, not < 48 -> days = 48/24 = 2.0
+    expect(formatDelay(172800)).toBe("2.0 天")
+  })
+
+  test("days render with one decimal", () => {
+    // 216000s = 60h = 2.5 days
+    expect(formatDelay(216000)).toBe("2.5 天")
+  })
+})
+
+describe("leaveFlavor", () => {
+  test("zero days is the work-machine line", () => {
+    expect(leaveFlavor(0)).toBe("今年還沒請過假，是個工作機器")
+  })
+
+  test("one day is in the 發育期 bucket", () => {
+    expect(leaveFlavor(1)).toBe("1 天，還在發育期")
+  })
+
+  test("just under three days stays 發育期", () => {
+    expect(leaveFlavor(2)).toBe("2 天，還在發育期")
+  })
+
+  test("exactly three days crosses into the 環島 bucket", () => {
+    // 3/9 = 0.333... -> toFixed(1) -> "0.3"
+    expect(leaveFlavor(3)).toBe("3 天，可以單車環島 0.3 圈")
+  })
+
+  test("nine days is exactly one lap", () => {
+    expect(leaveFlavor(9)).toBe("9 天，可以單車環島 1.0 圈")
+  })
+
+  test("laps render with one decimal", () => {
+    // 18/9 = 2.0
+    expect(leaveFlavor(18)).toBe("18 天，可以單車環島 2.0 圈")
+  })
+})
+
+describe("spendInReference", () => {
+  const egg = { name: "7-11 茶葉蛋", price: 10, unit: "顆" }
+
+  test("exact multiple divides cleanly", () => {
+    expect(spendInReference(100, egg)).toBe(10)
+  })
+
+  test("remainder is floored down", () => {
+    expect(spendInReference(99, egg)).toBe(9)
+  })
+
+  test("spending less than one unit floors to zero", () => {
+    expect(spendInReference(9, egg)).toBe(0)
+  })
+
+  test("zero spend is zero units", () => {
+    expect(spendInReference(0, egg)).toBe(0)
+  })
+
+  test("floors against an arbitrary price", () => {
+    // 200 / 75 = 2.66... -> floor 2
+    expect(
+      spendInReference(200, { name: "麥當勞大麥克", price: 75, unit: "顆" })
+    ).toBe(2)
+  })
+})

--- a/apps/portal/lib/reimburse/transformers.test.ts
+++ b/apps/portal/lib/reimburse/transformers.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "bun:test"
+
+import { transformEgress, transformIngress } from "@/lib/reimburse/transformers"
+import type { DatabaseEgress, DatabaseIngress } from "@/lib/reimburse/types"
+
+function egressRow(overrides: Partial<DatabaseEgress> = {}): DatabaseEgress {
+  return {
+    id: "e-1",
+    applicant_name: "Alice",
+    item_name: "Cables",
+    item_amount: 120,
+    item_comment: "spare HDMI",
+    invoice_date: "2026-01-02",
+    invoice_files: ["inv-a.pdf"],
+    transfer_date: "2026-01-05",
+    transfer_fee: 15,
+    transfer_files: ["tr-a.pdf"],
+    status: "approved",
+    user_id: "u-1",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  }
+}
+
+function ingressRow(overrides: Partial<DatabaseIngress> = {}): DatabaseIngress {
+  return {
+    id: "i-1",
+    ingress_date: "2026-02-03",
+    ingress_amount: 500,
+    ingress_comment: "grant",
+    ingress_files: ["in-a.pdf"],
+    user_id: "u-1",
+    created_at: "2026-02-01T00:00:00Z",
+    updated_at: "2026-02-01T00:00:00Z",
+    ...overrides,
+  }
+}
+
+describe("transformEgress", () => {
+  test("maps snake_case row to camelCase Reimbursement, dropping db-only fields", () => {
+    expect(transformEgress(egressRow())).toEqual({
+      id: "e-1",
+      applicantName: "Alice",
+      itemName: "Cables",
+      itemAmount: 120,
+      itemComment: "spare HDMI",
+      invoiceDate: "2026-01-02",
+      invoiceFiles: ["inv-a.pdf"],
+      transferDate: "2026-01-05",
+      transferFee: 15,
+      transferFiles: ["tr-a.pdf"],
+      status: "approved",
+    })
+  })
+
+  test("does not leak user_id / created_at / updated_at into the app shape", () => {
+    const result = transformEgress(egressRow())
+    expect(result).not.toHaveProperty("user_id")
+    expect(result).not.toHaveProperty("created_at")
+    expect(result).not.toHaveProperty("updated_at")
+  })
+
+  test("coerces a string item_amount to a Number", () => {
+    const result = transformEgress(
+      egressRow({ item_amount: "250" as unknown as number })
+    )
+    expect(result.itemAmount).toBe(250)
+    expect(typeof result.itemAmount).toBe("number")
+  })
+
+  test("null invoice_files normalizes to an empty array", () => {
+    const result = transformEgress(
+      egressRow({ invoice_files: null as unknown as string[] })
+    )
+    expect(result.invoiceFiles).toEqual([])
+  })
+
+  test("undefined invoice_files normalizes to an empty array", () => {
+    const result = transformEgress(
+      egressRow({ invoice_files: undefined as unknown as string[] })
+    )
+    expect(result.invoiceFiles).toEqual([])
+  })
+
+  test("present invoice_files pass through untouched", () => {
+    const result = transformEgress(
+      egressRow({ invoice_files: ["a.pdf", "b.pdf"] })
+    )
+    expect(result.invoiceFiles).toEqual(["a.pdf", "b.pdf"])
+  })
+
+  test("null transfer_fee stays null (not coerced to 0)", () => {
+    const result = transformEgress(egressRow({ transfer_fee: null }))
+    expect(result.transferFee).toBeNull()
+  })
+
+  test("zero transfer_fee is kept as a Number, not flipped to null", () => {
+    const result = transformEgress(egressRow({ transfer_fee: 0 }))
+    expect(result.transferFee).toBe(0)
+  })
+
+  test("string transfer_fee is coerced to a Number", () => {
+    const result = transformEgress(
+      egressRow({ transfer_fee: "42" as unknown as number })
+    )
+    expect(result.transferFee).toBe(42)
+    expect(typeof result.transferFee).toBe("number")
+  })
+
+  test("null transfer_files stays null", () => {
+    const result = transformEgress(egressRow({ transfer_files: null }))
+    expect(result.transferFiles).toBeNull()
+  })
+
+  test("empty transfer_files array normalizes to null", () => {
+    const result = transformEgress(egressRow({ transfer_files: [] }))
+    expect(result.transferFiles).toBeNull()
+  })
+
+  test("non-empty transfer_files pass through as an array", () => {
+    const result = transformEgress(
+      egressRow({ transfer_files: ["t1.pdf", "t2.pdf"] })
+    )
+    expect(result.transferFiles).toEqual(["t1.pdf", "t2.pdf"])
+  })
+
+  test("null item_comment and transfer_date pass through as null", () => {
+    const result = transformEgress(
+      egressRow({ item_comment: null, transfer_date: null })
+    )
+    expect(result.itemComment).toBeNull()
+    expect(result.transferDate).toBeNull()
+  })
+})
+
+describe("transformIngress", () => {
+  test("maps snake_case row to camelCase Ingress, dropping db-only fields", () => {
+    expect(transformIngress(ingressRow())).toEqual({
+      id: "i-1",
+      ingressDate: "2026-02-03",
+      ingressAmount: 500,
+      ingressComment: "grant",
+      ingressFiles: ["in-a.pdf"],
+    })
+  })
+
+  test("does not leak user_id / created_at / updated_at into the app shape", () => {
+    const result = transformIngress(ingressRow())
+    expect(result).not.toHaveProperty("user_id")
+    expect(result).not.toHaveProperty("created_at")
+    expect(result).not.toHaveProperty("updated_at")
+  })
+
+  test("coerces a string ingress_amount to a Number", () => {
+    const result = transformIngress(
+      ingressRow({ ingress_amount: "999" as unknown as number })
+    )
+    expect(result.ingressAmount).toBe(999)
+    expect(typeof result.ingressAmount).toBe("number")
+  })
+
+  test("null ingress_files normalizes to an empty array", () => {
+    const result = transformIngress(
+      ingressRow({ ingress_files: null as unknown as string[] })
+    )
+    expect(result.ingressFiles).toEqual([])
+  })
+
+  test("present ingress_files pass through untouched", () => {
+    const result = transformIngress(
+      ingressRow({ ingress_files: ["x.pdf", "y.pdf"] })
+    )
+    expect(result.ingressFiles).toEqual(["x.pdf", "y.pdf"])
+  })
+
+  test("null ingress_comment passes through as null", () => {
+    const result = transformIngress(ingressRow({ ingress_comment: null }))
+    expect(result.ingressComment).toBeNull()
+  })
+})

--- a/apps/portal/lib/user.test.ts
+++ b/apps/portal/lib/user.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from "bun:test"
+
+import { normalizeClaims } from "@/lib/user"
+
+type Claims = Parameters<typeof normalizeClaims>[0]
+
+function claims(overrides: Partial<Claims> = {}): Claims {
+  return {
+    sub: "user-123",
+    ...overrides,
+  }
+}
+
+describe("normalizeClaims — id / email", () => {
+  test("maps sub to id", () => {
+    expect(normalizeClaims(claims({ sub: "abc" })).id).toBe("abc")
+  })
+
+  test("passes email through", () => {
+    expect(normalizeClaims(claims({ email: "a@b.com" })).email).toBe("a@b.com")
+  })
+
+  test("missing email normalizes to null", () => {
+    expect(normalizeClaims(claims()).email).toBeNull()
+  })
+})
+
+describe("normalizeClaims — name fallback chain", () => {
+  test("full_name wins when present", () => {
+    const result = normalizeClaims(
+      claims({
+        email: "e@x.com",
+        user_metadata: {
+          full_name: "Full Name",
+          name: "Name",
+          preferred_username: "pref",
+        },
+      })
+    )
+    expect(result.name).toBe("Full Name")
+  })
+
+  test("falls back to name when full_name absent", () => {
+    const result = normalizeClaims(
+      claims({
+        user_metadata: { name: "Name", preferred_username: "pref" },
+      })
+    )
+    expect(result.name).toBe("Name")
+  })
+
+  test("falls back to preferred_username when full_name + name absent", () => {
+    const result = normalizeClaims(
+      claims({ user_metadata: { preferred_username: "pref" } })
+    )
+    expect(result.name).toBe("pref")
+  })
+
+  test("falls back to email when no metadata name fields", () => {
+    const result = normalizeClaims(
+      claims({ email: "fallback@x.com", user_metadata: {} })
+    )
+    expect(result.name).toBe("fallback@x.com")
+  })
+
+  test("falls back to 'Unknown' when nothing is available", () => {
+    expect(normalizeClaims(claims()).name).toBe("Unknown")
+  })
+
+  test("missing user_metadata is treated as empty, name falls to email", () => {
+    const result = normalizeClaims(claims({ email: "only@x.com" }))
+    expect(result.name).toBe("only@x.com")
+  })
+})
+
+describe("normalizeClaims — non-string metadata is dropped", () => {
+  test("non-string full_name is skipped, chain continues to name", () => {
+    const result = normalizeClaims(
+      claims({
+        user_metadata: { full_name: 42, name: "RealName" },
+      })
+    )
+    expect(result.name).toBe("RealName")
+  })
+
+  test("null full_name is skipped (typeof null !== string)", () => {
+    const result = normalizeClaims(
+      claims({
+        user_metadata: { full_name: null, name: "RealName" },
+      })
+    )
+    expect(result.name).toBe("RealName")
+  })
+
+  test("all metadata non-string falls through to email", () => {
+    const result = normalizeClaims(
+      claims({
+        email: "e@x.com",
+        user_metadata: { full_name: 1, name: {}, preferred_username: [] },
+      })
+    )
+    expect(result.name).toBe("e@x.com")
+  })
+
+  test("empty string full_name is a string, so it short-circuits the chain", () => {
+    const result = normalizeClaims(
+      claims({
+        email: "e@x.com",
+        user_metadata: { full_name: "", name: "RealName" },
+      })
+    )
+    expect(result.name).toBe("")
+  })
+})
+
+describe("normalizeClaims — avatar fallback", () => {
+  test("avatar_url wins when present", () => {
+    const result = normalizeClaims(
+      claims({
+        user_metadata: { avatar_url: "a.png", picture: "p.png" },
+      })
+    )
+    expect(result.avatarUrl).toBe("a.png")
+  })
+
+  test("falls back to picture when avatar_url absent", () => {
+    const result = normalizeClaims(
+      claims({ user_metadata: { picture: "p.png" } })
+    )
+    expect(result.avatarUrl).toBe("p.png")
+  })
+
+  test("no avatar fields normalizes to null", () => {
+    expect(normalizeClaims(claims({ user_metadata: {} })).avatarUrl).toBeNull()
+  })
+
+  test("non-string avatar_url is dropped, falls back to picture", () => {
+    const result = normalizeClaims(
+      claims({
+        user_metadata: { avatar_url: 123, picture: "p.png" },
+      })
+    )
+    expect(result.avatarUrl).toBe("p.png")
+  })
+
+  test("missing user_metadata yields null avatar", () => {
+    expect(normalizeClaims(claims()).avatarUrl).toBeNull()
+  })
+})
+
+describe("normalizeClaims — full shape", () => {
+  test("assembles the complete NormalizedUser", () => {
+    expect(
+      normalizeClaims(
+        claims({
+          sub: "u-9",
+          email: "u9@x.com",
+          user_metadata: { full_name: "Nine", avatar_url: "nine.png" },
+        })
+      )
+    ).toEqual({
+      id: "u-9",
+      email: "u9@x.com",
+      name: "Nine",
+      avatarUrl: "nine.png",
+    })
+  })
+})


### PR DESCRIPTION
Refs #159 (CI hardening — bun cache / coverage / audit — follows in a separate PR)

## Summary

+354 pure-logic unit tests across portal / gallery / mcp, all authored source-first (each assertion pins the **real** current behavior, verified before writing — no invented signatures). Plus three security-critical guards extracted from `"use server"` files into plain `lib/` modules so they're unit-testable (behavior identical).

### Tests added
- **Games**: `pipes-puzzle` (solvability + determinism + rotateCW invariants, all 100 levels), `queens-puzzles` (unique-solution validity, all 100), `constants.formatTime`, `typing-passages.countUnits`
- **Security/identity**: `verifyPkce` (done in #163), MCP OAuth helpers (`validateOAuthClientRequest`, `parseAuthorize/TokenRequest`, `registerOAuthClient`, `getRedirectUriMatch`, `urls`, `oauth-metadata`), `normalizeClaims` fallback chain
- **Domain logic**: `parseMentions`, `aggregateReactions`, `transformEgress/Ingress`, `bento/menu` grouping, `field-categories`, `profile/stats` formatters, `getRotation`

### Extractions (behavior-preserving)
- `isValidClientObjectPath` (gallery path-traversal + ownership guard) → `lib/gallery/object-path.ts`
- `validateUploadPayload` (50MB cap) → `lib/approve/upload.ts`
- `computeOrphanedSigners` (signer set-diff) → `lib/approve/signers.ts`

### Notable flags (pinned as current behavior, not changed)
- `parseMentions` has no leading boundary → `foo@alice.com` yields `alice.com` as a mention candidate. Pinned; flagged for the maintainer.
- `aggregateReactions` does **not** dedupe per-user (the one-vote invariant is enforced in the DB, not here).
- `countUnits("", "en") === 1` (latin branch) vs `0` (CJK) — boundary quirk pinned.

## Test plan
- [x] `bun run test` → all 4 workspaces pass (portal 308, gallery 44, + mcp + ui; 0 fail).
- [x] `bun run typecheck` → 4/4 (extractions don't break the actions).