### PR TITLE
feat(gallery): add cheers reaction emoji

### DIFF
--- a/apps/gallery/lib/gallery/reactions.test.ts
+++ b/apps/gallery/lib/gallery/reactions.test.ts
@@ -13,6 +13,7 @@ describe("isGalleryReaction", () => {
     expect(isGalleryReaction("haha")).toBe(true)
     expect(isGalleryReaction("angry")).toBe(true)
     expect(isGalleryReaction("point")).toBe(true)
+    expect(isGalleryReaction("cheers")).toBe(true)
   })
 
   test("rejects unknown values", () => {

--- a/apps/gallery/lib/gallery/reactions.ts
+++ b/apps/gallery/lib/gallery/reactions.ts
@@ -1,4 +1,4 @@
-/** Facebook-style reactions + WinLab point (👉👈). One per user per work. */
+/** Facebook-style reactions + WinLab point (👉👈) + cheers (🍻). One per user per work. */
 
 export const GALLERY_REACTIONS = [
   "like",
@@ -8,6 +8,7 @@ export const GALLERY_REACTIONS = [
   "sad",
   "angry",
   "point",
+  "cheers",
 ] as const
 
 export type GalleryReaction = (typeof GALLERY_REACTIONS)[number]
@@ -20,6 +21,7 @@ export const REACTION_EMOJI: Record<GalleryReaction, string> = {
   sad: "😢",
   angry: "😡",
   point: "👉👈",
+  cheers: "🍻",
 }
 
 export const REACTION_LABEL: Record<GalleryReaction, string> = {
@@ -30,6 +32,7 @@ export const REACTION_LABEL: Record<GalleryReaction, string> = {
   sad: "Sad",
   angry: "Angry",
   point: "Poke",
+  cheers: "Cheers",
 }
 
 export type ReactionCounts = Record<GalleryReaction, number>
@@ -63,8 +66,7 @@ export function totalReactions(counts: ReactionCounts): number {
 export function formatReactionSummary(counts: ReactionCounts): string {
   return GALLERY_REACTIONS.filter((r) => counts[r] > 0)
     .map((r) => {
-      const glyph =
-        r === "point" ? "👉\u2009👈" : REACTION_EMOJI[r]
+      const glyph = r === "point" ? "👉\u2009👈" : REACTION_EMOJI[r]
       return `${glyph} ${counts[r]}`
     })
     .join(" · ")

--- a/supabase/migrations/2026-06-12-gallery-reaction-cheers.sql
+++ b/supabase/migrations/2026-06-12-gallery-reaction-cheers.sql
@@ -1,0 +1,19 @@
+-- Add gallery cheers reaction (🍻).
+
+alter table public.gallery_image_votes
+  drop constraint if exists gallery_image_votes_reaction_check;
+
+alter table public.gallery_image_votes
+  add constraint gallery_image_votes_reaction_check
+  check (
+    reaction in (
+      'like',
+      'love',
+      'haha',
+      'wow',
+      'sad',
+      'angry',
+      'point',
+      'cheers'
+    )
+  );


### PR DESCRIPTION
## What
Add 🍻 (`cheers`) to the gallery reaction picker alongside the existing Facebook-style set and lab 👉👈.

## Why
Gallery-specific inside joke — "乾杯" vibe for the art wall.

## Scope
- `GALLERY_REACTIONS` + migration updating `gallery_image_votes_reaction_check`