### PR TITLE
test(db): pgTAP RLS regression suite + db-tests CI workflow

### DIFF
--- a/.github/workflows/db-tests.yml
+++ b/.github/workflows/db-tests.yml
@@ -1,0 +1,44 @@
+name: DB tests
+
+# RLS / SECURITY DEFINER regression tests (pgTAP). Only runs when the schema or
+# the tests change — booting a local Postgres is heavier than the unit lane.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "supabase/migrations/**"
+      - "supabase/tests/**"
+      - "supabase/config.toml"
+      - ".github/workflows/db-tests.yml"
+  pull_request:
+    paths:
+      - "supabase/migrations/**"
+      - "supabase/tests/**"
+      - "supabase/config.toml"
+      - ".github/workflows/db-tests.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pgtap:
+    name: pgTAP RLS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: supabase/setup-cli@v2
+        with:
+          version: latest
+
+      # Boots a local Postgres (Docker on the runner) and applies
+      # supabase/migrations/** — i.e. the captured baseline.
+      - name: Start local database
+        run: supabase db start
+
+      - name: Run pgTAP tests
+        run: supabase test db

--- a/supabase/tests/rls.test.sql
+++ b/supabase/tests/rls.test.sql
@@ -1,0 +1,101 @@
+-- RLS / SECURITY DEFINER regression suite — runs via `supabase test db`.
+-- Seeds two ordinary (non-admin) users, then asserts the security boundaries
+-- that the strategy doc (#161) and the security advisors flagged. Impersonation
+-- is done by switching to the `authenticated` role + setting the JWT claims that
+-- auth.uid() reads (request.jwt.claims->>'sub').
+
+begin;
+create extension if not exists pgtap with schema public;
+-- pgTAP assertion fns must be callable after we drop to the authenticated role.
+grant execute on all functions in schema public to authenticated;
+
+select plan(8);
+
+-- ── seed (as superuser — bypasses RLS) ──────────────────────────────────────
+insert into auth.users (id) values
+  ('11111111-1111-1111-1111-111111111111'),
+  ('22222222-2222-2222-2222-222222222222');
+insert into public.user_profiles (id, email, is_admin, roles) values
+  ('11111111-1111-1111-1111-111111111111', 'a@test.local', false, '{}'),
+  ('22222222-2222-2222-2222-222222222222', 'b@test.local', false, '{}');
+insert into public.game_scores (user_id, game_type, score, finish_time_ms) values
+  ('11111111-1111-1111-1111-111111111111', '2048', 1000, 5000);
+
+-- ── impersonate user A (ordinary authenticated user) ────────────────────────
+set local role authenticated;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"11111111-1111-1111-1111-111111111111","role":"authenticated"}',
+  true
+);
+
+-- 1-2. prevent_role_escalation trigger blocks self-privilege changes
+select throws_ok(
+  $$ update public.user_profiles set is_admin = true where id = '11111111-1111-1111-1111-111111111111' $$,
+  'Direct modification of is_admin is not allowed',
+  'a non-admin cannot self-promote is_admin'
+);
+select throws_ok(
+  $$ update public.user_profiles set roles = '{"bento":["admin"]}'::jsonb where id = '11111111-1111-1111-1111-111111111111' $$,
+  'Direct modification of roles is not allowed',
+  'a non-admin cannot self-grant app roles'
+);
+
+-- 3. but a non-privileged self-update of the same row is allowed (proves the
+--    trigger gates only the privileged columns, not the whole row)
+select lives_ok(
+  $$ update public.user_profiles set name = 'Renamed' where id = '11111111-1111-1111-1111-111111111111' $$,
+  'a user can still update non-privileged columns on their own profile'
+);
+
+-- 4. game_scores has no INSERT policy → direct writes are denied (must go
+--    through the submit_game_score RPC gate)
+select throws_ok(
+  $$ insert into public.game_scores (user_id, game_type, score, finish_time_ms)
+     values ('11111111-1111-1111-1111-111111111111', '2048', 999999, 1) $$,
+  '42501',
+  NULL,
+  'direct INSERT into game_scores is denied by RLS (no insert policy)'
+);
+
+-- 5-6. game_scores is append-only: the deny-all UPDATE/DELETE policies make
+--    those a silent no-op even for the row owner (RLS matches 0 rows).
+update public.game_scores set score = 999999 where user_id = '11111111-1111-1111-1111-111111111111';
+select is(
+  (select score from public.game_scores where user_id = '11111111-1111-1111-1111-111111111111'),
+  1000,
+  'game_scores UPDATE is a no-op for the owner (append-only)'
+);
+delete from public.game_scores where user_id = '11111111-1111-1111-1111-111111111111';
+select is(
+  (select count(*) from public.game_scores where user_id = '11111111-1111-1111-1111-111111111111'),
+  1::bigint,
+  'game_scores DELETE is a no-op for the owner (append-only)'
+);
+
+-- 7. trip_admin_get_member_signatures only returns rows for trip admins; an
+--    ordinary user gets zero rows regardless of the trip id (no signature leak).
+select is(
+  (select count(*) from public.trip_admin_get_member_signatures('33333333-3333-3333-3333-333333333333')),
+  0::bigint,
+  'a non-trip-admin batch-reads zero member signatures'
+);
+
+-- 8. another user (B) cannot read A's profile email via a privileged column?
+--    profiles are intentionally world-readable for signing, so instead assert
+--    B cannot mutate A's row (ownership check on the update policy).
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"22222222-2222-2222-2222-222222222222","role":"authenticated"}',
+  true
+);
+update public.user_profiles set name = 'HijackedByB' where id = '11111111-1111-1111-1111-111111111111';
+reset role;
+select is(
+  (select name from public.user_profiles where id = '11111111-1111-1111-1111-111111111111'),
+  'Renamed',
+  'user B cannot update user A''s profile (ownership-scoped update policy)'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Refs #160 (CodeQL / e2e / CI parallelization — remaining #160 items — follow in separate PRs)

## Summary

The security core of the testing overhaul: a pgTAP suite that exercises the RLS / SECURITY DEFINER boundaries against a real Postgres, plus the CI job that runs it. Builds on the captured baseline (#165) — `supabase db start` applies `supabase/migrations/**` then `supabase test db` runs the suite.

### `supabase/tests/rls.test.sql` (8 assertions, all green)
- `prevent_role_escalation` blocks a non-admin self-promoting `is_admin` / self-granting `roles`
- a non-privileged self-update of the same row still works (trigger gates only the privileged columns)
- direct `INSERT` into `game_scores` is denied (no insert policy — writes must go through the `submit_game_score` RPC gate)
- `game_scores` is append-only: owner `UPDATE`/`DELETE` are silent no-ops
- `trip_admin_get_member_signatures` returns 0 rows for a non-trip-admin (no signature leak)
- user B cannot update user A's profile (ownership-scoped update policy)

Impersonation uses the `authenticated` role + `request.jwt.claims` (what `auth.uid()` reads) — no external test-helper dependency.

### `.github/workflows/db-tests.yml`
`supabase/setup-cli@v2` → `supabase db start` → `supabase test db`, gated on `paths: supabase/migrations|tests/**` so it doesn't slow the unit lane.

## Validated
Ran the full sequence on a clean Postgres (fresh `supabase db start` applying the baseline from scratch) — `supabase test db` → **All tests successful (8/8)**.

## Test plan
- [x] `supabase db start` + `supabase test db` on a clean volume → 8/8 pass.