### PR TITLE
chore(ci): bun deps cache, audit gate, coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,19 @@ jobs:
         with:
           bun-version-file: package.json
 
+      # setup-bun caches only the Bun executable, not the dependency cache.
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: ${{ runner.os }}-bun-
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Audit dependencies
+        run: bun audit --audit-level=high
 
       - name: Typecheck
         run: bun run typecheck
@@ -34,7 +45,7 @@ jobs:
         run: bun run lint
 
       - name: Test
-        run: bun run test
+        run: bunx turbo run test -- --coverage
 
       - name: Build
         run: bun run build

--- a/bun.lock
+++ b/bun.lock
@@ -175,6 +175,9 @@
       },
     },
   },
+  "overrides": {
+    "fast-uri": "^3.1.2",
+  },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -1176,7 +1179,7 @@
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
-    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
 

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "date-fns": "^4.1.0",
     "lucide-react": "^1.8.0",
     "sonner": "^2.0.7"
+  },
+  "overrides": {
+    "fast-uri": "^3.1.2"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -29,7 +29,8 @@
       "dependsOn": ["^typecheck"]
     },
     "test": {
-      "dependsOn": ["^test"]
+      "dependsOn": ["^test"],
+      "inputs": ["$TURBO_DEFAULT$"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
Closes #159

## Summary

CI hardening (the second half of #159, after the unit tests in #166):

- **Bun install cache** — `actions/cache@v4` on `~/.bun/install/cache` keyed by `bun.lock`. `setup-bun` caches only the executable, not deps, so every run was re-downloading the full graph.
- **Audit gate** — `bun audit --audit-level=high` blocks PRs that introduce high/critical advisories (Dependabot is async, not a PR gate).
- **Coverage reporting** — `bunx turbo run test -- --coverage` prints per-workspace coverage in CI logs (ui 100% / gallery 96% / mcp 93% / portal 87% lines). No hard threshold — `bun --coverage` measures only test-imported files, so a gate would mislead; ratcheting a real gate needs a codecov baseline (future).
- **turbo `test` inputs** — added `$TURBO_DEFAULT$` so the test task caches/invalidates on source changes.
- **fast-uri `^3.1.2` override** — clears two pre-existing high advisories (GHSA-v39h-62p7-jpjc, GHSA-q3j6-qgpj-74h6) pulled transitively via ajv / @modelcontextprotocol/sdk / eslint, so the new audit gate is green.

## Test plan
- [x] `bun audit --audit-level=high` → exit 0 (fast-uri resolves to 3.1.2).
- [x] `bunx turbo run test -- --coverage` → 4/4 workspaces pass with coverage tables.