### PR TITLE
feat(gallery): comments, burst sequences, and paginated wall

### DIFF
--- a/apps/gallery/app/_components/gallery-card.tsx
+++ b/apps/gallery/app/_components/gallery-card.tsx
@@ -1,8 +1,14 @@
 "use client"
 
-import { useState, useTransition, type Dispatch, type SetStateAction } from "react"
+import {
+  useEffect,
+  useState,
+  useTransition,
+  type Dispatch,
+  type SetStateAction,
+} from "react"
 
-import { IconX } from "@tabler/icons-react"
+import { IconChevronLeft, IconChevronRight, IconX } from "@tabler/icons-react"
 
 import {
   Dialog,
@@ -20,6 +26,7 @@ import { cn } from "@workspace/ui/lib/utils"
 import { toast } from "sonner"
 
 import { ReactionBar } from "@/app/_components/reaction-bar"
+import { GalleryComments } from "@/app/_components/gallery-comments"
 import { ReactionGlyph } from "@/app/_components/reaction-glyph"
 import { setGalleryReaction } from "@/app/actions"
 import { getRotation } from "@/lib/gallery/rotation"
@@ -30,7 +37,7 @@ import {
   type ReactionNames,
   totalReactions,
 } from "@/lib/gallery/reactions"
-import type { GalleryImage } from "@/lib/gallery/types"
+import type { GalleryImage, GallerySequenceItem } from "@/lib/gallery/types"
 import { getGalleryImageUrl } from "@/lib/gallery/url"
 
 function applyReactionOptimistic(
@@ -80,22 +87,49 @@ function applyReactionOptimistic(
   return "added" as const
 }
 
+function mediaUrlFromItem(item: GallerySequenceItem): string {
+  return getGalleryImageUrl(item.image_path)
+}
+
+function posterUrlFromItem(item: GallerySequenceItem): string | null {
+  return item.poster_path ? getGalleryImageUrl(item.poster_path) : null
+}
+
 export function GalleryCard({
   image,
   isSignedIn,
+  viewerId,
   viewerName,
 }: {
   image: GalleryImage
   isSignedIn: boolean
+  viewerId: string | null
   viewerName: string
 }) {
   const rotation = getRotation(image.id)
-  const isVideo = image.media_type === "video"
-  const mediaUrl = getGalleryImageUrl(image.image_path)
-  const thumbUrl =
-    isVideo && image.poster_path
-      ? getGalleryImageUrl(image.poster_path)
-      : mediaUrl
+  const sequenceMedia: GallerySequenceItem[] =
+    image.sequence_items.length > 0
+      ? image.sequence_items
+      : [
+          {
+            id: image.id,
+            name: image.name,
+            image_path: image.image_path,
+            media_type: image.media_type,
+            poster_path: image.poster_path,
+          },
+        ]
+  const isSequence = sequenceMedia.length > 1
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(0)
+  const activeItem = sequenceMedia[activeIndex] ?? sequenceMedia[0]
+  const activeIsVideo = activeItem?.media_type === "video"
+  const mediaUrl = activeItem ? mediaUrlFromItem(activeItem) : ""
+  const thumbUrl = activeItem
+    ? activeIsVideo && activeItem.poster_path
+      ? posterUrlFromItem(activeItem) ?? mediaUrlFromItem(activeItem)
+      : mediaUrlFromItem(activeItem)
+    : ""
   const [thumbFailed, setThumbFailed] = useState(false)
   const [lightboxFailed, setLightboxFailed] = useState(false)
   const [isPending, startTransition] = useTransition()
@@ -105,6 +139,16 @@ export function GalleryCard({
 
   const canReact = isSignedIn && !isPending
   const reactionTotal = totalReactions(counts)
+
+  useEffect(() => {
+    if (isDialogOpen) return
+    setActiveIndex(0)
+    setLightboxFailed(false)
+  }, [isDialogOpen])
+
+  useEffect(() => {
+    setLightboxFailed(false)
+  }, [activeIndex])
 
   const onReact = (reaction: GalleryReaction) => {
     if (!isSignedIn) {
@@ -147,7 +191,7 @@ export function GalleryCard({
         } as React.CSSProperties
       }
     >
-      <Dialog>
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <DialogTrigger asChild>
           <div
             className={cn(
@@ -163,7 +207,7 @@ export function GalleryCard({
               <>
                 <img
                   src={thumbUrl}
-                  alt={image.name}
+                  alt={activeItem?.name ?? image.name}
                   width={1200}
                   height={1500}
                   loading="lazy"
@@ -171,7 +215,12 @@ export function GalleryCard({
                   className="h-auto w-full object-cover"
                   onError={() => setThumbFailed(true)}
                 />
-                {isVideo ? <PlayBadge /> : null}
+                {activeIsVideo ? <PlayBadge /> : null}
+                {isSequence ? (
+                  <div className="pointer-events-none absolute top-3 right-3 rounded-full bg-black/65 px-2.5 py-1 text-xs text-white">
+                    {image.sequence_count} shots
+                  </div>
+                ) : null}
               </>
             )}
           </div>
@@ -179,11 +228,10 @@ export function GalleryCard({
         <DialogContent
           showCloseButton={false}
           className={cn(
-            "flex h-[100dvh] w-screen max-w-none items-center justify-center !rounded-none border-0 bg-transparent p-4 shadow-none ring-0",
-            "sm:h-auto sm:max-h-[95vh] sm:w-auto sm:max-w-[95vw]"
+            "!h-[100dvh] !w-screen !max-w-none !rounded-none border-0 bg-transparent p-2 shadow-none ring-0"
           )}
         >
-          <DialogTitle className="sr-only">{image.name}</DialogTitle>
+          <DialogTitle className="sr-only">{activeItem?.name ?? image.name}</DialogTitle>
           <DialogClose
             aria-label="Close"
             className={cn(
@@ -196,34 +244,93 @@ export function GalleryCard({
           >
             <IconX className="h-5 w-5" />
           </DialogClose>
-          {lightboxFailed ? (
-            <div className="max-w-[95vw] rounded-sm bg-muted px-8 py-16 text-center text-muted-foreground italic shadow-2xl">
-              This {isVideo ? "video" : "image"} cannot be previewed in your
-              browser.
+          <div className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-xl border border-white/10 bg-background/95 shadow-2xl md:flex-row">
+            <div className="relative flex min-h-[42vh] min-w-0 flex-1 items-center justify-center bg-black/70 p-4 md:min-h-0 md:min-w-[22rem]">
+              {lightboxFailed ? (
+                <div className="max-w-[95vw] rounded-sm bg-muted px-8 py-16 text-center text-muted-foreground italic shadow-2xl">
+                  This {activeIsVideo ? "video" : "image"} cannot be previewed in
+                  your browser.
+                </div>
+              ) : activeIsVideo ? (
+                <video
+                  src={mediaUrl}
+                  poster={
+                    activeItem ? (posterUrlFromItem(activeItem) ?? undefined) : undefined
+                  }
+                  controls
+                  autoPlay
+                  playsInline
+                  preload="metadata"
+                  className="block h-auto max-h-[calc(100dvh-5.5rem)] w-auto max-w-full bg-black object-contain shadow-2xl"
+                  onError={() => setLightboxFailed(true)}
+                />
+              ) : (
+                <img
+                  src={mediaUrl}
+                  alt={activeItem?.name ?? image.name}
+                  className="block h-auto max-h-[calc(100dvh-5.5rem)] w-auto max-w-full bg-white object-contain shadow-2xl"
+                  onError={() => setLightboxFailed(true)}
+                />
+              )}
+              {isSequence ? (
+                <>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setActiveIndex((idx) =>
+                        idx === 0 ? sequenceMedia.length - 1 : idx - 1
+                      )
+                    }
+                    className="absolute left-3 top-1/2 z-[60] inline-flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-white/85 text-foreground shadow-lg backdrop-blur-sm transition-colors hover:bg-white focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none"
+                    aria-label="Previous photo"
+                  >
+                    <IconChevronLeft className="h-5 w-5" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setActiveIndex((idx) => (idx + 1) % sequenceMedia.length)
+                    }
+                    className="absolute right-3 top-1/2 z-[60] inline-flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-white/85 text-foreground shadow-lg backdrop-blur-sm transition-colors hover:bg-white focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none"
+                    aria-label="Next photo"
+                  >
+                    <IconChevronRight className="h-5 w-5" />
+                  </button>
+                  <div className="absolute right-0 bottom-3 left-0 z-[60] mx-auto flex w-full max-w-2xl items-center justify-center gap-2 px-4">
+                    {sequenceMedia.map((item, idx) => (
+                      <button
+                        key={item.id}
+                        type="button"
+                        onClick={() => setActiveIndex(idx)}
+                        className={cn(
+                          "h-2.5 w-2.5 rounded-full bg-white/50 transition-colors",
+                          idx === activeIndex && "bg-white"
+                        )}
+                        aria-label={`View shot ${idx + 1}`}
+                      />
+                    ))}
+                  </div>
+                </>
+              ) : null}
             </div>
-          ) : isVideo ? (
-            <video
-              src={mediaUrl}
-              poster={
-                image.poster_path
-                  ? getGalleryImageUrl(image.poster_path)
-                  : undefined
-              }
-              controls
-              autoPlay
-              playsInline
-              preload="metadata"
-              className="block h-auto max-h-full w-auto max-w-full bg-black object-contain shadow-2xl"
-              onError={() => setLightboxFailed(true)}
-            />
-          ) : (
-            <img
-              src={mediaUrl}
-              alt={image.name}
-              className="block h-auto max-h-full w-auto max-w-full bg-white object-contain shadow-2xl"
-              onError={() => setLightboxFailed(true)}
-            />
-          )}
+            <aside className="flex w-full min-h-0 flex-col border-t border-border/60 bg-background md:w-[24rem] md:shrink-0 md:border-t-0 md:border-l">
+              <div className="border-b border-border/60 px-4 py-3">
+                <p className="truncate text-base text-foreground">{image.name}</p>
+                <p className="mt-1 truncate text-xs text-muted-foreground">
+                  by {image.uploader_name}
+                </p>
+              </div>
+              <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+                <GalleryComments
+                  imageId={image.id}
+                  initialComments={image.comments}
+                  isSignedIn={isSignedIn}
+                  viewerId={viewerId}
+                  viewerName={viewerName}
+                />
+              </div>
+            </aside>
+          </div>
         </DialogContent>
       </Dialog>
       <figcaption
@@ -237,18 +344,32 @@ export function GalleryCard({
           <p className="mt-1 truncate text-sm text-muted-foreground md:text-base">
             by {image.uploader_name}
           </p>
+          {isSequence ? (
+            <p className="mt-1 truncate text-xs text-muted-foreground/80 not-italic md:text-sm">
+              Sequence · {image.sequence_count} shots (tap to expand)
+            </p>
+          ) : null}
           <ReactionSummary
             total={reactionTotal}
             counts={counts}
             namesByReaction={namesByReaction}
           />
         </div>
-        <ReactionBar
-          counts={counts}
-          myReaction={myReaction}
-          canReact={canReact}
-          onReact={onReact}
-        />
+        <div className="flex items-center gap-3 self-end sm:self-auto">
+          <button
+            type="button"
+            onClick={() => setIsDialogOpen(true)}
+            className="text-xs text-muted-foreground not-italic transition-colors hover:text-foreground md:text-sm"
+          >
+            Comments ({image.comments.length})
+          </button>
+          <ReactionBar
+            counts={counts}
+            myReaction={myReaction}
+            canReact={canReact}
+            onReact={onReact}
+          />
+        </div>
       </figcaption>
     </figure>
   )

--- a/apps/gallery/app/_components/gallery-comments.tsx
+++ b/apps/gallery/app/_components/gallery-comments.tsx
@@ -1,0 +1,213 @@
+"use client"
+
+import { useMemo, useState, useTransition } from "react"
+
+import { Button } from "@workspace/ui/components/button"
+import { Textarea } from "@workspace/ui/components/textarea"
+import { cn } from "@workspace/ui/lib/utils"
+import { toast } from "sonner"
+
+import { addGalleryComment, deleteGalleryComment } from "@/app/actions"
+import type { GalleryComment } from "@/lib/gallery/types"
+
+type CommentNode = GalleryComment & { depth: number }
+
+export function GalleryComments({
+  imageId,
+  initialComments,
+  isSignedIn,
+  viewerId,
+  viewerName,
+}: {
+  imageId: string
+  initialComments: GalleryComment[]
+  isSignedIn: boolean
+  viewerId: string | null
+  viewerName: string
+}) {
+  const [comments, setComments] = useState(initialComments)
+  const [draft, setDraft] = useState("")
+  const [replyTarget, setReplyTarget] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  const flattened = useMemo(() => flattenComments(comments), [comments])
+
+  const submit = () => {
+    if (!isSignedIn) {
+      toast.error("Please sign in before commenting.")
+      return
+    }
+    const body = draft.trim()
+    if (!body) return
+
+    startTransition(async () => {
+      const result = await addGalleryComment(imageId, body, replyTarget)
+      if (!result.ok) {
+        toast.error(result.error)
+        return
+      }
+      setComments((prev) => [
+        ...prev,
+        {
+          ...result.data,
+          commenter_name: viewerName,
+        },
+      ])
+      setDraft("")
+      setReplyTarget(null)
+      toast.success("Comment posted.")
+    })
+  }
+
+  const removeComment = (commentId: string) => {
+    startTransition(async () => {
+      const result = await deleteGalleryComment(commentId)
+      if (!result.ok) {
+        toast.error(result.error)
+        return
+      }
+      setComments((prev) => removeCommentWithDescendants(prev, commentId))
+      toast.success("Comment deleted.")
+    })
+  }
+
+  return (
+    <div className="mt-3 space-y-3 not-italic">
+      <div className="space-y-2">
+        <Textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder={
+            isSignedIn ? "Write a comment..." : "Sign in to leave a comment"
+          }
+          disabled={!isSignedIn || isPending}
+          className="min-h-20 resize-none text-sm"
+        />
+        <div className="flex items-center justify-between gap-2">
+          {replyTarget ? (
+            <button
+              type="button"
+              onClick={() => setReplyTarget(null)}
+              className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+            >
+              Replying to a comment · cancel
+            </button>
+          ) : (
+            <span className="text-xs text-muted-foreground">
+              {comments.length} comment{comments.length === 1 ? "" : "s"}
+            </span>
+          )}
+          <Button
+            type="button"
+            size="sm"
+            disabled={!isSignedIn || isPending || !draft.trim()}
+            onClick={submit}
+          >
+            Post
+          </Button>
+        </div>
+      </div>
+
+      {flattened.length === 0 ? (
+        <p className="text-xs text-muted-foreground">No comments yet.</p>
+      ) : (
+        <ul className="space-y-2">
+          {flattened.map((comment) => {
+            const mine = viewerId === comment.created_by
+            return (
+              <li
+                key={comment.id}
+                className={cn(
+                  "space-y-1 rounded-md border border-border/60 px-3 py-2",
+                  comment.depth > 0 && "ml-5"
+                )}
+              >
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <span className="font-medium text-foreground">
+                    {comment.commenter_name}
+                  </span>
+                  <span>·</span>
+                  <span>{new Date(comment.created_at).toLocaleString()}</span>
+                </div>
+                <p className="whitespace-pre-wrap break-words text-sm leading-relaxed text-foreground/90">
+                  {comment.body}
+                </p>
+                <div className="flex items-center gap-3">
+                  {isSignedIn ? (
+                    <button
+                      type="button"
+                      onClick={() => setReplyTarget(comment.id)}
+                      className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+                    >
+                      Reply
+                    </button>
+                  ) : null}
+                  {mine ? (
+                    <button
+                      type="button"
+                      onClick={() => removeComment(comment.id)}
+                      className="text-xs text-destructive/90 transition-colors hover:text-destructive"
+                    >
+                      Delete
+                    </button>
+                  ) : null}
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function flattenComments(comments: GalleryComment[]): CommentNode[] {
+  const byParent = new Map<string | null, GalleryComment[]>()
+  for (const comment of comments) {
+    const bucket = byParent.get(comment.parent_id) ?? []
+    bucket.push(comment)
+    byParent.set(comment.parent_id, bucket)
+  }
+  for (const bucket of byParent.values()) {
+    bucket.sort(
+      (a, b) =>
+        new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+    )
+  }
+
+  const out: CommentNode[] = []
+  const walk = (parentId: string | null, depth: number) => {
+    const children = byParent.get(parentId) ?? []
+    for (const child of children) {
+      out.push({ ...child, depth })
+      walk(child.id, depth + 1)
+    }
+  }
+  walk(null, 0)
+  return out
+}
+
+function removeCommentWithDescendants(
+  comments: GalleryComment[],
+  targetId: string
+): GalleryComment[] {
+  const childrenByParent = new Map<string, string[]>()
+  for (const c of comments) {
+    if (!c.parent_id) continue
+    const bucket = childrenByParent.get(c.parent_id) ?? []
+    bucket.push(c.id)
+    childrenByParent.set(c.parent_id, bucket)
+  }
+
+  const toDelete = new Set<string>()
+  const queue = [targetId]
+  while (queue.length > 0) {
+    const current = queue.shift()
+    if (!current || toDelete.has(current)) continue
+    toDelete.add(current)
+    const children = childrenByParent.get(current) ?? []
+    for (const childId of children) queue.push(childId)
+  }
+
+  return comments.filter((c) => !toDelete.has(c.id))
+}

--- a/apps/gallery/app/_components/gallery-grid.tsx
+++ b/apps/gallery/app/_components/gallery-grid.tsx
@@ -19,10 +19,12 @@ function pickCols(width: number): number {
 export function GalleryGrid({
   images,
   isSignedIn,
+  viewerId,
   viewerName,
 }: {
   images: GalleryImage[]
   isSignedIn: boolean
+  viewerId: string | null
   viewerName: string
 }) {
   // SSR seeds with 3-col layout (desktop default). useEffect rebuckets on
@@ -63,6 +65,7 @@ export function GalleryGrid({
               key={image.id}
               image={image}
               isSignedIn={isSignedIn}
+              viewerId={viewerId}
               viewerName={viewerName}
             />
           ))}

--- a/apps/gallery/app/_components/gallery-pagination.tsx
+++ b/apps/gallery/app/_components/gallery-pagination.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link"
+
+import { cn } from "@workspace/ui/lib/utils"
+
+function buildPageHref(page: number) {
+  if (page <= 1) return "/"
+  return `/?page=${page}`
+}
+
+export function GalleryPagination({
+  page,
+  totalPages,
+}: {
+  page: number
+  totalPages: number
+}) {
+  if (totalPages <= 1) return null
+
+  const start = Math.max(1, page - 2)
+  const end = Math.min(totalPages, start + 4)
+  const visible = Array.from({ length: end - start + 1 }, (_, i) => start + i)
+
+  return (
+    <nav
+      aria-label="Gallery pages"
+      className="mt-12 flex items-center justify-center gap-2 not-italic"
+    >
+      <Link
+        href={buildPageHref(page - 1)}
+        className={cn(
+          "rounded-full border px-3 py-1 text-sm transition-colors",
+          page <= 1
+            ? "pointer-events-none opacity-40"
+            : "hover:bg-foreground/10"
+        )}
+      >
+        Prev
+      </Link>
+      {visible.map((p) => (
+        <Link
+          key={p}
+          href={buildPageHref(p)}
+          className={cn(
+            "rounded-full border px-3 py-1 text-sm transition-colors",
+            p === page
+              ? "border-foreground bg-foreground/10 text-foreground"
+              : "hover:bg-foreground/10"
+          )}
+        >
+          {p}
+        </Link>
+      ))}
+      <Link
+        href={buildPageHref(page + 1)}
+        className={cn(
+          "rounded-full border px-3 py-1 text-sm transition-colors",
+          page >= totalPages
+            ? "pointer-events-none opacity-40"
+            : "hover:bg-foreground/10"
+        )}
+      >
+        Next
+      </Link>
+    </nav>
+  )
+}

--- a/apps/gallery/app/actions.ts
+++ b/apps/gallery/app/actions.ts
@@ -9,6 +9,9 @@ import {
 import { createClient } from "@/lib/supabase/server"
 
 export type ReactionActionResult = { ok: true } | { ok: false; error: string }
+export type CommentActionResult<T = undefined> =
+  | ({ ok: true } & (T extends undefined ? {} : { data: T }))
+  | { ok: false; error: string }
 
 export async function setGalleryReaction(
   imageId: string,
@@ -63,6 +66,89 @@ export async function setGalleryReaction(
     if (insertError) {
       return { ok: false, error: `Reaction failed: ${insertError.message}` }
     }
+  }
+
+  revalidatePath("/")
+  return { ok: true }
+}
+
+export type CreatedGalleryComment = {
+  id: string
+  image_id: string
+  parent_id: string | null
+  body: string
+  created_by: string
+  created_at: string
+}
+
+export async function addGalleryComment(
+  imageId: string,
+  body: string,
+  parentId?: string | null
+): Promise<CommentActionResult<CreatedGalleryComment>> {
+  const trimmed = body.trim()
+  if (!imageId) return { ok: false, error: "Missing image id." }
+  if (!trimmed) return { ok: false, error: "Comment cannot be empty." }
+  if (trimmed.length > 1000) {
+    return { ok: false, error: "Comment is too long (max 1000 chars)." }
+  }
+
+  const supabase = await createClient()
+  const { data: claimsData } = await supabase.auth.getClaims()
+  const userId = claimsData?.claims?.sub
+  if (!userId) return { ok: false, error: "Please sign in first." }
+
+  if (parentId) {
+    const { data: parent, error: parentError } = await supabase
+      .from("gallery_comments")
+      .select("id, image_id")
+      .eq("id", parentId)
+      .maybeSingle()
+    if (parentError) {
+      return { ok: false, error: `Comment failed: ${parentError.message}` }
+    }
+    if (!parent || parent.image_id !== imageId) {
+      return { ok: false, error: "Invalid parent comment." }
+    }
+  }
+
+  const { data, error } = await supabase
+    .from("gallery_comments")
+    .insert({
+      image_id: imageId,
+      parent_id: parentId ?? null,
+      body: trimmed,
+      created_by: userId,
+    })
+    .select("id, image_id, parent_id, body, created_by, created_at")
+    .single()
+
+  if (error || !data) {
+    return { ok: false, error: `Comment failed: ${error?.message ?? "Unknown error."}` }
+  }
+
+  revalidatePath("/")
+  return { ok: true, data }
+}
+
+export async function deleteGalleryComment(
+  commentId: string
+): Promise<CommentActionResult> {
+  if (!commentId) return { ok: false, error: "Missing comment id." }
+
+  const supabase = await createClient()
+  const { data: claimsData } = await supabase.auth.getClaims()
+  const userId = claimsData?.claims?.sub
+  if (!userId) return { ok: false, error: "Please sign in first." }
+
+  const { error } = await supabase
+    .from("gallery_comments")
+    .delete()
+    .eq("id", commentId)
+    .eq("created_by", userId)
+
+  if (error) {
+    return { ok: false, error: `Delete failed: ${error.message}` }
   }
 
   revalidatePath("/")

--- a/apps/gallery/app/page.tsx
+++ b/apps/gallery/app/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link"
 
 import { PortalShell } from "@workspace/ui/components/portal-shell"
 
+import { GalleryPagination } from "@/app/_components/gallery-pagination"
 import { GalleryGrid } from "@/app/_components/gallery-grid"
 import { SignOutButton } from "@/components/sign-out-button"
 import {
@@ -10,30 +11,78 @@ import {
   aggregateReactions,
   isGalleryReaction,
 } from "@/lib/gallery/reactions"
-import type { GalleryImage } from "@/lib/gallery/types"
+import type { GalleryComment, GalleryImage } from "@/lib/gallery/types"
 import { createClient } from "@/lib/supabase/server"
 import { getCurrentUser } from "@/lib/user"
 
 export const dynamic = "force-dynamic"
 
-export default async function GalleryHomePage() {
+const PAGE_SIZE = 36
+
+type GalleryHomePageProps = {
+  searchParams: Promise<{ page?: string }>
+}
+
+export default async function GalleryHomePage({
+  searchParams,
+}: GalleryHomePageProps) {
+  const { page } = await searchParams
+  const parsedPage = Number.parseInt(page ?? "1", 10)
+  const currentPage = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1
+  const from = (currentPage - 1) * PAGE_SIZE
+  const to = from + PAGE_SIZE - 1
+
   const supabase = await createClient()
   const user = await getCurrentUser()
-  const { data, error } = await supabase
+  const { data, count, error } = await supabase
     .from("gallery_images")
     .select(
-      "id, name, image_path, media_type, poster_path, duration_seconds, created_by, created_at"
+      "id, name, image_path, media_type, poster_path, duration_seconds, created_by, created_at, sequence_id, sequence_index",
+      { count: "exact" }
     )
+    .or("sequence_id.is.null,sequence_index.eq.0")
     .order("created_at", { ascending: false })
+    .range(from, to)
 
   if (error) {
     console.error("[gallery] failed to load images", error)
   }
 
-  const baseImages = data ?? []
-  const imageIds = baseImages.map((image) => image.id)
+  const coverRows = data ?? []
+  const sequenceIds = Array.from(
+    new Set(
+      coverRows
+        .map((image) => image.sequence_id)
+        .filter((id): id is string => typeof id === "string")
+    )
+  )
+
+  const sequenceRowsById = new Map<string, typeof coverRows>()
+  if (sequenceIds.length > 0) {
+    const { data: sequenceRows, error: sequenceError } = await supabase
+      .from("gallery_images")
+      .select(
+        "id, name, image_path, media_type, poster_path, duration_seconds, created_by, created_at, sequence_id, sequence_index"
+      )
+      .in("sequence_id", sequenceIds)
+      .order("sequence_index", { ascending: true })
+      .order("created_at", { ascending: true })
+    if (sequenceError) {
+      console.error("[gallery] failed to load sequence rows", sequenceError)
+    } else {
+      for (const row of sequenceRows ?? []) {
+        const sequenceId = row.sequence_id
+        if (!sequenceId) continue
+        const bucket = sequenceRowsById.get(sequenceId) ?? []
+        bucket.push(row)
+        sequenceRowsById.set(sequenceId, bucket)
+      }
+    }
+  }
+
+  const imageIds = coverRows.map((image) => image.id)
   const creatorIds = Array.from(
-    new Set(baseImages.map((image) => image.created_by).filter(Boolean))
+    new Set(coverRows.map((image) => image.created_by).filter(Boolean))
   ) as string[]
 
   let uploaderNameById = new Map<string, string>()
@@ -62,6 +111,7 @@ export default async function GalleryHomePage() {
   let countsByImage = new Map<string, typeof EMPTY_REACTION_COUNTS>()
   let namesByImage = new Map<string, typeof EMPTY_REACTION_NAMES>()
   const myReactionByImage = new Map<string, GalleryImage["my_reaction"]>()
+  let commentsByImage = new Map<string, GalleryComment[]>()
 
   if (imageIds.length > 0) {
     const { data: voteRows, error: voteError } = await supabase
@@ -120,7 +170,63 @@ export default async function GalleryHomePage() {
     }
   }
 
-  const images: GalleryImage[] = baseImages.map((image) => ({
+  if (imageIds.length > 0) {
+    const { data: commentRows, error: commentError } = await supabase
+      .from("gallery_comments")
+      .select("id, image_id, parent_id, body, created_by, created_at")
+      .in("image_id", imageIds)
+      .order("created_at", { ascending: true })
+
+    if (commentError) {
+      console.error("[gallery] failed to load comments", commentError)
+    } else {
+      const commenterIds = Array.from(
+        new Set((commentRows ?? []).map((row) => row.created_by).filter(Boolean))
+      ) as string[]
+
+      let commenterNameById = new Map<string, string>()
+      if (commenterIds.length > 0) {
+        const { data: commenterProfiles, error: commenterProfilesError } =
+          await supabase
+            .from("user_profiles")
+            .select("id, name, email")
+            .in("id", commenterIds)
+        if (commenterProfilesError) {
+          console.error(
+            "[gallery] failed to load commenter profiles",
+            commenterProfilesError
+          )
+        } else {
+          commenterNameById = (commenterProfiles ?? []).reduce((map, row) => {
+            const fallback =
+              typeof row.email === "string" ? row.email.split("@")[0] : null
+            const name =
+              (typeof row.name === "string" && row.name.trim()) ||
+              fallback ||
+              "Unknown"
+            map.set(row.id, name)
+            return map
+          }, new Map<string, string>())
+        }
+      }
+
+      for (const row of commentRows ?? []) {
+        const bucket = commentsByImage.get(row.image_id) ?? []
+        bucket.push({
+          id: row.id,
+          image_id: row.image_id,
+          parent_id: row.parent_id ?? null,
+          body: row.body,
+          created_by: row.created_by,
+          created_at: row.created_at,
+          commenter_name: commenterNameById.get(row.created_by) ?? "Unknown",
+        })
+        commentsByImage.set(row.image_id, bucket)
+      }
+    }
+  }
+
+  const images: GalleryImage[] = coverRows.map((image) => ({
     id: image.id,
     name: image.name,
     image_path: image.image_path,
@@ -129,6 +235,12 @@ export default async function GalleryHomePage() {
     duration_seconds: image.duration_seconds ?? null,
     created_by: image.created_by,
     created_at: image.created_at,
+    sequence_id: image.sequence_id ?? null,
+    sequence_index:
+      typeof image.sequence_index === "number" ? image.sequence_index : null,
+    sequence_count: 1,
+    sequence_items: [],
+    comments: commentsByImage.get(image.id) ?? [],
     uploader_name: image.created_by
       ? (uploaderNameById.get(image.created_by) ?? "Unknown")
       : "Unknown",
@@ -137,12 +249,36 @@ export default async function GalleryHomePage() {
     reaction_names: namesByImage.get(image.id) ?? EMPTY_REACTION_NAMES,
   }))
 
+  for (const image of images) {
+    if (!image.sequence_id) continue
+    const items = sequenceRowsById.get(image.sequence_id) ?? []
+    if (items.length <= 1) continue
+    image.sequence_count = items.length
+    image.sequence_items = items.map((item) => ({
+      id: item.id,
+      name: item.name,
+      image_path: item.image_path,
+      media_type: item.media_type === "video" ? "video" : "image",
+      poster_path: item.poster_path ?? null,
+    }))
+  }
+
+  const totalPages = Math.max(1, Math.ceil((count ?? 0) / PAGE_SIZE))
+
   return (
     <PortalShell
       appName="Gallery"
       appHref="/"
       containerClassName="mx-auto w-full max-w-7xl px-6 py-24"
       cornerClassName="text-lg"
+      bottomLeft={
+        <Link
+          href="https://portal.winlab.tw"
+          className="transition-colors hover:text-foreground"
+        >
+          ← Portal
+        </Link>
+      }
       topRight={
         user ? (
           <div className="flex items-center gap-4">
@@ -167,8 +303,10 @@ export default async function GalleryHomePage() {
       <GalleryGrid
         images={images}
         isSignedIn={Boolean(user)}
+        viewerId={user?.id ?? null}
         viewerName={user?.name ?? "You"}
       />
+      <GalleryPagination page={currentPage} totalPages={totalPages} />
     </PortalShell>
   )
 }

--- a/apps/gallery/app/upload/_components/upload-form.tsx
+++ b/apps/gallery/app/upload/_components/upload-form.tsx
@@ -76,6 +76,7 @@ export function UploadForm() {
 
       let successCount = 0
       const failed: string[] = []
+      const sequenceId = files.length > 1 ? crypto.randomUUID() : null
 
       for (let i = 0; i < files.length; i++) {
         const file = files[i]!
@@ -103,6 +104,8 @@ export function UploadForm() {
               artworkName,
               setStatus,
               labelPrefix,
+              sequenceId,
+              sequenceIndex: sequenceId ? i : null,
             })
           } else {
             await uploadVideo({
@@ -112,6 +115,8 @@ export function UploadForm() {
               artworkName,
               setStatus,
               labelPrefix,
+              sequenceId,
+              sequenceIndex: sequenceId ? i : null,
             })
           }
           successCount += 1
@@ -181,6 +186,9 @@ export function UploadForm() {
           Videos: max {VIDEO_MAX_DURATION_SECONDS}s, auto-compressed to 720p mp4
           in your browser.
         </p>
+        <p className="text-sm text-muted-foreground italic">
+          Multi-select uploads are grouped as one sequence card on the wall.
+        </p>
       </div>
       {status.kind === "working" ? (
         <div className="flex flex-col gap-2">
@@ -212,6 +220,8 @@ type UploadCtx = {
   artworkName: string
   setStatus: (s: Status) => void
   labelPrefix: string
+  sequenceId: string | null
+  sequenceIndex: number | null
 }
 
 async function uploadImage(
@@ -225,6 +235,8 @@ async function uploadImage(
     artworkName,
     setStatus,
     labelPrefix,
+    sequenceId,
+    sequenceIndex,
   } = ctx
   const ext = guessExtension(resolved.mime, file.name)
   if (ext === "bin") throw new Error("Unsupported extension")
@@ -254,6 +266,8 @@ async function uploadImage(
     name: artworkName,
     imagePath: objectPath,
     mediaType: "image",
+    sequenceId,
+    sequenceIndex,
   })
   if (!result.ok) {
     await supabase.storage.from("gallery").remove([objectPath])
@@ -262,7 +276,16 @@ async function uploadImage(
 }
 
 async function uploadVideo(ctx: UploadCtx): Promise<void> {
-  const { supabase, userId, file, artworkName, setStatus, labelPrefix } = ctx
+  const {
+    supabase,
+    userId,
+    file,
+    artworkName,
+    setStatus,
+    labelPrefix,
+    sequenceId,
+    sequenceIndex,
+  } = ctx
 
   const compressed = await compressVideo(file, {
     onProgress: (ratio, phase) => {
@@ -319,6 +342,8 @@ async function uploadVideo(ctx: UploadCtx): Promise<void> {
     mediaType: "video",
     posterPath,
     durationSeconds: compressed.durationSeconds,
+    sequenceId,
+    sequenceIndex,
   })
   if (!result.ok) {
     await supabase.storage.from("gallery").remove([videoPath, posterPath])

--- a/apps/gallery/app/upload/actions.ts
+++ b/apps/gallery/app/upload/actions.ts
@@ -13,6 +13,8 @@ export type RegisterMediaInput = {
   mediaType: "image" | "video"
   posterPath?: string | null
   durationSeconds?: number | null
+  sequenceId?: string | null
+  sequenceIndex?: number | null
 }
 
 /**
@@ -33,6 +35,12 @@ export async function registerGalleryImage(
   }
   if (input.mediaType === "image" && input.posterPath) {
     return { ok: false, error: "Images must not have a poster path." }
+  }
+  if ((input.sequenceId && input.sequenceIndex == null) || (!input.sequenceId && input.sequenceIndex != null)) {
+    return { ok: false, error: "Sequence metadata is incomplete." }
+  }
+  if (input.sequenceIndex != null && input.sequenceIndex < 0) {
+    return { ok: false, error: "Invalid sequence index." }
   }
 
   const supabase = await createClient()
@@ -92,6 +100,8 @@ export async function registerGalleryImage(
         ? Math.max(1, Math.round(input.durationSeconds))
         : null,
     created_by: userId,
+    sequence_id: input.sequenceId ?? null,
+    sequence_index: input.sequenceIndex ?? null,
   }
 
   const { error: insertError } = await supabase

--- a/apps/gallery/lib/gallery/types.ts
+++ b/apps/gallery/lib/gallery/types.ts
@@ -19,9 +19,32 @@ export type GalleryImage = {
   duration_seconds: number | null
   created_by: string | null
   created_at: string
+  sequence_id: string | null
+  sequence_index: number | null
+  sequence_count: number
+  sequence_items: GallerySequenceItem[]
+  comments: GalleryComment[]
   reaction_counts: ReactionCounts
   my_reaction: GalleryReaction | null
   reaction_names: ReactionNames
+}
+
+export type GallerySequenceItem = {
+  id: string
+  name: string
+  image_path: string
+  media_type: MediaKind
+  poster_path: string | null
+}
+
+export type GalleryComment = {
+  id: string
+  image_id: string
+  parent_id: string | null
+  body: string
+  created_by: string
+  created_at: string
+  commenter_name: string
 }
 
 export { EMPTY_REACTION_COUNTS, EMPTY_REACTION_NAMES }

--- a/supabase/migrations/2026-06-02-gallery-comments.sql
+++ b/supabase/migrations/2026-06-02-gallery-comments.sql
@@ -1,0 +1,35 @@
+-- Gallery comments with thread-style replies.
+create table if not exists public.gallery_comments (
+  id uuid primary key default gen_random_uuid(),
+  image_id uuid not null references public.gallery_images(id) on delete cascade,
+  parent_id uuid references public.gallery_comments(id) on delete cascade,
+  body text not null check (char_length(trim(body)) between 1 and 1000),
+  created_by uuid not null references public.user_profiles(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  constraint gallery_comments_parent_not_self check (
+    parent_id is null or parent_id <> id
+  )
+);
+
+create index if not exists gallery_comments_image_created_idx
+  on public.gallery_comments (image_id, created_at asc);
+
+create index if not exists gallery_comments_parent_idx
+  on public.gallery_comments (parent_id);
+
+alter table public.gallery_comments enable row level security;
+
+create policy "gallery_comments_select"
+on public.gallery_comments for select
+using (true);
+
+create policy "gallery_comments_insert"
+on public.gallery_comments for insert
+with check (
+  auth.uid() is not null
+  and created_by = auth.uid()
+);
+
+create policy "gallery_comments_delete"
+on public.gallery_comments for delete
+using (created_by = auth.uid());

--- a/supabase/migrations/2026-06-02-gallery-sequences.sql
+++ b/supabase/migrations/2026-06-02-gallery-sequences.sql
@@ -1,0 +1,7 @@
+-- Group burst uploads into a single expandable gallery card.
+alter table public.gallery_images
+  add column if not exists sequence_id uuid,
+  add column if not exists sequence_index integer;
+
+create index if not exists gallery_images_sequence_idx
+  on public.gallery_images (sequence_id, sequence_index, created_at desc);


### PR DESCRIPTION
Closes #80
Closes #149

## Summary
- Threaded comments on gallery works (lightbox sidebar on desktop)
- Burst / sequence uploads (one cover on wall, prev/next in lightbox)
- Paginated wall (36 per page) + Portal link in shell bottom-left

## Test plan
- [ ] Run migrations `2026-06-02-gallery-comments.sql` and `2026-06-02-gallery-sequences.sql` on Supabase
- [ ] Upload multi-file burst; wall shows one card with shot count
- [ ] Post / reply / delete own comment (signed in)
- [ ] Pagination Prev/Next and page numbers
- [ ] `bun run build` in `apps/gallery` passes