### PR TITLE
chore: hide non-signature field types in approve palette

### DIFF
--- a/apps/portal/app/approve/_components/field-palette.tsx
+++ b/apps/portal/app/approve/_components/field-palette.tsx
@@ -7,6 +7,15 @@ import {
   type CategoryDef,
 } from "@/lib/approve/field-categories"
 
+// 前端暫時隱藏這些欄位類型，僅保留「簽名」。恢復時移除此集合與下方的 filter 即可。
+const HIDDEN_CATEGORIES = new Set<CategoryDef["id"]>([
+  "contact_address",
+  "household_address",
+  "id_number",
+  "phone",
+  "other",
+])
+
 export function FieldPalette({
   onPlace,
 }: {
@@ -14,7 +23,7 @@ export function FieldPalette({
 }) {
   return (
     <div className="flex flex-wrap gap-1">
-      {FIELD_CATEGORIES.map((c) => {
+      {FIELD_CATEGORIES.filter((c) => !HIDDEN_CATEGORIES.has(c.id)).map((c) => {
         const Icon = c.icon
         return (
           <Button


### PR DESCRIPTION
Closes #174

## Summary

Frontend-only hide of the non-signature field types in the approve palette. `field-palette.tsx` now filters `contact_address` / `household_address` / `id_number` / `phone` / `other` out of `FIELD_CATEGORIES`, leaving only **signature** placeable.

No backend, schema, or field-rendering changes — existing fields/data are untouched. Reversible by dropping the `HIDDEN_CATEGORIES` set.

## Test plan

- [x] `turbo run typecheck lint --filter=portal` — 0 errors
- [ ] `/approve/new/...` palette shows only the 簽名 button

🤖 Generated with [Claude Code](https://claude.com/claude-code)