### PR TITLE
fix(gallery): mobile icon nav and zongzi viewport clipping

### DIFF
--- a/apps/gallery/app/gallery.css
+++ b/apps/gallery/app/gallery.css
@@ -233,7 +233,7 @@ html[data-gallery-theme="dragon-boat"] .gallery-zongzi-pop {
   border: 0;
   background: transparent;
   cursor: pointer;
-  transform: rotate(var(--seed-rotate, 0deg));
+  transform: translate(-50%, -50%) rotate(var(--seed-rotate, 0deg));
   opacity: 0;
   filter: drop-shadow(0 6px 14px rgba(30, 120, 75, 0.22));
   animation: gallery-zongzi-pop-in 0.55s ease-out forwards;
@@ -244,7 +244,7 @@ html[data-gallery-theme="dragon-boat"] .gallery-zongzi-pop {
 }
 
 html[data-gallery-theme="dragon-boat"] .gallery-zongzi-pop:hover {
-  transform: rotate(var(--seed-rotate, 0deg)) scale(1.08);
+  transform: translate(-50%, -50%) rotate(var(--seed-rotate, 0deg)) scale(1.08);
   filter: drop-shadow(0 8px 18px rgba(30, 120, 75, 0.32));
 }
 
@@ -282,18 +282,21 @@ html[data-gallery-theme="dragon-boat"] .gallery-zongzi-burst-particle {
 @keyframes gallery-zongzi-pop-in {
   from {
     opacity: 0;
-    transform: rotate(var(--seed-rotate, 0deg)) translateY(0.5rem) scale(0.75);
+    transform: translate(-50%, -50%) rotate(var(--seed-rotate, 0deg))
+      translateY(0.5rem) scale(0.75);
   }
   to {
     opacity: 1;
-    transform: rotate(var(--seed-rotate, 0deg)) translateY(0) scale(1);
+    transform: translate(-50%, -50%) rotate(var(--seed-rotate, 0deg))
+      translateY(0) scale(1);
   }
 }
 
 @keyframes gallery-zongzi-pop-out {
   to {
     opacity: 0;
-    transform: rotate(var(--seed-rotate, 0deg)) scale(1.35);
+    transform: translate(-50%, -50%) rotate(var(--seed-rotate, 0deg))
+      scale(1.35);
   }
 }
 
@@ -321,12 +324,13 @@ html[data-gallery-theme="dragon-boat"] .gallery-zongzi-burst-particle {
 
 @media (max-width: 767px) {
   html[data-gallery-theme="dragon-boat"] .gallery-zongzi-pop {
-    transform: rotate(var(--seed-rotate, 0deg)) scale(0.92);
+    transform: translate(-50%, -50%) rotate(var(--seed-rotate, 0deg))
+      scale(0.92);
   }
 
   html[data-gallery-theme="dragon-boat"] .gallery-zongzi-pop-image {
-    max-width: 2.5rem;
-    max-height: 2.5rem;
+    max-width: 2rem;
+    max-height: 2rem;
     width: auto !important;
     height: auto !important;
   }

--- a/apps/gallery/app/page.tsx
+++ b/apps/gallery/app/page.tsx
@@ -1,10 +1,5 @@
 import { GalleryGrid } from "@/app/_components/gallery-grid"
 import { GalleryPagination } from "@/app/_components/gallery-pagination"
-import { SignOutButton } from "@/components/sign-out-button"
-import {
-  GalleryNavLink,
-  galleryShellNavLinkClass,
-} from "@/components/gallery-chrome"
 import { GalleryShell } from "@/components/gallery-shell"
 import { loadGalleryHomePage } from "@/lib/gallery/load-home-page"
 import { createClient } from "@/lib/supabase/server"
@@ -31,21 +26,8 @@ export default async function GalleryHomePage({
       userId: user?.id ?? null,
     })
 
-  const nav = user ? (
-    <>
-      <GalleryNavLink href="/upload" tone="shell">
-        Manage
-      </GalleryNavLink>
-      <SignOutButton className={galleryShellNavLinkClass()} />
-    </>
-  ) : (
-    <GalleryNavLink href="/auth/login?next=/upload" tone="shell">
-      Sign in
-    </GalleryNavLink>
-  )
-
   return (
-    <GalleryShell active="home" nav={nav}>
+    <GalleryShell active="home" signedIn={Boolean(user)}>
       <div className="overflow-x-clip">
         <GalleryGrid
           images={images}

--- a/apps/gallery/app/upload/page.tsx
+++ b/apps/gallery/app/upload/page.tsx
@@ -6,14 +6,12 @@ import { RenameButton } from "@/app/upload/_components/rename-button"
 import { UploadListThumb } from "@/app/upload/_components/upload-list-thumb"
 import { UploadForm } from "@/app/upload/_components/upload-form"
 import {
-  galleryShellNavLinkClass,
   galleryPanelClass,
   gallerySans,
   gallerySectionLeadClass,
   gallerySectionTitleClass,
 } from "@/components/gallery-chrome"
 import { GalleryShell } from "@/components/gallery-shell"
-import { SignOutButton } from "@/components/sign-out-button"
 import { createClient } from "@/lib/supabase/server"
 import type { GalleryImage } from "@/lib/gallery/types"
 import {
@@ -59,15 +57,7 @@ export default async function UploadPage() {
   >
 
   return (
-    <GalleryShell
-      active="manage"
-      nav={
-        <>
-          <SignOutButton className={galleryShellNavLinkClass()} />
-        </>
-      }
-      containerClassName="max-w-3xl"
-    >
+    <GalleryShell active="manage" signedIn containerClassName="max-w-3xl">
       <div className="flex flex-col gap-10 sm:gap-12">
         <header>
           <h1 className={gallerySectionTitleClass()}>Manage</h1>

--- a/apps/gallery/components/gallery-chrome.tsx
+++ b/apps/gallery/components/gallery-chrome.tsx
@@ -48,6 +48,15 @@ export function galleryShellNavLinkClass(active = false) {
   )
 }
 
+export function galleryShellIconButtonClass() {
+  return cn(
+    gallerySans(),
+    "inline-flex size-8 shrink-0 items-center justify-center rounded-full text-muted-foreground/85 transition-colors",
+    "hover:bg-muted/60 hover:text-foreground",
+    "focus-visible:ring-2 focus-visible:ring-ring/40 focus-visible:outline-none"
+  )
+}
+
 export function galleryPillClass() {
   return cn(
     gallerySans(),

--- a/apps/gallery/components/gallery-shell-nav.tsx
+++ b/apps/gallery/components/gallery-shell-nav.tsx
@@ -1,0 +1,135 @@
+"use client"
+
+import Link from "next/link"
+import {
+  IconExternalLink,
+  IconLayoutGrid,
+  IconLogin,
+  IconMenu2,
+  IconPhotoEdit,
+} from "@tabler/icons-react"
+
+import { Button } from "@workspace/ui/components/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@workspace/ui/components/dropdown-menu"
+import { cn } from "@workspace/ui/lib/utils"
+
+import {
+  GalleryNavLink,
+  gallerySans,
+  galleryShellIconButtonClass,
+  galleryShellNavLinkClass,
+} from "@/components/gallery-chrome"
+import { SignOutButton } from "@/components/sign-out-button"
+
+export type GalleryShellActive = "home" | "manage"
+
+export function GalleryShellNav({
+  active,
+  signedIn,
+}: {
+  active: GalleryShellActive
+  signedIn: boolean
+}) {
+  return (
+    <>
+      <nav
+        className={cn(
+          gallerySans(),
+          "relative z-10 hidden shrink-0 items-center justify-end gap-4 md:flex"
+        )}
+      >
+        <GalleryNavLink href="https://portal.winlab.tw" external tone="shell">
+          Portal
+        </GalleryNavLink>
+        {signedIn ? (
+          <>
+            {active !== "manage" ? (
+              <GalleryNavLink href="/upload" tone="shell">
+                Manage
+              </GalleryNavLink>
+            ) : null}
+            <SignOutButton className={galleryShellNavLinkClass()} />
+          </>
+        ) : (
+          <GalleryNavLink href="/auth/login?next=/upload" tone="shell">
+            Sign in
+          </GalleryNavLink>
+        )}
+      </nav>
+
+      <div
+        className={cn(
+          gallerySans(),
+          "relative z-10 flex shrink-0 items-center gap-0.5 md:hidden"
+        )}
+      >
+        {signedIn ? (
+          <SignOutButton iconOnly className={galleryShellIconButtonClass()} />
+        ) : (
+          <Link
+            href="/auth/login?next=/upload"
+            className={galleryShellIconButtonClass()}
+            aria-label="Sign in"
+          >
+            <IconLogin className="size-4" aria-hidden />
+          </Link>
+        )}
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className={galleryShellIconButtonClass()}
+              aria-label="Open navigation menu"
+            >
+              <IconMenu2 className="size-4" aria-hidden />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="end"
+            className={cn(gallerySans(), "w-44")}
+          >
+            <DropdownMenuItem asChild>
+              <a
+                href="https://portal.winlab.tw"
+                className="flex cursor-pointer items-center gap-2"
+              >
+                <IconExternalLink className="size-4 shrink-0" aria-hidden />
+                Portal
+              </a>
+            </DropdownMenuItem>
+            {signedIn && active !== "manage" ? (
+              <DropdownMenuItem asChild>
+                <Link
+                  href="/upload"
+                  className="flex cursor-pointer items-center gap-2"
+                >
+                  <IconPhotoEdit className="size-4 shrink-0" aria-hidden />
+                  Manage
+                </Link>
+              </DropdownMenuItem>
+            ) : null}
+            {active === "manage" ? (
+              <DropdownMenuItem asChild>
+                <Link
+                  href="/"
+                  className="flex cursor-pointer items-center gap-2"
+                >
+                  <IconLayoutGrid className="size-4 shrink-0" aria-hidden />
+                  Gallery
+                </Link>
+              </DropdownMenuItem>
+            ) : null}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </>
+  )
+}

--- a/apps/gallery/components/gallery-shell.tsx
+++ b/apps/gallery/components/gallery-shell.tsx
@@ -8,23 +8,26 @@ import { GalleryHeaderWaterline } from "@/components/gallery-header-waterline"
 import { GalleryZongziSeeds } from "@/components/gallery-zongzi-seeds"
 import {
   GalleryFooter,
-  GalleryNavLink,
   galleryShellBrandClass,
   galleryPageBackdropClass,
   gallerySans,
 } from "@/components/gallery-chrome"
+import {
+  GalleryShellNav,
+  type GalleryShellActive,
+} from "@/components/gallery-shell-nav"
 
-export type GalleryShellActive = "home" | "manage"
+export type { GalleryShellActive } from "@/components/gallery-shell-nav"
 
 export function GalleryShell({
   children,
-  nav,
   active = "home",
+  signedIn = false,
   containerClassName,
 }: {
   children: ReactNode
-  nav?: ReactNode
   active?: GalleryShellActive
+  signedIn?: boolean
   containerClassName?: string
 }) {
   return (
@@ -36,43 +39,29 @@ export function GalleryShell({
       />
       <header className="gallery-shell-header pointer-events-none">
         <div className="gallery-shell-header-inner pointer-events-auto relative mx-auto max-w-6xl px-4 pt-1.5 pb-1 sm:px-6 sm:pb-1.5">
-          <div className="gallery-shell-nav-row relative flex min-h-[1.75rem] items-center gap-2 sm:gap-3">
+          <div className="gallery-shell-nav-row relative flex min-h-[1.75rem] flex-nowrap items-center gap-2 sm:gap-3">
             <Link
               href="/"
               className={cn(
                 galleryShellBrandClass(active === "home"),
-                "relative z-10 inline-flex shrink-0 items-center gap-2"
+                "relative z-10 inline-flex min-w-0 shrink-0 items-center gap-1.5 sm:gap-2"
               )}
             >
               Gallery
               <span
                 className={cn(
                   gallerySans(),
-                  "gallery-seasonal-badge rounded-full border border-emerald-700/25 bg-emerald-600/10 px-2 py-0.5 text-[10px] tracking-wide text-emerald-800 uppercase not-italic"
+                  "gallery-seasonal-badge shrink-0 rounded-full border border-emerald-700/25 bg-emerald-600/10 px-1.5 py-0.5 text-[9px] tracking-wide text-emerald-800 uppercase not-italic sm:px-2 sm:text-[10px]"
                 )}
                 aria-hidden
               >
                 端午
               </span>
             </Link>
-            <div className="gallery-header-seasonal-row min-w-0 flex-1">
+            <div className="gallery-header-seasonal-row min-w-0 flex-1 overflow-hidden">
               <GalleryHeaderSeasonal />
             </div>
-            <nav
-              className={cn(
-                gallerySans(),
-                "relative z-10 flex shrink-0 flex-wrap items-center justify-end gap-3 sm:gap-4"
-              )}
-            >
-              <GalleryNavLink
-                href="https://portal.winlab.tw"
-                external
-                tone="shell"
-              >
-                Portal
-              </GalleryNavLink>
-              {nav}
-            </nav>
+            <GalleryShellNav active={active} signedIn={signedIn} />
           </div>
         </div>
         <GalleryHeaderWaterline />

--- a/apps/gallery/components/sign-out-button.tsx
+++ b/apps/gallery/components/sign-out-button.tsx
@@ -2,12 +2,19 @@
 
 import { useTransition } from "react"
 import { useRouter } from "next/navigation"
+import { IconLogout } from "@tabler/icons-react"
 
 import { cn } from "@workspace/ui/lib/utils"
 
 import { createClient } from "@/lib/supabase/client"
 
-export function SignOutButton({ className }: { className?: string }) {
+export function SignOutButton({
+  className,
+  iconOnly = false,
+}: {
+  className?: string
+  iconOnly?: boolean
+}) {
   const [pending, startTransition] = useTransition()
   const router = useRouter()
 
@@ -25,12 +32,19 @@ export function SignOutButton({ className }: { className?: string }) {
       type="button"
       onClick={onClick}
       disabled={pending}
+      aria-label={iconOnly ? "Sign out" : undefined}
       className={cn(
         className,
         "disabled:pointer-events-none disabled:opacity-50"
       )}
     >
-      {pending ? "Signing out…" : "Sign out"}
+      {iconOnly ? (
+        <IconLogout className="size-4" aria-hidden />
+      ) : pending ? (
+        "Signing out…"
+      ) : (
+        "Sign out"
+      )}
     </button>
   )
 }

--- a/apps/gallery/lib/gallery/zongzi-seeds.ts
+++ b/apps/gallery/lib/gallery/zongzi-seeds.ts
@@ -24,17 +24,17 @@ export const POPPABLE_ZONGZI_SPOTS: Omit<PoppableZongziSpec, "id" | "delay">[] =
     { left: "86%", top: "36%", size: 52, rotate: -10 },
   ]
 
-/** Phone — four corners only, smaller, so polaroids stay tappable. */
+/** Phone — edge spots with room for center-anchored sticker size. */
 export const MOBILE_POPPABLE_ZONGZI_SPOTS: Omit<
   PoppableZongziSpec,
   "id" | "delay"
 >[] = [
-  { left: "3%", top: "17%", size: 40, rotate: -10 },
-  { left: "4%", top: "83%", size: 36, rotate: 8 },
-  { left: "91%", top: "18%", size: 38, rotate: 12 },
-  { left: "90%", top: "82%", size: 36, rotate: -8 },
-  { left: "6%", top: "48%", size: 34, rotate: 6 },
-  { left: "88%", top: "50%", size: 34, rotate: -6 },
+  { left: "11%", top: "18%", size: 34, rotate: -10 },
+  { left: "11%", top: "84%", size: 32, rotate: 8 },
+  { left: "89%", top: "18%", size: 34, rotate: 12 },
+  { left: "89%", top: "84%", size: 32, rotate: -8 },
+  { left: "13%", top: "50%", size: 30, rotate: 6 },
+  { left: "87%", top: "50%", size: 30, rotate: -6 },
 ]
 
 export function getPoppableZongziSpotPool(isMobile: boolean) {


### PR DESCRIPTION
Closes #194

## Summary
- Add mobile header nav: sign-in/sign-out icons plus hamburger menu for Portal, Manage, and Gallery links; desktop keeps text links
- Prevent header nav from wrapping to a second row on narrow screens (`flex-nowrap`, compact seasonal badge)
- Anchor zongzi stickers by center point and inset mobile spawn spots so rotated stickers are not clipped at screen edges

## Test plan
- [ ] Open gallery on phone or DevTools (<768px): header shows icon + hamburger, no wrapped nav row
- [ ] Hamburger opens Portal / Manage (signed in) / Gallery (on manage page)
- [ ] Sign in / Sign out icons work with accessible labels
- [ ] Dragon Boat theme: zongzi stickers fully visible at corners, tap still pops and respawns
- [ ] Desktop (md+): text nav unchanged