### PR TITLE
perf: add loading skeletons across portal routes

### DIFF
--- a/apps/portal/app/_components/content-skeleton.tsx
+++ b/apps/portal/app/_components/content-skeleton.tsx
@@ -1,0 +1,19 @@
+import { Skeleton } from "@workspace/ui/components/skeleton"
+
+// Shared route-level loading fallback. Sits inside each app's <PortalShell>
+// (mounted in the route layout), so it only renders the content-area skeleton.
+export function ContentSkeleton() {
+  return (
+    <div className="flex flex-col gap-10">
+      <div className="flex flex-col gap-1">
+        <Skeleton className="h-6 w-32 rounded-md" />
+        <Skeleton className="h-4 w-56 rounded-md" />
+      </div>
+      <div className="flex flex-col gap-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-[72px] w-full rounded-xl" />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/portal/app/admin/loading.tsx
+++ b/apps/portal/app/admin/loading.tsx
@@ -1,0 +1,5 @@
+import { ContentSkeleton } from "@/app/_components/content-skeleton"
+
+export default function Loading() {
+  return <ContentSkeleton />
+}

--- a/apps/portal/app/approve/_components/document-dashboard.tsx
+++ b/apps/portal/app/approve/_components/document-dashboard.tsx
@@ -17,6 +17,7 @@ import {
   TabsList,
   TabsTrigger,
 } from "@workspace/ui/components/tabs"
+import { Skeleton } from "@workspace/ui/components/skeleton"
 import { IconDots } from "@tabler/icons-react"
 import Link from "next/link"
 
@@ -33,6 +34,16 @@ import { deleteDocument } from "../actions"
 
 import { ConfirmDialog } from "./confirm-dialog"
 import { DocumentCard } from "./document-card"
+
+function DocListSkeleton() {
+  return (
+    <div className="flex flex-col gap-3">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <Skeleton key={i} className="h-[68px] w-full rounded-xl" />
+      ))}
+    </div>
+  )
+}
 
 export function DocumentDashboard() {
   const { user } = useAuth()
@@ -85,7 +96,9 @@ export function DocumentDashboard() {
         </TabsList>
 
         <TabsContent value="inbox" className="flex flex-col gap-3">
-          {(inbox.data ?? []).length === 0 ? (
+          {inbox.isLoading ? (
+            <DocListSkeleton />
+          ) : (inbox.data ?? []).length === 0 ? (
             <p className="py-12 text-center text-sm text-muted-foreground">
               沒有待簽文件
             </p>
@@ -102,7 +115,9 @@ export function DocumentDashboard() {
         </TabsContent>
 
         <TabsContent value="signed" className="flex flex-col gap-3">
-          {(signed.data ?? []).length === 0 ? (
+          {signed.isLoading ? (
+            <DocListSkeleton />
+          ) : (signed.data ?? []).length === 0 ? (
             <p className="py-12 text-center text-sm text-muted-foreground">
               還沒簽過任何文件
             </p>
@@ -118,7 +133,9 @@ export function DocumentDashboard() {
         </TabsContent>
 
         <TabsContent value="sent" className="flex flex-col gap-3">
-          {(sent.data ?? []).length === 0 ? (
+          {sent.isLoading ? (
+            <DocListSkeleton />
+          ) : (sent.data ?? []).length === 0 ? (
             <p className="py-12 text-center text-sm text-muted-foreground">
               還沒送過任何文件
             </p>

--- a/apps/portal/app/approve/loading.tsx
+++ b/apps/portal/app/approve/loading.tsx
@@ -1,0 +1,5 @@
+import { ContentSkeleton } from "@/app/_components/content-skeleton"
+
+export default function Loading() {
+  return <ContentSkeleton />
+}

--- a/apps/portal/app/approve/new/[id]/loading.tsx
+++ b/apps/portal/app/approve/new/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { ContentSkeleton } from "@/app/_components/content-skeleton"
+
+export default function Loading() {
+  return <ContentSkeleton />
+}

--- a/apps/portal/app/approve/new/loading.tsx
+++ b/apps/portal/app/approve/new/loading.tsx
@@ -1,0 +1,5 @@
+import { ContentSkeleton } from "@/app/_components/content-skeleton"
+
+export default function Loading() {
+  return <ContentSkeleton />
+}

--- a/apps/portal/app/approve/sign/[id]/loading.tsx
+++ b/apps/portal/app/approve/sign/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { ContentSkeleton } from "@/app/_components/content-skeleton"
+
+export default function Loading() {
+  return <ContentSkeleton />
+}

--- a/apps/portal/app/approve/view/[id]/loading.tsx
+++ b/apps/portal/app/approve/view/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { ContentSkeleton } from "@/app/_components/content-skeleton"
+
+export default function Loading() {
+  return <ContentSkeleton />
+}

--- a/apps/portal/app/bento/loading.tsx
+++ b/apps/portal/app/bento/loading.tsx
@@ -1,0 +1,5 @@
+import { ContentSkeleton } from "@/app/_components/content-skeleton"
+
+export default function Loading() {
+  return <ContentSkeleton />
+}

--- a/apps/portal/app/bento/menus/loading.tsx
+++ b/apps/portal/app/bento/menus/loading.tsx
@@ -1,0 +1,5 @@
+import { ContentSkeleton } from "@/app/_components/content-skeleton"
+
+export default function Loading() {
+  return <ContentSkeleton />
+}

--- a/apps/portal/app/bento/orders/[id]/loading.tsx
+++ b/apps/portal/app/bento/orders/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { ContentSkeleton } from "@/app/_components/content-skeleton"
+
+export default function Loading() {
+  return <ContentSkeleton />
+}

--- a/apps/portal/app/bulletin/[id]/loading.tsx
+++ b/apps/portal/app/bulletin/[id]/loading.tsx
@@ -1,0 +1,12 @@
+import { ContentSkeleton } from "@/app/_components/content-skeleton"
+import { PortalShell } from "@/components/portal-shell"
+
+// bulletin detail mounts <PortalShell> in the page (no shell in the route
+// layout), so the loading fallback has to provide its own chrome.
+export default function Loading() {
+  return (
+    <PortalShell appName="公布欄">
+      <ContentSkeleton />
+    </PortalShell>
+  )
+}

--- a/apps/portal/app/debt/_components/debt-home.tsx
+++ b/apps/portal/app/debt/_components/debt-home.tsx
@@ -4,6 +4,7 @@ import { IconPlus } from "@tabler/icons-react"
 import { useState } from "react"
 
 import { Button } from "@workspace/ui/components/button"
+import { Skeleton } from "@workspace/ui/components/skeleton"
 
 import { useBalances } from "@/hooks/debt/use-balances"
 import { useMembers } from "@/hooks/debt/use-members"
@@ -15,8 +16,8 @@ import { ExpenseCard } from "./expense-card"
 import { ExpenseForm } from "./expense-form"
 
 export function DebtHome() {
-  const { data: balances } = useBalances()
-  const { data: expenses } = useMyExpenses()
+  const { data: balances, isLoading: balancesLoading } = useBalances()
+  const { data: expenses, isLoading: expensesLoading } = useMyExpenses()
   const { data: members = [] } = useMembers()
 
   const [showForm, setShowForm] = useState(false)
@@ -35,6 +36,26 @@ export function DebtHome() {
   const handleClose = () => {
     setShowForm(false)
     setEditingExpense(null)
+  }
+
+  if ((balancesLoading || expensesLoading) && !balances && !expenses) {
+    return (
+      <div className="flex flex-col gap-10">
+        <div className="flex flex-col gap-1">
+          <Skeleton className="h-6 w-16 rounded-md" />
+          <Skeleton className="h-4 w-72 rounded-md" />
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Skeleton className="h-24 w-full rounded-xl" />
+          <Skeleton className="h-24 w-full rounded-xl" />
+        </div>
+        <div className="flex flex-col gap-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-16 w-full rounded-xl" />
+          ))}
+        </div>
+      </div>
+    )
   }
 
   return (

--- a/apps/portal/app/debt/loading.tsx
+++ b/apps/portal/app/debt/loading.tsx
@@ -1,0 +1,5 @@
+import { ContentSkeleton } from "@/app/_components/content-skeleton"
+
+export default function Loading() {
+  return <ContentSkeleton />
+}

--- a/apps/portal/app/debt/settlements/loading.tsx
+++ b/apps/portal/app/debt/settlements/loading.tsx
@@ -1,0 +1,5 @@
+import { ContentSkeleton } from "@/app/_components/content-skeleton"
+
+export default function Loading() {
+  return <ContentSkeleton />
+}

--- a/apps/portal/app/leave/loading.tsx
+++ b/apps/portal/app/leave/loading.tsx
@@ -1,0 +1,5 @@
+import { ContentSkeleton } from "@/app/_components/content-skeleton"
+
+export default function Loading() {
+  return <ContentSkeleton />
+}

--- a/apps/portal/app/meetings/_components/papers-tab.tsx
+++ b/apps/portal/app/meetings/_components/papers-tab.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Button } from "@workspace/ui/components/button"
+import { Skeleton } from "@workspace/ui/components/skeleton"
 import {
   Table,
   TableBody,
@@ -22,7 +23,13 @@ export function PapersTab() {
   const deletePaper = useDeleteTeacherPaper()
 
   if (isLoading) {
-    return <p className="text-sm text-muted-foreground">載入中…</p>
+    return (
+      <div className="flex flex-col gap-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-12 w-full rounded-lg" />
+        ))}
+      </div>
+    )
   }
 
   if (papers.length === 0) {

--- a/apps/portal/app/meetings/_components/schedule-tab.tsx
+++ b/apps/portal/app/meetings/_components/schedule-tab.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 
 import { IconPaperclip } from "@tabler/icons-react"
 import { Button } from "@workspace/ui/components/button"
+import { Skeleton } from "@workspace/ui/components/skeleton"
 import {
   Table,
   TableBody,
@@ -64,7 +65,13 @@ export function ScheduleTab({ year }: { year: number }) {
   const currentWeekId = getCurrentWeekId(meetings)
 
   if (isLoading) {
-    return <p className="text-sm text-muted-foreground">載入中…</p>
+    return (
+      <div className="flex flex-col gap-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-12 w-full rounded-lg" />
+        ))}
+      </div>
+    )
   }
 
   return (

--- a/apps/portal/app/meetings/loading.tsx
+++ b/apps/portal/app/meetings/loading.tsx
@@ -1,0 +1,5 @@
+import { ContentSkeleton } from "@/app/_components/content-skeleton"
+
+export default function Loading() {
+  return <ContentSkeleton />
+}

--- a/apps/portal/app/profile/loading.tsx
+++ b/apps/portal/app/profile/loading.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link"
+
+import { ContentSkeleton } from "@/app/_components/content-skeleton"
+import { PortalShell } from "@/components/portal-shell"
+
+// profile has no route layout — <PortalShell> lives in page.tsx, so the
+// loading fallback has to mount its own shell to avoid a chrome-less flash.
+export default function Loading() {
+  return (
+    <PortalShell
+      appName="Profile"
+      appHref="/profile"
+      bottomLeft={
+        <Link href="/" className="transition-colors hover:text-foreground">
+          Portal
+        </Link>
+      }
+    >
+      <ContentSkeleton />
+    </PortalShell>
+  )
+}

--- a/apps/portal/app/receipts/loading.tsx
+++ b/apps/portal/app/receipts/loading.tsx
@@ -1,0 +1,5 @@
+import { ContentSkeleton } from "@/app/_components/content-skeleton"
+
+export default function Loading() {
+  return <ContentSkeleton />
+}

--- a/apps/portal/app/reimburse/loading.tsx
+++ b/apps/portal/app/reimburse/loading.tsx
@@ -1,0 +1,5 @@
+import { ContentSkeleton } from "@/app/_components/content-skeleton"
+
+export default function Loading() {
+  return <ContentSkeleton />
+}

--- a/apps/portal/app/trip/[id]/loading.tsx
+++ b/apps/portal/app/trip/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { ContentSkeleton } from "@/app/_components/content-skeleton"
+
+export default function Loading() {
+  return <ContentSkeleton />
+}

--- a/apps/portal/app/trip/loading.tsx
+++ b/apps/portal/app/trip/loading.tsx
@@ -1,0 +1,5 @@
+import { ContentSkeleton } from "@/app/_components/content-skeleton"
+
+export default function Loading() {
+  return <ContentSkeleton />
+}


### PR DESCRIPTION
Closes #203

## Summary

每頁第一次載入整頁空白的止血:把白屏換成「chrome + 骨架」。

- **`approve` / `debt`**:主 dashboard 補 `isLoading` SSR skeleton。原本 loading 時 `data` 為 `undefined`,會走到「沒有待簽文件 / 還沒有分帳紀錄」空狀態 — 先假裝沒資料再跳出資料,比白屏更糟。
- **`meetings`**:`schedule-tab` / `papers-tab` 的純文字「載入中…」對齊成 skeleton。
- **`loading.tsx` + 共用 `ContentSkeleton`**:鋪到所有業務 route 及子 route(approve/bento/debt/trip/bulletin 的動態子頁含在內)。server-fetch 頁(profile / reimburse / approve 子頁 / bulletin)的 hard-reload 會直接觸發;client-fetch 頁則提供點 Link 跳頁的反饋。

> 注:client-fetch 業務頁的 hard-reload 白屏,主要靠 component 內的 SSR skeleton 解(loading.tsx 對「空殼不 await 的 page」不觸發)。治本(server prefetch + HydrationBoundary,讓首屏資料隨 HTML 來)另開 issue 處理。

## Test plan

- [x] `bun run build --filter=portal` 綠,TypeScript 通過
- [ ] 登入後 hard-reload `/approve`、`/debt`、`/meetings` → 顯示 chrome + 骨架,非空白