### PR TITLE
fix(meetings): fill lowest available group number instead of max+1

### DIFF
--- a/apps/portal/app/meetings/_components/groups-panel.tsx
+++ b/apps/portal/app/meetings/_components/groups-panel.tsx
@@ -181,8 +181,9 @@ export function GroupsPanel({ isAdmin }: { isAdmin: boolean }) {
     return <p className="text-sm text-muted-foreground">載入中…</p>
   }
 
-  const nextNumber =
-    groups.length > 0 ? Math.max(...groups.map((g) => g.groupNumber)) + 1 : 1
+  const usedNumbers = new Set(groups.map((g) => g.groupNumber))
+  let nextNumber = 1
+  while (usedNumbers.has(nextNumber)) nextNumber++
 
   return (
     <div className="flex flex-col gap-2">

--- a/apps/portal/app/meetings/_components/meeting-edit-dialog.tsx
+++ b/apps/portal/app/meetings/_components/meeting-edit-dialog.tsx
@@ -226,6 +226,12 @@ export function MeetingEditDialog({
     }
 
     if (isAdmin) {
+      const validGroupNumber =
+        questionGroupNumber !== null &&
+        groups.some((g) => g.groupNumber === questionGroupNumber)
+          ? questionGroupNumber
+          : null
+
       updateAdmin.mutate(
         {
           ...common,
@@ -234,7 +240,7 @@ export function MeetingEditDialog({
           isHoliday,
           location: location || "EC 411",
           startTime: startTime || "15:30",
-          questionGroupNumber,
+          questionGroupNumber: validGroupNumber,
         },
         { onSuccess: () => onOpenChange(false) }
       )


### PR DESCRIPTION
Closes #201

## Summary
- `groups-panel.tsx` used `Math.max(...groupNumbers) + 1` to pick the next group number
- After deleting groups 1 and 2, adding a new group would get number 6 (not 1)
- Fix: iterate from 1 upward and return the first number not in the current set

## Test plan
- [ ] Delete groups 1 and 2 so only 3, 4, 5 remain
- [ ] Click 新增小組 — new group should be numbered 1
- [ ] Delete group 2 from groups 1, 2, 4 — adding should produce group 2