### PR TITLE
perf: server-prefetch trip, receipts, bento list pages

### DIFF
--- a/apps/portal/app/bento/page.tsx
+++ b/apps/portal/app/bento/page.tsx
@@ -1,5 +1,27 @@
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from "@tanstack/react-query"
+
+import { queryKeys } from "@/hooks/bento/query-keys"
+import { fetchOrders } from "@/lib/bento/fetch"
+import { createClient } from "@/lib/supabase/server"
+
 import { OrderList } from "./_components/order-list"
 
-export default function BentoHome() {
-  return <OrderList />
+export default async function BentoHome() {
+  const queryClient = new QueryClient()
+  const supabase = await createClient()
+
+  await queryClient.prefetchQuery({
+    queryKey: queryKeys.orders.list(),
+    queryFn: () => fetchOrders(supabase),
+  })
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <OrderList />
+    </HydrationBoundary>
+  )
 }

--- a/apps/portal/app/receipts/page.tsx
+++ b/apps/portal/app/receipts/page.tsx
@@ -1,6 +1,14 @@
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from "@tanstack/react-query"
 import { notFound } from "next/navigation"
 
+import { queryKeys } from "@/hooks/receipts/query-keys"
 import { isReceiptsAdmin } from "@/lib/receipts/admin"
+import { fetchReceipts } from "@/lib/receipts/fetch"
+import { createClient } from "@/lib/supabase/server"
 
 import { ReceiptsView } from "./_components/receipts-view"
 
@@ -11,5 +19,17 @@ export const dynamic = "force-dynamic"
 export default async function ReceiptsPage() {
   const isAdmin = await isReceiptsAdmin()
   if (!isAdmin) notFound()
-  return <ReceiptsView />
+
+  const queryClient = new QueryClient()
+  const supabase = await createClient()
+  await queryClient.prefetchQuery({
+    queryKey: queryKeys.receipts.all,
+    queryFn: () => fetchReceipts(supabase),
+  })
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ReceiptsView />
+    </HydrationBoundary>
+  )
 }

--- a/apps/portal/app/trip/page.tsx
+++ b/apps/portal/app/trip/page.tsx
@@ -1,5 +1,27 @@
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from "@tanstack/react-query"
+
+import { queryKeys } from "@/hooks/trip/query-keys"
+import { fetchTrips } from "@/lib/trip/fetch"
+import { createClient } from "@/lib/supabase/server"
+
 import { TripList } from "./_components/trip-list"
 
-export default function TripHome() {
-  return <TripList />
+export default async function TripHome() {
+  const queryClient = new QueryClient()
+  const supabase = await createClient()
+
+  await queryClient.prefetchQuery({
+    queryKey: queryKeys.trips.list(),
+    queryFn: () => fetchTrips(supabase),
+  })
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <TripList />
+    </HydrationBoundary>
+  )
 }

--- a/apps/portal/hooks/bento/use-orders.ts
+++ b/apps/portal/hooks/bento/use-orders.ts
@@ -2,68 +2,18 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 
-import type { Order, OrderWithStats } from "@/lib/bento/types"
+import { fetchOrders } from "@/lib/bento/fetch"
+import type { Order } from "@/lib/bento/types"
 import { createClient } from "@/lib/supabase/client"
 
 import { queryKeys } from "./query-keys"
-
-interface OrderItemRaw {
-  user_id: string | null
-  menu_items?: { name: string; price: number } | null
-}
-
-function computeOrderStats(orderItems: OrderItemRaw[]) {
-  const uniqueUsers = new Set(
-    orderItems.map((item) => item.user_id).filter(Boolean)
-  )
-
-  const menuItemCounts = new Map<string, { name: string; count: number }>()
-  let totalPrice = 0
-
-  for (const item of orderItems) {
-    const name = item.menu_items?.name
-    const price = parseFloat(String(item.menu_items?.price || 0))
-    totalPrice += price
-
-    if (name) {
-      const existing = menuItemCounts.get(name)
-      if (existing) {
-        existing.count += 1
-      } else {
-        menuItemCounts.set(name, { name, count: 1 })
-      }
-    }
-  }
-
-  return {
-    user_count: uniqueUsers.size,
-    menu_item_names: Array.from(menuItemCounts.keys()),
-    menu_items: Array.from(menuItemCounts.values()),
-    total_items: orderItems.length,
-    total_price: totalPrice,
-  }
-}
 
 export function useOrders() {
   const supabase = createClient()
 
   return useQuery({
     queryKey: queryKeys.orders.list(),
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("bento_orders")
-        .select(
-          "*, restaurants:bento_menus(name, additional), order_items:bento_order_items(*, menu_items:bento_menu_items(name, price))"
-        )
-        .order("created_at", { ascending: false })
-
-      if (error) throw error
-
-      return (data || []).map((order) => ({
-        ...order,
-        stats: computeOrderStats((order.order_items || []) as OrderItemRaw[]),
-      })) as unknown as OrderWithStats[]
-    },
+    queryFn: () => fetchOrders(supabase),
   })
 }
 

--- a/apps/portal/hooks/receipts/use-receipts.ts
+++ b/apps/portal/hooks/receipts/use-receipts.ts
@@ -3,6 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 
 import { triggerReceiptEmailDrain } from "@/app/receipts/actions"
+import { fetchReceipts } from "@/lib/receipts/fetch"
 import { createClient } from "@/lib/supabase/client"
 import {
   RECEIPT_FILE_EXT,
@@ -11,10 +12,8 @@ import {
 } from "@/lib/receipts/file"
 import {
   RECEIPTS_BUCKET,
-  STATUS_ORDER,
   toReceipt,
   type DatabaseReceiptWithTags,
-  type Receipt,
   type ReceiptStatus,
 } from "@/lib/receipts/types"
 
@@ -23,36 +22,11 @@ import { queryKeys } from "./query-keys"
 const TABLE = "receipts"
 const SIGNED_URL_TTL = 60 * 60 // one hour — covers the time a tab stays open
 
-// Embed tags via the assignments join table; PostgREST returns
-// { receipt_tag_assignments: [{ receipt_tags: {...} }, ...] }
-const RECEIPT_WITH_TAGS_SELECT = `
-  *,
-  receipt_tag_assignments (
-    receipt_tags ( id, name, variant, created_by, created_at )
-  )
-`
-
 export function useReceipts() {
   const supabase = createClient()
   return useQuery({
     queryKey: queryKeys.receipts.all,
-    queryFn: async (): Promise<Receipt[]> => {
-      const { data, error } = await supabase
-        .from(TABLE)
-        .select(RECEIPT_WITH_TAGS_SELECT)
-        .order("created_at", { ascending: false })
-      if (error) {
-        console.error("[receipts] list query failed", error)
-        throw new Error(error.message || "讀取收據失敗")
-      }
-      return (data as unknown as DatabaseReceiptWithTags[])
-        .map(toReceipt)
-        .sort((a, b) => {
-          const byStatus = STATUS_ORDER[a.status] - STATUS_ORDER[b.status]
-          if (byStatus !== 0) return byStatus
-          return b.createdAt.localeCompare(a.createdAt)
-        })
-    },
+    queryFn: () => fetchReceipts(supabase),
     retry: 2,
   })
 }

--- a/apps/portal/hooks/trip/use-trips.ts
+++ b/apps/portal/hooks/trip/use-trips.ts
@@ -2,6 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 
+import { fetchTrips } from "@/lib/trip/fetch"
 import { createClient } from "@/lib/supabase/client"
 import type { Trip, TripStatus } from "@/lib/trip/types"
 
@@ -12,16 +13,7 @@ export function useTrips() {
 
   return useQuery({
     queryKey: queryKeys.trips.list(),
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("trips")
-        .select("*")
-        .order("status", { ascending: true }) // open first
-        .order("created_at", { ascending: false })
-
-      if (error) throw error
-      return (data ?? []) as Trip[]
-    },
+    queryFn: () => fetchTrips(supabase),
   })
 }
 

--- a/apps/portal/lib/bento/fetch.ts
+++ b/apps/portal/lib/bento/fetch.ts
@@ -1,0 +1,60 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import type { OrderWithStats } from "@/lib/bento/types"
+
+interface OrderItemRaw {
+  user_id: string | null
+  menu_items?: { name: string; price: number } | null
+}
+
+function computeOrderStats(orderItems: OrderItemRaw[]) {
+  const uniqueUsers = new Set(
+    orderItems.map((item) => item.user_id).filter(Boolean)
+  )
+
+  const menuItemCounts = new Map<string, { name: string; count: number }>()
+  let totalPrice = 0
+
+  for (const item of orderItems) {
+    const name = item.menu_items?.name
+    const price = parseFloat(String(item.menu_items?.price || 0))
+    totalPrice += price
+
+    if (name) {
+      const existing = menuItemCounts.get(name)
+      if (existing) {
+        existing.count += 1
+      } else {
+        menuItemCounts.set(name, { name, count: 1 })
+      }
+    }
+  }
+
+  return {
+    user_count: uniqueUsers.size,
+    menu_item_names: Array.from(menuItemCounts.keys()),
+    menu_items: Array.from(menuItemCounts.values()),
+    total_items: orderItems.length,
+    total_price: totalPrice,
+  }
+}
+
+// Shared by the client hook and the server prefetch — same query + queryKey
+// (orders.list) so the page hydrates with real rows from the HTML.
+export async function fetchOrders(
+  supabase: SupabaseClient
+): Promise<OrderWithStats[]> {
+  const { data, error } = await supabase
+    .from("bento_orders")
+    .select(
+      "*, restaurants:bento_menus(name, additional), order_items:bento_order_items(*, menu_items:bento_menu_items(name, price))"
+    )
+    .order("created_at", { ascending: false })
+
+  if (error) throw error
+
+  return (data || []).map((order) => ({
+    ...order,
+    stats: computeOrderStats((order.order_items || []) as OrderItemRaw[]),
+  })) as unknown as OrderWithStats[]
+}

--- a/apps/portal/lib/receipts/fetch.ts
+++ b/apps/portal/lib/receipts/fetch.ts
@@ -1,0 +1,39 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import {
+  STATUS_ORDER,
+  toReceipt,
+  type DatabaseReceiptWithTags,
+  type Receipt,
+} from "@/lib/receipts/types"
+
+// Embed tags via the assignments join table; PostgREST returns
+// { receipt_tag_assignments: [{ receipt_tags: {...} }, ...] }
+const RECEIPT_WITH_TAGS_SELECT = `
+  *,
+  receipt_tag_assignments (
+    receipt_tags ( id, name, variant, created_by, created_at )
+  )
+`
+
+// Shared by the client hook and the server prefetch — same query + same
+// queryKey (receipts.all) so the page hydrates with real rows from the HTML.
+export async function fetchReceipts(
+  supabase: SupabaseClient
+): Promise<Receipt[]> {
+  const { data, error } = await supabase
+    .from("receipts")
+    .select(RECEIPT_WITH_TAGS_SELECT)
+    .order("created_at", { ascending: false })
+  if (error) {
+    console.error("[receipts] list query failed", error)
+    throw new Error(error.message || "讀取收據失敗")
+  }
+  return (data as unknown as DatabaseReceiptWithTags[])
+    .map(toReceipt)
+    .sort((a, b) => {
+      const byStatus = STATUS_ORDER[a.status] - STATUS_ORDER[b.status]
+      if (byStatus !== 0) return byStatus
+      return b.createdAt.localeCompare(a.createdAt)
+    })
+}

--- a/apps/portal/lib/trip/fetch.ts
+++ b/apps/portal/lib/trip/fetch.ts
@@ -1,0 +1,17 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import type { Trip } from "@/lib/trip/types"
+
+// Shared by the client hook (browser client) and the server prefetch (server
+// client) — same query + same queryKey so the page hydrates with real rows
+// from the HTML instead of a post-hydration client fetch.
+export async function fetchTrips(supabase: SupabaseClient): Promise<Trip[]> {
+  const { data, error } = await supabase
+    .from("trips")
+    .select("*")
+    .order("status", { ascending: true }) // open first
+    .order("created_at", { ascending: false })
+
+  if (error) throw error
+  return (data ?? []) as Trip[]
+}


### PR DESCRIPTION
Closes #213

## Summary

推廣 #208 的 server prefetch pattern 到 `trip` / `receipts` / `bento`:
- 抽 `lib/<app>/fetch.ts` 的 `fetchX(supabase)` 給 server/client 共用同 query + queryKey
- 各 `page.tsx` server prefetch + `dehydrate` + `HydrationBoundary`
- 首屏資料隨 HTML,免 post-hydration client fetch round-trip

follow-up(本 PR 不含):`debt`/`approve`(user-scoped 多 query)、`meetings`(client page 需重構成 server)

## Test plan

- [x] `typecheck` 0 error
- [ ] 登入 hard-reload `/trip` `/receipts` `/bento` → 骨架→內容,無中間 client fetch 空窗