### PR TITLE
fix(meetings): clear stale questionGroupNumber on save if group was deleted

### DIFF
--- a/apps/portal/app/meetings/_components/meeting-edit-dialog.tsx
+++ b/apps/portal/app/meetings/_components/meeting-edit-dialog.tsx
@@ -226,6 +226,12 @@ export function MeetingEditDialog({
     }
 
     if (isAdmin) {
+      const validGroupNumber =
+        questionGroupNumber !== null &&
+        groups.some((g) => g.groupNumber === questionGroupNumber)
+          ? questionGroupNumber
+          : null
+
       updateAdmin.mutate(
         {
           ...common,
@@ -234,7 +240,7 @@ export function MeetingEditDialog({
           isHoliday,
           location: location || "EC 411",
           startTime: startTime || "15:30",
-          questionGroupNumber,
+          questionGroupNumber: validGroupNumber,
         },
         { onSuccess: () => onOpenChange(false) }
       )


### PR DESCRIPTION
Closes #199

## Summary
- Follow-up to #197: even with dynamic dropdown options, a meeting stored in DB with `question_group_number` pointing to a deleted group still violates FK when the admin opens and saves it
- The dialog initialises `questionGroupNumber` state from `meeting.questionGroupNumber`; the Select shows "未指定" but state holds the stale value
- Fix: validate against loaded `groups` in `handleSave()`, null-out any value whose group no longer exists

## Test plan
- [ ] Find or create a meeting with a `question_group_number` set, then delete that group
- [ ] Open the edit dialog — verify it shows 未指定 for question group
- [ ] Save without changing anything — should succeed without FK error
- [ ] Verify `question_group_number` in DB is now NULL for that meeting