### PR TITLE
chore: hide timestamps from approve document list

### DIFF
--- a/apps/portal/app/approve/_components/document-card.tsx
+++ b/apps/portal/app/approve/_components/document-card.tsx
@@ -23,7 +23,7 @@ export function DocumentCard({
 }: {
   href: string
   title: string
-  subtitle: string
+  subtitle?: string
   status?: ApproveDocument["status"]
   actions?: ReactNode
 }) {
@@ -38,7 +38,9 @@ export function DocumentCard({
             </Badge>
           )}
         </div>
-        <p className="text-xs text-muted-foreground">{subtitle}</p>
+        {subtitle && (
+          <p className="text-xs text-muted-foreground">{subtitle}</p>
+        )}
       </Link>
       {actions}
     </div>

--- a/apps/portal/app/approve/_components/document-dashboard.tsx
+++ b/apps/portal/app/approve/_components/document-dashboard.tsx
@@ -95,7 +95,7 @@ export function DocumentDashboard() {
                 key={row.id}
                 href={`/approve/sign/${row.document_id}`}
                 title={row.document.title}
-                subtitle={`送簽：${row.document.creator?.name ?? "?"} · ${row.created_at.slice(0, 10)}`}
+                subtitle={`送簽：${row.document.creator?.name ?? "?"}`}
               />
             ))
           )}
@@ -112,7 +112,6 @@ export function DocumentDashboard() {
                 key={row.id}
                 href={`/approve/view/${row.document_id}`}
                 title={row.document.title}
-                subtitle={`簽於 ${row.signed_at?.slice(0, 10) ?? ""}`}
               />
             ))
           )}
@@ -142,7 +141,6 @@ export function DocumentDashboard() {
                       : `/approve/view/${doc.id}`
                   }
                   title={doc.title}
-                  subtitle={`更新於 ${doc.updated_at.slice(0, 10)}`}
                   status={doc.status}
                   actions={
                     canRemove ? (


### PR DESCRIPTION
Closes #176

## Summary

Hides the date line from the approve document list across all three tabs.

- `DocumentCard` `subtitle` is now optional and only renders the `<p>` when present.
- 代簽 (inbox): `送簽：<name> · <date>` → `送簽：<name>` (keeps sender, drops date)
- 已簽 (signed): drops the `簽於 <date>` subtitle
- 送簽 (sent): drops the `更新於 <date>` subtitle

Frontend-only — no query, schema, or data change.

## Test plan

- [x] `turbo run typecheck lint --filter=portal` — 0 errors
- [ ] `/approve` list: no dates on any tab; 代簽 still shows sender name

🤖 Generated with [Claude Code](https://claude.com/claude-code)