### PR TITLE
feat: type-safe supabase clients via generated Database types

### DIFF
--- a/apps/portal/hooks/bento/use-menus.ts
+++ b/apps/portal/hooks/bento/use-menus.ts
@@ -2,6 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 
+import type { Database } from "@/lib/supabase/database.types"
 import { createClient } from "@/lib/supabase/client"
 
 import { queryKeys } from "./query-keys"
@@ -216,9 +217,10 @@ export function useUpdateMenu(id: string) {
       additional?: string[] | null
       menu_items?: MenuItemInput[]
     }) => {
-      const updatePayload: Record<string, unknown> = {
-        updated_at: new Date().toISOString(),
-      }
+      const updatePayload: Database["public"]["Tables"]["bento_menus"]["Update"] =
+        {
+          updated_at: new Date().toISOString(),
+        }
       if (params.name !== undefined) updatePayload.name = params.name
       if (params.phone !== undefined) updatePayload.phone = params.phone
       if (params.additional !== undefined)

--- a/apps/portal/hooks/bento/use-orders.ts
+++ b/apps/portal/hooks/bento/use-orders.ts
@@ -2,6 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 
+import type { Order, OrderWithStats } from "@/lib/bento/types"
 import { createClient } from "@/lib/supabase/client"
 
 import { queryKeys } from "./query-keys"
@@ -9,17 +10,6 @@ import { queryKeys } from "./query-keys"
 interface OrderItemRaw {
   user_id: string | null
   menu_items?: { name: string; price: number } | null
-}
-
-interface OrderItemWithUser extends OrderItemRaw {
-  id: string
-  order_id: string
-  menu_item_id: string
-  anonymous_name?: string | null
-  anonymous_contact?: string | null
-  no_sauce?: boolean
-  additional?: number | null
-  user?: { name: string | null } | null
 }
 
 function computeOrderStats(orderItems: OrderItemRaw[]) {
@@ -72,7 +62,7 @@ export function useOrders() {
       return (data || []).map((order) => ({
         ...order,
         stats: computeOrderStats((order.order_items || []) as OrderItemRaw[]),
-      }))
+      })) as unknown as OrderWithStats[]
     },
   })
 }
@@ -83,7 +73,7 @@ export function useOrder(id: string | undefined) {
   return useQuery({
     queryKey: queryKeys.orders.detail(id!),
     queryFn: async () => {
-      const { data: order, error } = await supabase
+      const { data, error } = await supabase
         .from("bento_orders")
         .select(
           "*, restaurants:bento_menus(*), order_items:bento_order_items(*, menu_items:bento_menu_items(*))"
@@ -93,8 +83,10 @@ export function useOrder(id: string | undefined) {
 
       if (error) throw error
 
+      const order = data as unknown as Order
+
       if (order?.order_items) {
-        const items = order.order_items as OrderItemWithUser[]
+        const items = order.order_items
         const userIds = [
           ...new Set(
             items
@@ -156,7 +148,7 @@ export function useCreateOrder() {
       const { data, error } = await supabase.rpc("create_bento_order", {
         p_restaurant_id: params.p_restaurant_id,
         p_order_date: params.p_order_date,
-        p_auto_close_at: params.p_auto_close_at ?? null,
+        p_auto_close_at: params.p_auto_close_at ?? undefined,
       })
       if (error) throw error
       return data

--- a/apps/portal/hooks/debt/use-expenses.ts
+++ b/apps/portal/hooks/debt/use-expenses.ts
@@ -43,7 +43,7 @@ export function useCreateExpense() {
     mutationFn: async (input: ExpenseInput) => {
       const { data, error } = await supabase.rpc("debt_create_expense", {
         p_name: input.name,
-        p_description: input.description || null,
+        p_description: input.description || "",
         p_items: input.items,
       })
 
@@ -70,7 +70,7 @@ export function useUpdateExpense() {
       const { error } = await supabase.rpc("debt_update_expense", {
         p_expense_id: input.id,
         p_name: input.name,
-        p_description: input.description || null,
+        p_description: input.description || "",
         p_items: input.items,
       })
 

--- a/apps/portal/hooks/games/use-scores.ts
+++ b/apps/portal/hooks/games/use-scores.ts
@@ -18,7 +18,7 @@ export function useLeaderboard(
     queryFn: async (): Promise<GameScore[]> => {
       const { data, error } = await supabase.rpc("get_game_leaderboard", {
         p_game_type: gameType,
-        p_level: level,
+        p_level: level ?? undefined,
       })
       if (error) throw error
       return (data ?? []) as GameScore[]
@@ -52,7 +52,7 @@ export function useSubmitScore(
         p_game_type: gameType,
         p_score: Math.floor(score),
         p_finish_ms: Math.floor(finishTimeMs),
-        p_level: level,
+        p_level: level ?? undefined,
       })
       if (error) throw error
     },

--- a/apps/portal/lib/supabase/client.ts
+++ b/apps/portal/lib/supabase/client.ts
@@ -1,5 +1,7 @@
 import { createBrowserClient } from "@supabase/ssr"
 
+import type { Database } from "./database.types"
+
 // Mirrors the exact UTF-8 validation that @supabase/supabase-js runs when it
 // decodes a stored JWT. If a stored session contains bytes that fail this
 // check the SDK throws "Invalid UTF-8 sequence" and the auth client is left
@@ -65,7 +67,7 @@ function purgeCorruptedAuthStorageOnce() {
 
 export function createClient() {
   purgeCorruptedAuthStorageOnce()
-  return createBrowserClient(
+  return createBrowserClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
     { cookieOptions: { name: "portal" } }

--- a/apps/portal/lib/supabase/database.types.ts
+++ b/apps/portal/lib/supabase/database.types.ts
@@ -1,0 +1,2367 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "14.1"
+  }
+  public: {
+    Tables: {
+      announcements: {
+        Row: {
+          content: string
+          created_at: string
+          created_by: string | null
+          id: string
+          is_published: boolean
+          notified_at: string | null
+          pinned: boolean
+          tags: string[]
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          content: string
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          is_published?: boolean
+          notified_at?: string | null
+          pinned?: boolean
+          tags?: string[]
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          content?: string
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          is_published?: boolean
+          notified_at?: string | null
+          pinned?: boolean
+          tags?: string[]
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "announcements_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      approve_documents: {
+        Row: {
+          completed_at: string | null
+          created_at: string
+          created_by: string
+          file_path: string | null
+          id: string
+          status: string
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          completed_at?: string | null
+          created_at?: string
+          created_by: string
+          file_path?: string | null
+          id?: string
+          status?: string
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          completed_at?: string | null
+          created_at?: string
+          created_by?: string
+          file_path?: string | null
+          id?: string
+          status?: string
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "approve_documents_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      approve_email_outbox: {
+        Row: {
+          attempts: number
+          created_at: string
+          document_id: string
+          id: string
+          kind: string
+          last_error: string | null
+          recipient_id: string
+          sent_at: string | null
+        }
+        Insert: {
+          attempts?: number
+          created_at?: string
+          document_id: string
+          id?: string
+          kind: string
+          last_error?: string | null
+          recipient_id: string
+          sent_at?: string | null
+        }
+        Update: {
+          attempts?: number
+          created_at?: string
+          document_id?: string
+          id?: string
+          kind?: string
+          last_error?: string | null
+          recipient_id?: string
+          sent_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "approve_email_outbox_document_id_fkey"
+            columns: ["document_id"]
+            isOneToOne: false
+            referencedRelation: "approve_documents"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "approve_email_outbox_recipient_id_fkey"
+            columns: ["recipient_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      approve_fields: {
+        Row: {
+          category: string
+          created_at: string
+          document_id: string
+          height: number
+          id: string
+          label: string | null
+          page: number
+          signed_at: string | null
+          signer_id: string | null
+          value: string | null
+          width: number
+          x: number
+          y: number
+        }
+        Insert: {
+          category: string
+          created_at?: string
+          document_id: string
+          height: number
+          id?: string
+          label?: string | null
+          page: number
+          signed_at?: string | null
+          signer_id?: string | null
+          value?: string | null
+          width: number
+          x: number
+          y: number
+        }
+        Update: {
+          category?: string
+          created_at?: string
+          document_id?: string
+          height?: number
+          id?: string
+          label?: string | null
+          page?: number
+          signed_at?: string | null
+          signer_id?: string | null
+          value?: string | null
+          width?: number
+          x?: number
+          y?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "approve_fields_document_id_fkey"
+            columns: ["document_id"]
+            isOneToOne: false
+            referencedRelation: "approve_documents"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "approve_fields_signer_id_fkey"
+            columns: ["signer_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      approve_signers: {
+        Row: {
+          created_at: string
+          document_id: string
+          id: string
+          signed_at: string | null
+          signer_id: string
+          status: string
+        }
+        Insert: {
+          created_at?: string
+          document_id: string
+          id?: string
+          signed_at?: string | null
+          signer_id: string
+          status?: string
+        }
+        Update: {
+          created_at?: string
+          document_id?: string
+          id?: string
+          signed_at?: string | null
+          signer_id?: string
+          status?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "approve_signers_document_id_fkey"
+            columns: ["document_id"]
+            isOneToOne: false
+            referencedRelation: "approve_documents"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "approve_signers_signer_id_fkey"
+            columns: ["signer_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      approve_user_field_values: {
+        Row: {
+          category: string
+          id: string
+          updated_at: string
+          user_id: string
+          value: string
+        }
+        Insert: {
+          category: string
+          id?: string
+          updated_at?: string
+          user_id: string
+          value: string
+        }
+        Update: {
+          category?: string
+          id?: string
+          updated_at?: string
+          user_id?: string
+          value?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "approve_user_field_values_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      bento_mcp_auth_codes: {
+        Row: {
+          access_token: string
+          client_id: string
+          code: string
+          code_challenge: string
+          code_challenge_method: string
+          expires_at: string
+          redirect_uri: string
+          refresh_token: string | null
+          state: string | null
+        }
+        Insert: {
+          access_token: string
+          client_id: string
+          code: string
+          code_challenge: string
+          code_challenge_method?: string
+          expires_at?: string
+          redirect_uri: string
+          refresh_token?: string | null
+          state?: string | null
+        }
+        Update: {
+          access_token?: string
+          client_id?: string
+          code?: string
+          code_challenge?: string
+          code_challenge_method?: string
+          expires_at?: string
+          redirect_uri?: string
+          refresh_token?: string | null
+          state?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "bento_mcp_auth_codes_client_id_fkey"
+            columns: ["client_id"]
+            isOneToOne: false
+            referencedRelation: "bento_mcp_clients"
+            referencedColumns: ["client_id"]
+          },
+        ]
+      }
+      bento_mcp_clients: {
+        Row: {
+          client_id: string
+          created_at: string
+          redirect_uris: string[]
+          token_endpoint_auth_method: string
+        }
+        Insert: {
+          client_id?: string
+          created_at?: string
+          redirect_uris: string[]
+          token_endpoint_auth_method?: string
+        }
+        Update: {
+          client_id?: string
+          created_at?: string
+          redirect_uris?: string[]
+          token_endpoint_auth_method?: string
+        }
+        Relationships: []
+      }
+      bento_menu_items: {
+        Row: {
+          created_at: string | null
+          id: string
+          name: string
+          options: Json | null
+          price: number
+          restaurant_id: string
+          type: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          name: string
+          options?: Json | null
+          price: number
+          restaurant_id: string
+          type?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          name?: string
+          options?: Json | null
+          price?: number
+          restaurant_id?: string
+          type?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "bento_menu_items_restaurant_id_fkey"
+            columns: ["restaurant_id"]
+            isOneToOne: false
+            referencedRelation: "bento_menus"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      bento_menus: {
+        Row: {
+          additional: Json | null
+          created_at: string | null
+          google_map_link: string | null
+          id: string
+          is_active: boolean
+          name: string
+          phone: string
+          updated_at: string | null
+        }
+        Insert: {
+          additional?: Json | null
+          created_at?: string | null
+          google_map_link?: string | null
+          id?: string
+          is_active?: boolean
+          name: string
+          phone: string
+          updated_at?: string | null
+        }
+        Update: {
+          additional?: Json | null
+          created_at?: string | null
+          google_map_link?: string | null
+          id?: string
+          is_active?: boolean
+          name?: string
+          phone?: string
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
+      bento_order_items: {
+        Row: {
+          additional: number | null
+          anonymous_contact: string | null
+          anonymous_name: string | null
+          created_at: string | null
+          id: string
+          menu_item_id: string
+          no_sauce: boolean | null
+          order_id: string
+          user_id: string | null
+        }
+        Insert: {
+          additional?: number | null
+          anonymous_contact?: string | null
+          anonymous_name?: string | null
+          created_at?: string | null
+          id?: string
+          menu_item_id: string
+          no_sauce?: boolean | null
+          order_id: string
+          user_id?: string | null
+        }
+        Update: {
+          additional?: number | null
+          anonymous_contact?: string | null
+          anonymous_name?: string | null
+          created_at?: string | null
+          id?: string
+          menu_item_id?: string
+          no_sauce?: boolean | null
+          order_id?: string
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "bento_order_items_menu_item_id_fkey"
+            columns: ["menu_item_id"]
+            isOneToOne: false
+            referencedRelation: "bento_menu_items"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "bento_order_items_order_id_fkey"
+            columns: ["order_id"]
+            isOneToOne: false
+            referencedRelation: "bento_order_stats"
+            referencedColumns: ["order_id"]
+          },
+          {
+            foreignKeyName: "bento_order_items_order_id_fkey"
+            columns: ["order_id"]
+            isOneToOne: false
+            referencedRelation: "bento_orders"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "bento_order_items_user_profile_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      bento_orders: {
+        Row: {
+          auto_close_at: string | null
+          closed_at: string | null
+          created_at: string | null
+          created_by: string
+          id: string
+          restaurant_id: string
+          status: string
+        }
+        Insert: {
+          auto_close_at?: string | null
+          closed_at?: string | null
+          created_at?: string | null
+          created_by: string
+          id: string
+          restaurant_id: string
+          status?: string
+        }
+        Update: {
+          auto_close_at?: string | null
+          closed_at?: string | null
+          created_at?: string | null
+          created_by?: string
+          id?: string
+          restaurant_id?: string
+          status?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "bento_orders_created_by_profile_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "bento_orders_new_restaurant_id_fkey"
+            columns: ["restaurant_id"]
+            isOneToOne: false
+            referencedRelation: "bento_menus"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      bento_ratings: {
+        Row: {
+          created_at: string | null
+          id: string
+          menu_item_id: string
+          score: number
+          updated_at: string | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          menu_item_id: string
+          score: number
+          updated_at?: string | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          menu_item_id?: string
+          score?: number
+          updated_at?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "bento_ratings_menu_item_id_fkey"
+            columns: ["menu_item_id"]
+            isOneToOne: false
+            referencedRelation: "bento_menu_items"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "bento_ratings_user_profile_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      bulletin_message_mentions: {
+        Row: {
+          mentioned_user_id: string
+          message_id: string
+          notified_at: string | null
+        }
+        Insert: {
+          mentioned_user_id: string
+          message_id: string
+          notified_at?: string | null
+        }
+        Update: {
+          mentioned_user_id?: string
+          message_id?: string
+          notified_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "bulletin_message_mentions_mentioned_user_id_fkey"
+            columns: ["mentioned_user_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "bulletin_message_mentions_message_id_fkey"
+            columns: ["message_id"]
+            isOneToOne: false
+            referencedRelation: "bulletin_messages"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      bulletin_messages: {
+        Row: {
+          author_id: string
+          broadcast_notified_at: string | null
+          content: string
+          created_at: string
+          id: string
+          is_broadcast: boolean
+        }
+        Insert: {
+          author_id: string
+          broadcast_notified_at?: string | null
+          content: string
+          created_at?: string
+          id?: string
+          is_broadcast?: boolean
+        }
+        Update: {
+          author_id?: string
+          broadcast_notified_at?: string | null
+          content?: string
+          created_at?: string
+          id?: string
+          is_broadcast?: boolean
+        }
+        Relationships: [
+          {
+            foreignKeyName: "bulletin_messages_author_id_fkey"
+            columns: ["author_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      claims: {
+        Row: {
+          created_at: string
+          id: string
+          status: string
+          title: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id: string
+          status?: string
+          title: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          status?: string
+          title?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "claims_user_profiles_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      debit_expense_items: {
+        Row: {
+          amount: number
+          created_at: string
+          debtor_id: string
+          expense_id: string
+          id: string
+          paid_at: string | null
+        }
+        Insert: {
+          amount: number
+          created_at?: string
+          debtor_id: string
+          expense_id: string
+          id?: string
+          paid_at?: string | null
+        }
+        Update: {
+          amount?: number
+          created_at?: string
+          debtor_id?: string
+          expense_id?: string
+          id?: string
+          paid_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "debit_expense_items_debtor_id_fkey"
+            columns: ["debtor_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "debit_expense_items_expense_id_fkey"
+            columns: ["expense_id"]
+            isOneToOne: false
+            referencedRelation: "debit_expenses"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      debit_expenses: {
+        Row: {
+          created_at: string
+          creator_id: string
+          description: string | null
+          id: string
+          name: string
+        }
+        Insert: {
+          created_at?: string
+          creator_id?: string
+          description?: string | null
+          id?: string
+          name: string
+        }
+        Update: {
+          created_at?: string
+          creator_id?: string
+          description?: string | null
+          id?: string
+          name?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "debit_expenses_creator_id_fkey"
+            columns: ["creator_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      debit_settlements: {
+        Row: {
+          amount: number
+          created_at: string
+          from_confirmed: boolean
+          from_user_id: string
+          id: string
+          period: string
+          settled_at: string | null
+          to_confirmed: boolean
+          to_user_id: string
+        }
+        Insert: {
+          amount: number
+          created_at?: string
+          from_confirmed?: boolean
+          from_user_id: string
+          id?: string
+          period: string
+          settled_at?: string | null
+          to_confirmed?: boolean
+          to_user_id: string
+        }
+        Update: {
+          amount?: number
+          created_at?: string
+          from_confirmed?: boolean
+          from_user_id?: string
+          id?: string
+          period?: string
+          settled_at?: string | null
+          to_confirmed?: boolean
+          to_user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "debit_settlements_from_user_id_fkey"
+            columns: ["from_user_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "debit_settlements_to_user_id_fkey"
+            columns: ["to_user_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      debt_expense_items: {
+        Row: {
+          amount: number
+          created_at: string
+          debtor_id: string
+          expense_id: string
+          id: string
+          paid_at: string | null
+        }
+        Insert: {
+          amount: number
+          created_at?: string
+          debtor_id: string
+          expense_id: string
+          id?: string
+          paid_at?: string | null
+        }
+        Update: {
+          amount?: number
+          created_at?: string
+          debtor_id?: string
+          expense_id?: string
+          id?: string
+          paid_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "debt_expense_items_debtor_id_fkey"
+            columns: ["debtor_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "debt_expense_items_expense_id_fkey"
+            columns: ["expense_id"]
+            isOneToOne: false
+            referencedRelation: "debt_expenses"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      debt_expenses: {
+        Row: {
+          created_at: string
+          creator_id: string
+          description: string | null
+          id: string
+          name: string
+        }
+        Insert: {
+          created_at?: string
+          creator_id?: string
+          description?: string | null
+          id?: string
+          name: string
+        }
+        Update: {
+          created_at?: string
+          creator_id?: string
+          description?: string | null
+          id?: string
+          name?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "debt_expenses_creator_id_fkey"
+            columns: ["creator_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      debt_settlements: {
+        Row: {
+          amount: number
+          created_at: string
+          from_confirmed: boolean
+          from_user_id: string
+          id: string
+          period: string
+          settled_at: string | null
+          to_confirmed: boolean
+          to_user_id: string
+        }
+        Insert: {
+          amount: number
+          created_at?: string
+          from_confirmed?: boolean
+          from_user_id: string
+          id?: string
+          period: string
+          settled_at?: string | null
+          to_confirmed?: boolean
+          to_user_id: string
+        }
+        Update: {
+          amount?: number
+          created_at?: string
+          from_confirmed?: boolean
+          from_user_id?: string
+          id?: string
+          period?: string
+          settled_at?: string | null
+          to_confirmed?: boolean
+          to_user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "debt_settlements_from_user_id_fkey"
+            columns: ["from_user_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "debt_settlements_to_user_id_fkey"
+            columns: ["to_user_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      egress: {
+        Row: {
+          applicant_name: string
+          created_at: string | null
+          id: string
+          invoice_date: string
+          invoice_files: string[] | null
+          item_amount: number
+          item_comment: string | null
+          item_name: string
+          status: Database["public"]["Enums"]["egress_status"]
+          transfer_date: string | null
+          transfer_fee: number | null
+          transfer_files: string[] | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          applicant_name: string
+          created_at?: string | null
+          id?: string
+          invoice_date: string
+          invoice_files?: string[] | null
+          item_amount: number
+          item_comment?: string | null
+          item_name: string
+          status?: Database["public"]["Enums"]["egress_status"]
+          transfer_date?: string | null
+          transfer_fee?: number | null
+          transfer_files?: string[] | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          applicant_name?: string
+          created_at?: string | null
+          id?: string
+          invoice_date?: string
+          invoice_files?: string[] | null
+          item_amount?: number
+          item_comment?: string | null
+          item_name?: string
+          status?: Database["public"]["Enums"]["egress_status"]
+          transfer_date?: string | null
+          transfer_fee?: number | null
+          transfer_files?: string[] | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: []
+      }
+      gallery_comment_mentions: {
+        Row: {
+          comment_id: string
+          mentioned_user_id: string
+          notified_at: string | null
+        }
+        Insert: {
+          comment_id: string
+          mentioned_user_id: string
+          notified_at?: string | null
+        }
+        Update: {
+          comment_id?: string
+          mentioned_user_id?: string
+          notified_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gallery_comment_mentions_comment_id_fkey"
+            columns: ["comment_id"]
+            isOneToOne: false
+            referencedRelation: "gallery_comments"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "gallery_comment_mentions_mentioned_user_id_fkey"
+            columns: ["mentioned_user_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      gallery_comments: {
+        Row: {
+          body: string
+          created_at: string
+          created_by: string
+          id: string
+          image_id: string
+          parent_id: string | null
+        }
+        Insert: {
+          body: string
+          created_at?: string
+          created_by: string
+          id?: string
+          image_id: string
+          parent_id?: string | null
+        }
+        Update: {
+          body?: string
+          created_at?: string
+          created_by?: string
+          id?: string
+          image_id?: string
+          parent_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gallery_comments_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "gallery_comments_image_id_fkey"
+            columns: ["image_id"]
+            isOneToOne: false
+            referencedRelation: "gallery_images"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "gallery_comments_parent_id_fkey"
+            columns: ["parent_id"]
+            isOneToOne: false
+            referencedRelation: "gallery_comments"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      gallery_image_votes: {
+        Row: {
+          created_at: string
+          image_id: string
+          reaction: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          image_id: string
+          reaction?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          image_id?: string
+          reaction?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gallery_image_votes_image_id_fkey"
+            columns: ["image_id"]
+            isOneToOne: false
+            referencedRelation: "gallery_images"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "gallery_image_votes_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      gallery_images: {
+        Row: {
+          created_at: string
+          created_by: string
+          duration_seconds: number | null
+          id: string
+          image_path: string
+          media_type: string
+          name: string
+          poster_path: string | null
+          sequence_id: string | null
+          sequence_index: number | null
+        }
+        Insert: {
+          created_at?: string
+          created_by: string
+          duration_seconds?: number | null
+          id?: string
+          image_path: string
+          media_type?: string
+          name: string
+          poster_path?: string | null
+          sequence_id?: string | null
+          sequence_index?: number | null
+        }
+        Update: {
+          created_at?: string
+          created_by?: string
+          duration_seconds?: number | null
+          id?: string
+          image_path?: string
+          media_type?: string
+          name?: string
+          poster_path?: string | null
+          sequence_id?: string | null
+          sequence_index?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gallery_images_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      gallery_settings: {
+        Row: {
+          key: string
+          updated_at: string
+          updated_by: string | null
+          value: Json
+        }
+        Insert: {
+          key: string
+          updated_at?: string
+          updated_by?: string | null
+          value?: Json
+        }
+        Update: {
+          key?: string
+          updated_at?: string
+          updated_by?: string | null
+          value?: Json
+        }
+        Relationships: [
+          {
+            foreignKeyName: "gallery_settings_updated_by_fkey"
+            columns: ["updated_by"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      game_scores: {
+        Row: {
+          created_at: string
+          finish_time_ms: number
+          game_type: Database["public"]["Enums"]["game_type"]
+          id: string
+          level: number | null
+          score: number
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          finish_time_ms: number
+          game_type: Database["public"]["Enums"]["game_type"]
+          id?: string
+          level?: number | null
+          score: number
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          finish_time_ms?: number
+          game_type?: Database["public"]["Enums"]["game_type"]
+          id?: string
+          level?: number | null
+          score?: number
+          user_id?: string
+        }
+        Relationships: []
+      }
+      images: {
+        Row: {
+          created_at: string
+          filename: string
+          id: string
+          mime_type: string
+          size: number
+          storage_path: string
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          filename: string
+          id: string
+          mime_type: string
+          size: number
+          storage_path: string
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          filename?: string
+          id?: string
+          mime_type?: string
+          size?: number
+          storage_path?: string
+          user_id?: string | null
+        }
+        Relationships: []
+      }
+      ingress: {
+        Row: {
+          created_at: string | null
+          id: string
+          ingress_amount: number
+          ingress_comment: string | null
+          ingress_date: string
+          ingress_files: string[] | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          ingress_amount: number
+          ingress_comment?: string | null
+          ingress_date: string
+          ingress_files?: string[] | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          ingress_amount?: number
+          ingress_comment?: string | null
+          ingress_date?: string
+          ingress_files?: string[] | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: []
+      }
+      invoice: {
+        Row: {
+          created_at: string
+          id: string
+          image_paths: string[]
+          notes: string | null
+          reason: string
+          status: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          image_paths?: string[]
+          notes?: string | null
+          reason: string
+          status?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          image_paths?: string[]
+          notes?: string | null
+          reason?: string
+          status?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "invoice_user_profile_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      items: {
+        Row: {
+          content: string | null
+          created_at: string
+          desktop_id: string
+          icon_url: string | null
+          id: string
+          sort_order: number | null
+          title: string
+          type: string
+          url: string | null
+          user_id: string
+        }
+        Insert: {
+          content?: string | null
+          created_at?: string
+          desktop_id: string
+          icon_url?: string | null
+          id?: string
+          sort_order?: number | null
+          title: string
+          type: string
+          url?: string | null
+          user_id: string
+        }
+        Update: {
+          content?: string | null
+          created_at?: string
+          desktop_id?: string
+          icon_url?: string | null
+          id?: string
+          sort_order?: number | null
+          title?: string
+          type?: string
+          url?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
+      leaves: {
+        Row: {
+          created_at: string | null
+          date: string
+          id: string
+          reason: string
+          updated_at: string | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          date: string
+          id?: string
+          reason: string
+          updated_at?: string | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string | null
+          date?: string
+          id?: string
+          reason?: string
+          updated_at?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
+      mcp_oauth_auth_codes: {
+        Row: {
+          code: string
+          created_at: string
+          data: Json
+          expires_at: string
+        }
+        Insert: {
+          code: string
+          created_at?: string
+          data: Json
+          expires_at?: string
+        }
+        Update: {
+          code?: string
+          created_at?: string
+          data?: Json
+          expires_at?: string
+        }
+        Relationships: []
+      }
+      mcp_oauth_clients: {
+        Row: {
+          client_id: string
+          client_name: string
+          created_at: string
+          grant_types: Json
+          redirect_uris: Json
+          response_types: Json
+        }
+        Insert: {
+          client_id: string
+          client_name: string
+          created_at?: string
+          grant_types: Json
+          redirect_uris: Json
+          response_types: Json
+        }
+        Update: {
+          client_id?: string
+          client_name?: string
+          created_at?: string
+          grant_types?: Json
+          redirect_uris?: Json
+          response_types?: Json
+        }
+        Relationships: []
+      }
+      meeting_groups: {
+        Row: {
+          group_number: number
+          members: string[]
+          updated_at: string
+        }
+        Insert: {
+          group_number: number
+          members?: string[]
+          updated_at?: string
+        }
+        Update: {
+          group_number?: number
+          members?: string[]
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      meetings: {
+        Row: {
+          created_at: string
+          id: string
+          is_holiday: boolean
+          location: string
+          notes: string | null
+          paper_link: string | null
+          paper_title: string | null
+          ppt_link: string | null
+          ppt_uploaded: boolean
+          presenter: string | null
+          presenter_user_id: string | null
+          question_group_number: number | null
+          scheduled_date: string
+          start_time: string
+          video_link: string | null
+          video_uploaded: boolean
+          week_label: string | null
+          year: number
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          is_holiday?: boolean
+          location?: string
+          notes?: string | null
+          paper_link?: string | null
+          paper_title?: string | null
+          ppt_link?: string | null
+          ppt_uploaded?: boolean
+          presenter?: string | null
+          presenter_user_id?: string | null
+          question_group_number?: number | null
+          scheduled_date: string
+          start_time?: string
+          video_link?: string | null
+          video_uploaded?: boolean
+          week_label?: string | null
+          year: number
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          is_holiday?: boolean
+          location?: string
+          notes?: string | null
+          paper_link?: string | null
+          paper_title?: string | null
+          ppt_link?: string | null
+          ppt_uploaded?: boolean
+          presenter?: string | null
+          presenter_user_id?: string | null
+          question_group_number?: number | null
+          scheduled_date?: string
+          start_time?: string
+          video_link?: string | null
+          video_uploaded?: boolean
+          week_label?: string | null
+          year?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fk_meeting_question_group"
+            columns: ["question_group_number"]
+            isOneToOne: false
+            referencedRelation: "meeting_groups"
+            referencedColumns: ["group_number"]
+          },
+          {
+            foreignKeyName: "meetings_presenter_user_id_fkey"
+            columns: ["presenter_user_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      members: {
+        Row: {
+          avatar_url: string | null
+          created_at: string | null
+          email: string
+          github: string | null
+          id: string
+          is_active: boolean | null
+          joined_year: number | null
+          name: string
+          name_en: string | null
+          office: string | null
+          phone: string | null
+          research_areas: string[] | null
+          role: string
+          student_id: string | null
+          title: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          avatar_url?: string | null
+          created_at?: string | null
+          email: string
+          github?: string | null
+          id?: string
+          is_active?: boolean | null
+          joined_year?: number | null
+          name: string
+          name_en?: string | null
+          office?: string | null
+          phone?: string | null
+          research_areas?: string[] | null
+          role: string
+          student_id?: string | null
+          title?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          avatar_url?: string | null
+          created_at?: string | null
+          email?: string
+          github?: string | null
+          id?: string
+          is_active?: boolean | null
+          joined_year?: number | null
+          name?: string
+          name_en?: string | null
+          office?: string | null
+          phone?: string | null
+          research_areas?: string[] | null
+          role?: string
+          student_id?: string | null
+          title?: string | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
+      notepads: {
+        Row: {
+          content: string
+          created_at: string
+          id: string
+          updated_at: string
+        }
+        Insert: {
+          content?: string
+          created_at?: string
+          id: string
+          updated_at?: string
+        }
+        Update: {
+          content?: string
+          created_at?: string
+          id?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      pending_bot_bindings: {
+        Row: {
+          code: string
+          created_at: string
+          expires_at: string
+          id: string
+          platform: string
+          user_id: string
+        }
+        Insert: {
+          code: string
+          created_at?: string
+          expires_at?: string
+          id?: string
+          platform: string
+          user_id: string
+        }
+        Update: {
+          code?: string
+          created_at?: string
+          expires_at?: string
+          id?: string
+          platform?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "pending_bot_bindings_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      receipt_tag_assignments: {
+        Row: {
+          created_at: string
+          receipt_id: string
+          tag_id: string
+        }
+        Insert: {
+          created_at?: string
+          receipt_id: string
+          tag_id: string
+        }
+        Update: {
+          created_at?: string
+          receipt_id?: string
+          tag_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "receipt_tag_assignments_receipt_id_fkey"
+            columns: ["receipt_id"]
+            isOneToOne: false
+            referencedRelation: "receipts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "receipt_tag_assignments_tag_id_fkey"
+            columns: ["tag_id"]
+            isOneToOne: false
+            referencedRelation: "receipt_tags"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      receipt_tags: {
+        Row: {
+          created_at: string
+          created_by: string | null
+          id: string
+          name: string
+          variant: string
+        }
+        Insert: {
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          name: string
+          variant?: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          name?: string
+          variant?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "receipt_tags_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      receipts: {
+        Row: {
+          created_at: string
+          created_by: string | null
+          id: string
+          image_path: string
+          name: string
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          image_path: string
+          name: string
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          image_path?: string
+          name?: string
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "receipts_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      reimburse_egress: {
+        Row: {
+          applicant_name: string
+          created_at: string
+          id: string
+          invoice_date: string
+          invoice_files: string[]
+          item_amount: number
+          item_comment: string | null
+          item_name: string
+          status: string
+          transfer_date: string | null
+          transfer_fee: number | null
+          transfer_files: string[] | null
+          updated_at: string
+          user_id: string | null
+        }
+        Insert: {
+          applicant_name: string
+          created_at?: string
+          id?: string
+          invoice_date: string
+          invoice_files?: string[]
+          item_amount: number
+          item_comment?: string | null
+          item_name: string
+          status?: string
+          transfer_date?: string | null
+          transfer_fee?: number | null
+          transfer_files?: string[] | null
+          updated_at?: string
+          user_id?: string | null
+        }
+        Update: {
+          applicant_name?: string
+          created_at?: string
+          id?: string
+          invoice_date?: string
+          invoice_files?: string[]
+          item_amount?: number
+          item_comment?: string | null
+          item_name?: string
+          status?: string
+          transfer_date?: string | null
+          transfer_fee?: number | null
+          transfer_files?: string[] | null
+          updated_at?: string
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "reimburse_egress_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      reimburse_ingress: {
+        Row: {
+          created_at: string
+          id: string
+          ingress_amount: number
+          ingress_comment: string | null
+          ingress_date: string
+          ingress_files: string[]
+          updated_at: string
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          ingress_amount: number
+          ingress_comment?: string | null
+          ingress_date: string
+          ingress_files?: string[]
+          updated_at?: string
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          ingress_amount?: number
+          ingress_comment?: string | null
+          ingress_date?: string
+          ingress_files?: string[]
+          updated_at?: string
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "reimburse_ingress_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      teacher_papers: {
+        Row: {
+          created_at: string
+          file_link: string | null
+          id: string
+          paper_name: string
+          provided_date: string
+          source: string | null
+        }
+        Insert: {
+          created_at?: string
+          file_link?: string | null
+          id?: string
+          paper_name: string
+          provided_date: string
+          source?: string | null
+        }
+        Update: {
+          created_at?: string
+          file_link?: string | null
+          id?: string
+          paper_name?: string
+          provided_date?: string
+          source?: string | null
+        }
+        Relationships: []
+      }
+      trip_files: {
+        Row: {
+          created_at: string
+          description: string | null
+          filename: string
+          id: string
+          size_bytes: number | null
+          storage_path: string
+          trip_id: string
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          description?: string | null
+          filename: string
+          id?: string
+          size_bytes?: number | null
+          storage_path: string
+          trip_id: string
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          description?: string | null
+          filename?: string
+          id?: string
+          size_bytes?: number | null
+          storage_path?: string
+          trip_id?: string
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "trip_files_trip_id_fkey"
+            columns: ["trip_id"]
+            isOneToOne: false
+            referencedRelation: "trips"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "trip_files_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      trips: {
+        Row: {
+          closed_at: string | null
+          created_at: string
+          created_by: string | null
+          description: string | null
+          id: string
+          name: string
+          status: string
+        }
+        Insert: {
+          closed_at?: string | null
+          created_at?: string
+          created_by?: string | null
+          description?: string | null
+          id?: string
+          name: string
+          status?: string
+        }
+        Update: {
+          closed_at?: string | null
+          created_at?: string
+          created_by?: string | null
+          description?: string | null
+          id?: string
+          name?: string
+          status?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "trips_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      user_profiles: {
+        Row: {
+          active_workflow: Json | null
+          claude_session_id: string | null
+          created_at: string | null
+          discord_user_id: string | null
+          email: string | null
+          id: string
+          is_admin: boolean | null
+          last_active_platform: string | null
+          line_user_id: string | null
+          name: string | null
+          roles: Json | null
+          telegram_user_id: string | null
+        }
+        Insert: {
+          active_workflow?: Json | null
+          claude_session_id?: string | null
+          created_at?: string | null
+          discord_user_id?: string | null
+          email?: string | null
+          id: string
+          is_admin?: boolean | null
+          last_active_platform?: string | null
+          line_user_id?: string | null
+          name?: string | null
+          roles?: Json | null
+          telegram_user_id?: string | null
+        }
+        Update: {
+          active_workflow?: Json | null
+          claude_session_id?: string | null
+          created_at?: string | null
+          discord_user_id?: string | null
+          email?: string | null
+          id?: string
+          is_admin?: boolean | null
+          last_active_platform?: string | null
+          line_user_id?: string | null
+          name?: string | null
+          roles?: Json | null
+          telegram_user_id?: string | null
+        }
+        Relationships: []
+      }
+      user_sign_prefs: {
+        Row: {
+          corner: string
+          enabled: boolean
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          corner?: string
+          enabled?: boolean
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          corner?: string
+          enabled?: boolean
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_sign_prefs_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+    }
+    Views: {
+      bento_order_stats: {
+        Row: {
+          order_id: string | null
+          total_items: number | null
+          total_price: number | null
+          user_count: number | null
+        }
+        Relationships: []
+      }
+      bento_user_rankings: {
+        Row: {
+          order_count: number | null
+          total_spending: number | null
+          unique_items: number | null
+          user_id: string | null
+          user_name: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "bento_order_items_user_profile_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+    }
+    Functions: {
+      approve_doc_status: { Args: { doc_id: string }; Returns: string }
+      approve_is_creator: {
+        Args: { doc_id: string; uid: string }
+        Returns: boolean
+      }
+      approve_is_signer: {
+        Args: { doc_id: string; uid: string }
+        Returns: boolean
+      }
+      approve_profile_stats: { Args: { p_user_id: string }; Returns: Json }
+      approve_submit_signature: {
+        Args: { p_document_id: string; p_values: Json }
+        Returns: undefined
+      }
+      bento_profile_stats: { Args: { p_user_id: string }; Returns: Json }
+      can_sign_document: { Args: { doc_id: string }; Returns: boolean }
+      can_view_document_signers: { Args: { doc_id: string }; Returns: boolean }
+      can_view_signature_boxes: { Args: { doc_id: string }; Returns: boolean }
+      confirm_settlement_from: {
+        Args: { p_settlement_id: string }
+        Returns: undefined
+      }
+      confirm_settlement_to: {
+        Args: { p_settlement_id: string }
+        Returns: undefined
+      }
+      create_bento_order: {
+        Args: {
+          p_auto_close_at?: string
+          p_order_date: string
+          p_restaurant_id: string
+        }
+        Returns: {
+          auto_close_at: string | null
+          closed_at: string | null
+          created_at: string | null
+          created_by: string
+          id: string
+          restaurant_id: string
+          status: string
+        }
+        SetofOptions: {
+          from: "*"
+          to: "bento_orders"
+          isOneToOne: true
+          isSetofReturn: false
+        }
+      }
+      create_expense: {
+        Args: { p_description?: string; p_items?: Json; p_name: string }
+        Returns: string
+      }
+      debt_confirm_settlement_from: {
+        Args: { p_settlement_id: string }
+        Returns: undefined
+      }
+      debt_confirm_settlement_to: {
+        Args: { p_settlement_id: string }
+        Returns: undefined
+      }
+      debt_create_expense: {
+        Args: { p_description: string; p_items: Json; p_name: string }
+        Returns: string
+      }
+      debt_generate_monthly_settlements: { Args: never; Returns: undefined }
+      debt_mark_item_paid: {
+        Args: { p_item_id: string; p_paid: boolean }
+        Returns: undefined
+      }
+      debt_update_expense: {
+        Args: {
+          p_description: string
+          p_expense_id: string
+          p_items: Json
+          p_name: string
+        }
+        Returns: undefined
+      }
+      generate_monthly_settlements: { Args: never; Returns: undefined }
+      generate_short_id: { Args: { length?: number }; Returns: string }
+      get_game_leaderboard: {
+        Args: {
+          p_game_type: Database["public"]["Enums"]["game_type"]
+          p_level?: number
+        }
+        Returns: {
+          achieved_at: string
+          finish_time_ms: number
+          score: number
+          user_id: string
+          user_name: string
+        }[]
+      }
+      get_profile_stats: { Args: { p_user_id: string }; Returns: Json }
+      get_user_email: { Args: never; Returns: string }
+      has_any_role_in_system: {
+        Args: { system_name: string; user_id_param: string }
+        Returns: boolean
+      }
+      has_role: {
+        Args: { role_name: string; system_name: string; user_id_param: string }
+        Returns: boolean
+      }
+      is_debt_expense_debtor: {
+        Args: { expense_uuid: string }
+        Returns: boolean
+      }
+      is_expense_debtor: { Args: { expense_uuid: string }; Returns: boolean }
+      is_meetings_admin: { Args: never; Returns: boolean }
+      is_portal_admin: { Args: never; Returns: boolean }
+      is_receipts_admin: { Args: never; Returns: boolean }
+      is_reimburse_admin: { Args: never; Returns: boolean }
+      is_trip_admin: { Args: never; Returns: boolean }
+      leave_profile_stats: { Args: { p_user_id: string }; Returns: Json }
+      mark_item_paid: {
+        Args: { p_item_id: string; p_paid: boolean }
+        Returns: undefined
+      }
+      mcp_create_oauth_auth_code: {
+        Args: { p_code: string; p_data: Json }
+        Returns: undefined
+      }
+      mcp_exchange_oauth_auth_code: { Args: { p_code: string }; Returns: Json }
+      portal_admin_get_users: {
+        Args: never
+        Returns: {
+          email: string
+          id: string
+          is_admin: boolean
+          name: string
+          roles: Json
+        }[]
+      }
+      portal_admin_update_user: {
+        Args: { p_is_admin: boolean; p_roles: Json; p_target_id: string }
+        Returns: undefined
+      }
+      submit_game_score: {
+        Args: {
+          p_finish_ms: number
+          p_game_type: Database["public"]["Enums"]["game_type"]
+          p_level?: number
+          p_score: number
+        }
+        Returns: undefined
+      }
+      trip_admin_get_member_signatures: {
+        Args: { p_trip_id: string }
+        Returns: {
+          corner: string
+          enabled: boolean
+          member_id: string
+          signature: string
+        }[]
+      }
+      trip_profile_stats: { Args: { p_user_id: string }; Returns: Json }
+      update_expense: {
+        Args: {
+          p_description?: string
+          p_expense_id: string
+          p_items?: Json
+          p_name: string
+        }
+        Returns: undefined
+      }
+      upsert_user_profile: {
+        Args: { p_email: string; p_name: string }
+        Returns: string
+      }
+    }
+    Enums: {
+      egress_status: "pending" | "approved" | "rejected" | "transferred"
+      game_type:
+        | "2048"
+        | "memory"
+        | "typing"
+        | "snake"
+        | "pipes"
+        | "kings"
+        | "queens"
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  public: {
+    Enums: {
+      egress_status: ["pending", "approved", "rejected", "transferred"],
+      game_type: [
+        "2048",
+        "memory",
+        "typing",
+        "snake",
+        "pipes",
+        "kings",
+        "queens",
+      ],
+    },
+  },
+} as const

--- a/apps/portal/lib/supabase/middleware.ts
+++ b/apps/portal/lib/supabase/middleware.ts
@@ -1,6 +1,8 @@
 import { createServerClient } from "@supabase/ssr"
 import { NextResponse, type NextRequest } from "next/server"
 
+import type { Database } from "./database.types"
+
 // Ghost cookies from the old portal (domain=.winlab.tw) are sent by the
 // browser to every *.winlab.tw subdomain alongside the correct host-only
 // cookies. @supabase/ssr receives duplicate cookie names from getAll() and
@@ -16,7 +18,7 @@ export async function updateSession(request: NextRequest) {
 
   // With Fluid compute, don't put this client in a global environment
   // variable. Always create a new one on each request.
-  const supabase = createServerClient(
+  const supabase = createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
     {

--- a/apps/portal/lib/supabase/server.ts
+++ b/apps/portal/lib/supabase/server.ts
@@ -1,6 +1,8 @@
 import { createServerClient } from "@supabase/ssr"
 import { cookies } from "next/headers"
 
+import type { Database } from "./database.types"
+
 /**
  * If using Fluid compute: Don't put this client in a global variable. Always create a new client within each
  * function when using it.
@@ -8,7 +10,7 @@ import { cookies } from "next/headers"
 export async function createClient() {
   const cookieStore = await cookies()
 
-  return createServerClient(
+  return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
     {


### PR DESCRIPTION
Closes #210

## Summary

- `supabase gen types` → `lib/supabase/database.types.ts`(winlab project)
- browser/server/middleware client 帶 `<Database>`;`admin` 維持 untyped(service-role 會碰 generated types 外的表)
- 修 18 個 typed client 揭露的真 type 問題:games/debt 傳 `null` 給 non-null RPC arg、bento hook 回傳 raw DB row 但 app 要業務 type(Order/OrderWithStats),在 query 邊界 cast

## 副產出(已開 issue,本 PR 不修)

type gen 揭露 **schema drift #209**:`receipts_email_outbox` 在 remote 不存在,但 cron + email-drain 還在用 → receipts email 通知 prod 可能壞。待確認方向。

## Test plan

- [x] `typecheck` 0 error、`build` 綠
- [ ] 登入後各 app(bento/debt/leave…)CRUD 正常 — type 改動不應改變 runtime 行為