### PR TITLE
chore: hide signed date in approve document view

### DIFF
--- a/apps/portal/app/approve/_components/signer-progress.tsx
+++ b/apps/portal/app/approve/_components/signer-progress.tsx
@@ -34,7 +34,7 @@ export function SignerProgress({
                 : "text-xs"
             }
           >
-            {r.status === "signed" ? r.signed_at?.slice(0, 10) : "pending"}
+            {r.status === "signed" ? "signed" : "pending"}
           </span>
         </div>
       ))}


### PR DESCRIPTION
Closes #179

## Summary

On `/approve/view/<id>`, the signer progress list showed each signer's `signed_at` date once signed. Now it shows `signed` instead — the pending/signed distinction stays, the date is gone.

`signer-progress.tsx`: `r.signed_at?.slice(0, 10)` → `"signed"`. Frontend-only, no query/schema change.

## Test plan

- [x] `turbo run typecheck lint --filter=portal` — 0 errors
- [ ] `/approve/view/<id>`: signed rows show "signed", not a date

🤖 Generated with [Claude Code](https://claude.com/claude-code)