### PR TITLE
chore: restore hidden field types in approve palette

### DIFF
--- a/apps/portal/app/approve/_components/field-palette.tsx
+++ b/apps/portal/app/approve/_components/field-palette.tsx
@@ -7,15 +7,6 @@ import {
   type CategoryDef,
 } from "@/lib/approve/field-categories"
 
-// 前端暫時隱藏這些欄位類型，僅保留「簽名」。恢復時移除此集合與下方的 filter 即可。
-const HIDDEN_CATEGORIES = new Set<CategoryDef["id"]>([
-  "contact_address",
-  "household_address",
-  "id_number",
-  "phone",
-  "other",
-])
-
 export function FieldPalette({
   onPlace,
 }: {
@@ -23,7 +14,7 @@ export function FieldPalette({
 }) {
   return (
     <div className="flex flex-wrap gap-1">
-      {FIELD_CATEGORIES.filter((c) => !HIDDEN_CATEGORIES.has(c.id)).map((c) => {
+      {FIELD_CATEGORIES.map((c) => {
         const Icon = c.icon
         return (
           <Button


### PR DESCRIPTION
Reverts the palette hiding introduced in #175 (issue #174).

## Summary

All field types are placeable in the approve palette again — removed the `HIDDEN_CATEGORIES` filter from `field-palette.tsx`, so `contact_address` / `household_address` / `id_number` / `phone` / `other` show up alongside `signature`.

Frontend-only. File is back to its pre-#175 state.

## Test plan

- [x] `turbo run typecheck lint --filter=portal` — 0 errors
- [ ] `/approve/new/...` palette shows all six field types

🤖 Generated with [Claude Code](https://claude.com/claude-code)