### PR TITLE
perf: server-prefetch the leave page

### DIFF
--- a/apps/portal/app/leave/page.tsx
+++ b/apps/portal/app/leave/page.tsx
@@ -1,5 +1,30 @@
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from "@tanstack/react-query"
+
+import { queryKeys } from "@/hooks/leave/query-keys"
+import { fetchLeaves } from "@/lib/leave/fetch"
+import { createClient } from "@/lib/supabase/server"
+
 import { LeaveList } from "./_components/leave-list"
 
-export default function LeaveHome() {
-  return <LeaveList />
+export default async function LeaveHome() {
+  const queryClient = new QueryClient()
+  const supabase = await createClient()
+
+  // Prefetch on the server with the same queryKey the client hook uses, then
+  // hand the dehydrated cache to the client. LeaveList hydrates with real rows
+  // from the HTML — no post-hydration client fetch round-trip on first load.
+  await queryClient.prefetchQuery({
+    queryKey: queryKeys.leaves.list(),
+    queryFn: () => fetchLeaves(supabase),
+  })
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <LeaveList />
+    </HydrationBoundary>
+  )
 }

--- a/apps/portal/hooks/leave/use-leaves.ts
+++ b/apps/portal/hooks/leave/use-leaves.ts
@@ -2,7 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 
-import type { Leave, LeaveWithUser } from "@/lib/leave/types"
+import { fetchLeaves } from "@/lib/leave/fetch"
 import { createClient } from "@/lib/supabase/client"
 
 import { queryKeys } from "./query-keys"
@@ -12,38 +12,7 @@ export function useLeaves() {
 
   return useQuery({
     queryKey: queryKeys.leaves.list(),
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("leaves")
-        .select("*")
-        .order("date", { ascending: false })
-        .order("created_at", { ascending: false })
-
-      if (error) throw error
-
-      const leaves = (data ?? []) as Leave[]
-      if (leaves.length === 0) return [] as LeaveWithUser[]
-
-      const userIds = [...new Set(leaves.map((l) => l.user_id))]
-      const { data: profiles } = await supabase
-        .from("user_profiles")
-        .select("id, name")
-        .in("id", userIds)
-
-      const profileMap = new Map(
-        (profiles ?? []).map((p: { id: string; name: string | null }) => [
-          p.id,
-          p,
-        ])
-      )
-
-      return leaves.map((leave) => ({
-        ...leave,
-        user: profileMap.has(leave.user_id)
-          ? { name: profileMap.get(leave.user_id)!.name ?? null }
-          : null,
-      })) as LeaveWithUser[]
-    },
+    queryFn: () => fetchLeaves(supabase),
   })
 }
 

--- a/apps/portal/lib/leave/fetch.ts
+++ b/apps/portal/lib/leave/fetch.ts
@@ -1,0 +1,40 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import type { Leave, LeaveWithUser } from "@/lib/leave/types"
+
+// Single source of truth for the leave-list query, shared by the client hook
+// (browser client) and the server prefetch (server client). Same queryKey on
+// both sides lets the server-prefetched data hydrate the client cache, so the
+// page paints real rows from the HTML instead of waiting on a client fetch.
+// RLS applies through whichever client is passed in.
+export async function fetchLeaves(
+  supabase: SupabaseClient
+): Promise<LeaveWithUser[]> {
+  const { data, error } = await supabase
+    .from("leaves")
+    .select("*")
+    .order("date", { ascending: false })
+    .order("created_at", { ascending: false })
+
+  if (error) throw error
+
+  const leaves = (data ?? []) as Leave[]
+  if (leaves.length === 0) return []
+
+  const userIds = [...new Set(leaves.map((l) => l.user_id))]
+  const { data: profiles } = await supabase
+    .from("user_profiles")
+    .select("id, name")
+    .in("id", userIds)
+
+  const profileMap = new Map(
+    (profiles ?? []).map((p: { id: string; name: string | null }) => [p.id, p])
+  )
+
+  return leaves.map((leave) => ({
+    ...leave,
+    user: profileMap.has(leave.user_id)
+      ? { name: profileMap.get(leave.user_id)!.name ?? null }
+      : null,
+  })) as LeaveWithUser[]
+}


### PR DESCRIPTION
Closes #207

## Summary

- 抽 `lib/leave/fetch.ts` 的 `fetchLeaves(supabase)`,server/client 共用查詢 + queryKey
- `leave/page.tsx` 改 async server component:`prefetchQuery` + `dehydrate` + `HydrationBoundary`
- 首屏 leave 列表隨 HTML 來,免 post-hydration client fetch round-trip

leave 是試點,驗證後推廣其他列表頁。校準報告 #4(治本)。

## Test plan

- [x] `bun run build --filter=portal` 綠
- [ ] 登入後 hard-reload `/leave` → Network 確認 leaves 自 HTML hydrate(無額外 XHR 等待)