### PR TITLE
harden: error boundaries + enable fluid compute

### DIFF
--- a/apps/portal/app/error.tsx
+++ b/apps/portal/app/error.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { useEffect } from "react"
+
+import { Button } from "@workspace/ui/components/button"
+
+import { PortalShell } from "@/components/portal-shell"
+
+// Root error boundary. Business apps have no error.tsx of their own, so any
+// thrown render/server error bubbles here instead of Next.js's bare 500.
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error("[portal] route error", error)
+  }, [error])
+
+  return (
+    <PortalShell appName="Portal">
+      <div className="flex min-h-[60vh] flex-col justify-center gap-6">
+        <div className="flex flex-col gap-1">
+          <h1 className="font-medium">出了點問題</h1>
+          <p className="text-sm text-muted-foreground">
+            這個頁面載入失敗了，再試一次通常就好。
+            {error.digest ? (
+              <span className="text-muted-foreground/60">
+                {" "}
+                (代碼 {error.digest})
+              </span>
+            ) : null}
+          </p>
+        </div>
+        <div className="flex gap-3">
+          <Button onClick={reset}>重試</Button>
+          <Button variant="outline" asChild>
+            <a href="/">回首頁</a>
+          </Button>
+        </div>
+      </div>
+    </PortalShell>
+  )
+}

--- a/apps/portal/app/global-error.tsx
+++ b/apps/portal/app/global-error.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import { useEffect } from "react"
+
+// global-error replaces the root layout when the layout itself throws, so it
+// must ship its own <html>/<body> and can't rely on globals.css or PortalShell.
+// Keep it minimal and inline-styled.
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error("[portal] global error", error)
+  }, [error])
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: "100vh",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: "1rem",
+          fontFamily: "system-ui, -apple-system, sans-serif",
+          color: "#1a1d24",
+          background: "#fff",
+        }}
+      >
+        <h1 style={{ fontWeight: 500, fontSize: "1.1rem", margin: 0 }}>
+          出了點問題
+        </h1>
+        <p style={{ fontSize: "0.875rem", color: "#5c636e", margin: 0 }}>
+          Portal 載入失敗，請重試。
+        </p>
+        <button
+          onClick={() => reset()}
+          style={{
+            padding: "0.5rem 1.25rem",
+            borderRadius: "0.5rem",
+            border: "none",
+            background: "#1a1d24",
+            color: "#fff",
+            fontSize: "0.875rem",
+            cursor: "pointer",
+          }}
+        >
+          重試
+        </button>
+      </body>
+    </html>
+  )
+}

--- a/apps/portal/app/not-found.tsx
+++ b/apps/portal/app/not-found.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link"
+
+import { Button } from "@workspace/ui/components/button"
+
+import { PortalShell } from "@/components/portal-shell"
+
+export default function NotFound() {
+  return (
+    <PortalShell appName="Portal">
+      <div className="flex min-h-[60vh] flex-col justify-center gap-6">
+        <div className="flex flex-col gap-1">
+          <h1 className="font-medium">找不到頁面</h1>
+          <p className="text-sm text-muted-foreground">
+            這個網址不存在，或內容已經被移除。
+          </p>
+        </div>
+        <div>
+          <Button asChild>
+            <Link href="/">回首頁</Link>
+          </Button>
+        </div>
+      </div>
+    </PortalShell>
+  )
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "fluid": true,
   "crons": [
     {
       "path": "/api/cron/approve-emails",


### PR DESCRIPTION
Closes #205

## Summary

- `error.tsx` / `not-found.tsx` / `global-error.tsx` — 補齊 Next.js error 慣例。server component throw(如 `profile` 的 RPC 失敗)不再是裸 500,改成帶 reset 重試的優雅降級頁。`global-error` 自帶 `html`/`body`,不依賴 globals.css。
- `vercel.json` `"fluid": true` — 顯式啟用 Fluid compute(cold start 緩解 + in-function concurrency),不再靠專案預設。

來自工程哲學校準報告 #3 / #5。

## Test plan

- [x] `bun run build --filter=portal` 綠,TypeScript 通過
- [ ] 觸發 server error / 訪問不存在路徑 → 看到優雅降級頁而非 500