### PR TITLE
ci: add CodeQL static analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: CodeQL
+
+# Static analysis (taint flow) for the auth / OAuth / file-upload / PDF surfaces
+# that ESLint can't reach. Runs on main + weekly — NOT a per-PR blocking gate,
+# so PR feedback stays fast.
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 3 * * 1" # Mondays 03:00 UTC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+
+      # No build step — CodeQL analyzes TS/JS sources directly.
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"


### PR DESCRIPTION
Closes #160

## Summary

Adds CodeQL (taint-flow SAST) for the JS/TS surfaces ESLint can't reach — the Keycloak auth flow, the MCP OAuth 2.1 server, gallery/receipts file uploads, and pdf-lib generation.

- Triggers on push to `main` + a weekly cron — **not** a per-PR blocking gate, so PR feedback stays fast.
- `permissions: security-events: write` (needed to upload results) + `contents: read`.
- No build step — CodeQL analyzes TS/JS sources directly.

This is the last of the #160 add-ons taken this round. CI parallelization (matrix / `--affected`) is deferred — it renames the required status checks and needs a branch-protection update to land safely. Playwright e2e is deferred — it needs a seeded Keycloak/auth environment. Both remain tracked notes in the strategy doc.

## Test plan
- [x] Existing CI (typecheck/lint/build) unaffected.
- [ ] CodeQL runs on merge to `main` (main-triggered; confirmed post-merge).