### PR TITLE
fix(gallery): show @mention picker in comment dialog

### DIFF
--- a/apps/gallery/app/_components/gallery-card.tsx
+++ b/apps/gallery/app/_components/gallery-card.tsx
@@ -37,7 +37,11 @@ import {
   type ReactionNames,
   totalReactions,
 } from "@/lib/gallery/reactions"
-import type { GalleryImage, GalleryMember, GallerySequenceItem } from "@/lib/gallery/types"
+import type {
+  GalleryImage,
+  GalleryMember,
+  GallerySequenceItem,
+} from "@/lib/gallery/types"
 import { getGalleryImageUrl } from "@/lib/gallery/url"
 
 function applyReactionOptimistic(
@@ -129,7 +133,7 @@ export function GalleryCard({
   const mediaUrl = activeItem ? mediaUrlFromItem(activeItem) : ""
   const thumbUrl = activeItem
     ? activeIsVideo && activeItem.poster_path
-      ? posterUrlFromItem(activeItem) ?? mediaUrlFromItem(activeItem)
+      ? (posterUrlFromItem(activeItem) ?? mediaUrlFromItem(activeItem))
       : mediaUrlFromItem(activeItem)
     : ""
   const [thumbFailed, setThumbFailed] = useState(false)
@@ -233,7 +237,9 @@ export function GalleryCard({
             "!h-[100dvh] !w-screen !max-w-none !rounded-none border-0 bg-transparent p-2 shadow-none ring-0"
           )}
         >
-          <DialogTitle className="sr-only">{activeItem?.name ?? image.name}</DialogTitle>
+          <DialogTitle className="sr-only">
+            {activeItem?.name ?? image.name}
+          </DialogTitle>
           <DialogClose
             aria-label="Close"
             className={cn(
@@ -250,14 +256,16 @@ export function GalleryCard({
             <div className="relative flex min-h-[42vh] min-w-0 flex-1 items-center justify-center bg-black/70 p-4 md:min-h-0 md:min-w-[22rem]">
               {lightboxFailed ? (
                 <div className="max-w-[95vw] rounded-sm bg-muted px-8 py-16 text-center text-muted-foreground italic shadow-2xl">
-                  This {activeIsVideo ? "video" : "image"} cannot be previewed in
-                  your browser.
+                  This {activeIsVideo ? "video" : "image"} cannot be previewed
+                  in your browser.
                 </div>
               ) : activeIsVideo ? (
                 <video
                   src={mediaUrl}
                   poster={
-                    activeItem ? (posterUrlFromItem(activeItem) ?? undefined) : undefined
+                    activeItem
+                      ? (posterUrlFromItem(activeItem) ?? undefined)
+                      : undefined
                   }
                   controls
                   autoPlay
@@ -283,7 +291,7 @@ export function GalleryCard({
                         idx === 0 ? sequenceMedia.length - 1 : idx - 1
                       )
                     }
-                    className="absolute left-3 top-1/2 z-[60] inline-flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-white/85 text-foreground shadow-lg backdrop-blur-sm transition-colors hover:bg-white focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none"
+                    className="absolute top-1/2 left-3 z-[60] inline-flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-white/85 text-foreground shadow-lg backdrop-blur-sm transition-colors hover:bg-white focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none"
                     aria-label="Previous photo"
                   >
                     <IconChevronLeft className="h-5 w-5" />
@@ -293,7 +301,7 @@ export function GalleryCard({
                     onClick={() =>
                       setActiveIndex((idx) => (idx + 1) % sequenceMedia.length)
                     }
-                    className="absolute right-3 top-1/2 z-[60] inline-flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-white/85 text-foreground shadow-lg backdrop-blur-sm transition-colors hover:bg-white focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none"
+                    className="absolute top-1/2 right-3 z-[60] inline-flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-white/85 text-foreground shadow-lg backdrop-blur-sm transition-colors hover:bg-white focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none"
                     aria-label="Next photo"
                   >
                     <IconChevronRight className="h-5 w-5" />
@@ -315,14 +323,16 @@ export function GalleryCard({
                 </>
               ) : null}
             </div>
-            <aside className="flex w-full min-h-0 flex-col border-t border-border/60 bg-background md:w-[24rem] md:shrink-0 md:border-t-0 md:border-l">
+            <aside className="flex min-h-0 w-full flex-col border-t border-border/60 bg-background md:w-[24rem] md:shrink-0 md:border-t-0 md:border-l">
               <div className="border-b border-border/60 px-4 py-3">
-                <p className="truncate text-base text-foreground">{image.name}</p>
+                <p className="truncate text-base text-foreground">
+                  {image.name}
+                </p>
                 <p className="mt-1 truncate text-xs text-muted-foreground">
                   by {image.uploader_name}
                 </p>
               </div>
-              <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+              <div className="flex min-h-0 flex-1 flex-col px-4 py-3">
                 <GalleryComments
                   imageId={image.id}
                   initialComments={image.comments}
@@ -427,7 +437,7 @@ function ReactionSummary({
           {entries.map(({ reaction, name }, idx) => (
             <li
               key={`${reaction}-${name}-${idx}`}
-              className="flex min-w-0 select-none items-center gap-2"
+              className="flex min-w-0 items-center gap-2 select-none"
             >
               <ReactionGlyph
                 reaction={reaction}

--- a/apps/gallery/app/_components/gallery-comments.tsx
+++ b/apps/gallery/app/_components/gallery-comments.tsx
@@ -110,23 +110,68 @@ export function GalleryComments({
     })
   }
 
+  const showMentionPicker = mentionQuery !== null && filteredMembers.length > 0
+
   return (
-    <div className="mt-3 space-y-3 not-italic">
-      <div className="relative space-y-2">
-        <Textarea
-          ref={textareaRef}
-          value={draft}
-          onChange={(e) => handleDraftChange(e.target.value)}
-          placeholder={
-            isSignedIn
-              ? "Write a comment… type @ to mention someone"
-              : "Sign in to leave a comment"
-          }
-          disabled={!isSignedIn || isPending}
-          className="min-h-20 resize-none text-sm"
-        />
-        {filteredMembers.length > 0 ? (
-          <div className="absolute right-0 bottom-full left-0 z-10 mb-1 flex max-h-48 flex-col overflow-y-auto rounded-xl border border-border bg-popover shadow-md">
+    <div className="flex min-h-0 flex-1 flex-col not-italic">
+      <div className="min-h-0 flex-1 space-y-2 overflow-y-auto">
+        {flattened.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No comments yet.</p>
+        ) : (
+          <ul className="space-y-2">
+            {flattened.map((comment) => {
+              const mine = viewerId === comment.created_by
+              return (
+                <li
+                  key={comment.id}
+                  className={cn(
+                    "space-y-1 rounded-md border border-border/60 px-3 py-2",
+                    comment.depth > 0 && "ml-5"
+                  )}
+                >
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <span className="font-medium text-foreground">
+                      {comment.commenter_name}
+                    </span>
+                    <span>·</span>
+                    <span>{new Date(comment.created_at).toLocaleString()}</span>
+                  </div>
+                  <p className="text-sm leading-relaxed break-words whitespace-pre-wrap text-foreground/90">
+                    <FormattedComment
+                      content={comment.body}
+                      members={members}
+                    />
+                  </p>
+                  <div className="flex items-center gap-3">
+                    {isSignedIn ? (
+                      <button
+                        type="button"
+                        onClick={() => setReplyTarget(comment.id)}
+                        className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+                      >
+                        Reply
+                      </button>
+                    ) : null}
+                    {mine ? (
+                      <button
+                        type="button"
+                        onClick={() => removeComment(comment.id)}
+                        className="text-xs text-destructive/90 transition-colors hover:text-destructive"
+                      >
+                        Delete
+                      </button>
+                    ) : null}
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+
+      <div className="relative shrink-0 space-y-2 border-t border-border/60 pt-3">
+        {showMentionPicker ? (
+          <div className="absolute right-0 bottom-full left-0 z-50 mb-1 flex max-h-48 flex-col overflow-y-auto rounded-xl border border-border bg-popover shadow-md">
             {filteredMembers.map((m) => (
               <button
                 key={m.id}
@@ -144,6 +189,18 @@ export function GalleryComments({
             ))}
           </div>
         ) : null}
+        <Textarea
+          ref={textareaRef}
+          value={draft}
+          onChange={(e) => handleDraftChange(e.target.value)}
+          placeholder={
+            isSignedIn
+              ? "Write a comment… type @ to mention someone"
+              : "Sign in to leave a comment"
+          }
+          disabled={!isSignedIn || isPending}
+          className="min-h-20 resize-none text-sm"
+        />
         <div className="flex items-center justify-between gap-2">
           {replyTarget ? (
             <button
@@ -168,56 +225,6 @@ export function GalleryComments({
           </Button>
         </div>
       </div>
-
-      {flattened.length === 0 ? (
-        <p className="text-xs text-muted-foreground">No comments yet.</p>
-      ) : (
-        <ul className="space-y-2">
-          {flattened.map((comment) => {
-            const mine = viewerId === comment.created_by
-            return (
-              <li
-                key={comment.id}
-                className={cn(
-                  "space-y-1 rounded-md border border-border/60 px-3 py-2",
-                  comment.depth > 0 && "ml-5"
-                )}
-              >
-                <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                  <span className="font-medium text-foreground">
-                    {comment.commenter_name}
-                  </span>
-                  <span>·</span>
-                  <span>{new Date(comment.created_at).toLocaleString()}</span>
-                </div>
-                <p className="whitespace-pre-wrap break-words text-sm leading-relaxed text-foreground/90">
-                  <FormattedComment content={comment.body} members={members} />
-                </p>
-                <div className="flex items-center gap-3">
-                  {isSignedIn ? (
-                    <button
-                      type="button"
-                      onClick={() => setReplyTarget(comment.id)}
-                      className="text-xs text-muted-foreground transition-colors hover:text-foreground"
-                    >
-                      Reply
-                    </button>
-                  ) : null}
-                  {mine ? (
-                    <button
-                      type="button"
-                      onClick={() => removeComment(comment.id)}
-                      className="text-xs text-destructive/90 transition-colors hover:text-destructive"
-                    >
-                      Delete
-                    </button>
-                  ) : null}
-                </div>
-              </li>
-            )
-          })}
-        </ul>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
Closes #188

## Summary
- Move the comment composer to a fixed footer outside the scrollable comment list (same pattern as bulletin chat).
- @mention autocomplete now expands upward from the footer without being clipped by overflow-y-auto.

## Test plan
- [ ] Open gallery image dialog, sign in
- [ ] Type @ in comment box — member list should appear above the textarea
- [ ] Select a member and post — mention highlights in comment body

Made with [Cursor](https://cursor.com)