### PR TITLE
ci: bump codeql-action to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,11 +24,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript
 
       # No build step — CodeQL analyzes TS/JS sources directly.
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@v4
         with:
           category: "/language:javascript-typescript"


### PR DESCRIPTION
Follow-up to #169. The v3 run on main passed but GitHub flags v3 for deprecation (Dec 2026); v4 is the current major. No behavior change.

## Test plan
- [x] v3 CodeQL run on main succeeded before this bump.
- [ ] v4 run confirmed on merge to main.