### PR TITLE
fix(meetings): load question groups dynamically to prevent FK violation

### DIFF
--- a/apps/portal/app/meetings/_components/meeting-edit-dialog.tsx
+++ b/apps/portal/app/meetings/_components/meeting-edit-dialog.tsx
@@ -33,6 +33,7 @@ import {
   useUpdateOwnMeeting,
 } from "@/hooks/meetings/use-meetings"
 import { useLabUsers } from "@/hooks/meetings/use-lab-users"
+import { useMeetingGroups } from "@/hooks/meetings/use-meeting-groups"
 import type { Meeting } from "@/lib/meetings/types"
 
 import { PresenterSelect } from "./presenter-select"
@@ -122,6 +123,7 @@ export function MeetingEditDialog({
   onOpenChange,
 }: Props) {
   const { data: users = [] } = useLabUsers()
+  const { data: groups = [] } = useMeetingGroups()
   const updateOwn = useUpdateOwnMeeting()
   const updateAdmin = useAdminUpdateMeeting()
 
@@ -307,9 +309,12 @@ export function MeetingEditDialog({
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="none">未指定</SelectItem>
-                    {[1, 2, 3, 4].map((n) => (
-                      <SelectItem key={n} value={String(n)}>
-                        小組 {n}
+                    {groups.map((g) => (
+                      <SelectItem
+                        key={g.groupNumber}
+                        value={String(g.groupNumber)}
+                      >
+                        小組 {g.groupNumber}
                       </SelectItem>
                     ))}
                   </SelectContent>


### PR DESCRIPTION
Closes #197

## Summary
- `meeting-edit-dialog.tsx` was hardcoding question group options as `[1, 2, 3, 4]`
- Admins can dynamically add/delete groups; a deleted group_number no longer exists in `meeting_groups`
- Selecting a deleted group and saving would violate `fk_meeting_question_group`
- Fix: replace hardcoded array with `useMeetingGroups()` — Select options now always reflect real DB state

## Test plan
- [ ] Open edit dialog on a meeting, verify question group dropdown shows only groups that exist in DB
- [ ] Delete a group in the Groups panel, reopen edit dialog — deleted group should not appear
- [ ] Select a valid group, save — should succeed without FK error