### PR TITLE
feat(gallery): World Cup seasonal theme

### DIFF
--- a/apps/gallery/.env.example
+++ b/apps/gallery/.env.example
@@ -11,5 +11,5 @@ SUPABASE_SECRET_KEY=
 GALLERY_API_SECRET=
 
 # Optional local preview when gallery_settings migration is not applied yet.
-# Ignored once the DB row exists (Manage toggle wins). Values: dragon-boat | off
-# GALLERY_SEASONAL_THEME=dragon-boat
+# Ignored once the DB row exists (Manage picker wins). Values: dragon-boat | world-cup | off
+# GALLERY_SEASONAL_THEME=world-cup

--- a/apps/gallery/app/auth/auth-code-error/page.tsx
+++ b/apps/gallery/app/auth/auth-code-error/page.tsx
@@ -7,11 +7,11 @@ import {
   gallerySectionLeadClass,
   gallerySectionTitleClass,
 } from "@/components/gallery-chrome"
-import { GalleryShell } from "@/components/gallery-shell"
+import { GalleryThemedShell } from "@/components/gallery-shell"
 
 export default function AuthCodeErrorPage() {
   return (
-    <GalleryShell>
+    <GalleryThemedShell>
       <div className="flex min-h-[50vh] flex-col justify-center">
         <div className={galleryPanelClass()}>
           <div className="mx-auto flex w-full max-w-md flex-col gap-6">
@@ -27,6 +27,6 @@ export default function AuthCodeErrorPage() {
           </div>
         </div>
       </div>
-    </GalleryShell>
+    </GalleryThemedShell>
   )
 }

--- a/apps/gallery/app/auth/login/page.tsx
+++ b/apps/gallery/app/auth/login/page.tsx
@@ -7,7 +7,7 @@ import {
   gallerySectionLeadClass,
   gallerySectionTitleClass,
 } from "@/components/gallery-chrome"
-import { GalleryShell } from "@/components/gallery-shell"
+import { GalleryThemedShell } from "@/components/gallery-shell"
 import { getCurrentUser } from "@/lib/user"
 
 type LoginPageProps = {
@@ -21,7 +21,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
   if (user) redirect(safeNext)
 
   return (
-    <GalleryShell>
+    <GalleryThemedShell>
       <AuthStateReset />
       <div className="flex min-h-[50vh] flex-col justify-center">
         <div className={galleryPanelClass()}>
@@ -41,6 +41,6 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
           </div>
         </div>
       </div>
-    </GalleryShell>
+    </GalleryThemedShell>
   )
 }

--- a/apps/gallery/app/gallery.css
+++ b/apps/gallery/app/gallery.css
@@ -163,7 +163,9 @@ html::-webkit-scrollbar {
 .gallery-header-seasonal,
 .gallery-header-seasonal-row,
 .gallery-header-waterline,
-.gallery-zongzi-field {
+.gallery-header-pitchline,
+.gallery-zongzi-field,
+.gallery-football-field {
   display: none;
 }
 
@@ -558,6 +560,370 @@ html[data-gallery-theme="dragon-boat"]
 html[data-gallery-theme="dragon-boat"] .gallery-footer::after {
   content: " · 端午安康";
   color: oklch(0.42 0.1 155);
+  font-style: normal;
+  font-weight: 500;
+}
+
+/* ── World Cup (世足) ─────────────────────────────────────────────────────── */
+
+html[data-gallery-theme="world-cup"],
+html[data-gallery-theme="world-cup"] body {
+  --gallery-header-height: calc(0.375rem + 1.75rem + 0.375rem + 0.625rem);
+  --gallery-content-gap: 1.25rem;
+  --background: oklch(0.955 0.055 142);
+  --foreground: oklch(0.24 0.06 145);
+  --card: oklch(0.978 0.04 142);
+  --card-foreground: oklch(0.24 0.06 145);
+  --muted: oklch(0.89 0.06 142);
+  --muted-foreground: oklch(0.42 0.08 145);
+  --accent: oklch(0.84 0.09 142);
+  --accent-foreground: oklch(0.26 0.07 145);
+  --border: oklch(0.78 0.07 142);
+  --input: oklch(0.78 0.07 142);
+  --primary: oklch(0.38 0.13 145);
+  --primary-foreground: oklch(0.98 0.01 142);
+}
+
+html[data-gallery-theme="world-cup"] .gallery-shell-nav-row {
+  align-items: flex-end;
+  padding-bottom: 0.125rem;
+}
+
+html[data-gallery-theme="world-cup"] .gallery-header-seasonal-row {
+  position: relative;
+  z-index: 0;
+  display: block;
+  overflow: hidden;
+  height: 1.35rem;
+  pointer-events: none;
+}
+
+html[data-gallery-theme="world-cup"] .gallery-seasonal-badge {
+  display: inline-flex;
+}
+
+html[data-gallery-theme="world-cup"] .gallery-football-field {
+  display: block;
+}
+
+html[data-gallery-theme="world-cup"] .gallery-football-pop {
+  position: fixed;
+  z-index: 1;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  transform: translate(-50%, -50%) rotate(var(--seed-rotate, 0deg));
+  opacity: 0;
+  filter: drop-shadow(0 5px 12px rgba(20, 90, 40, 0.28));
+  animation: gallery-football-pop-in 0.55s ease-out forwards;
+  animation-delay: var(--seed-delay, 0s);
+  transition:
+    transform 0.18s ease,
+    filter 0.18s ease;
+}
+
+html[data-gallery-theme="world-cup"] .gallery-football-pop:hover {
+  transform: translate(-50%, -50%) rotate(var(--seed-rotate, 0deg)) scale(1.08);
+  filter: drop-shadow(0 7px 16px rgba(20, 90, 40, 0.36));
+}
+
+html[data-gallery-theme="world-cup"]
+  .gallery-football-pop[data-kicking="true"] {
+  animation: gallery-football-kick 0.42s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  pointer-events: none;
+}
+
+html[data-gallery-theme="world-cup"] .gallery-football-pop-glyph {
+  display: block;
+  line-height: 1;
+  pointer-events: none;
+  user-select: none;
+}
+
+html[data-gallery-theme="world-cup"] .gallery-football-burst {
+  position: fixed;
+  z-index: 2;
+  transform: translate(-50%, -50%);
+}
+
+html[data-gallery-theme="world-cup"] .gallery-football-burst-particle {
+  position: absolute;
+  left: 0;
+  top: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  opacity: 0;
+  animation: gallery-football-burst-particle 0.65s ease-out forwards;
+  animation-delay: var(--delay, 0s);
+}
+
+@keyframes gallery-football-pop-in {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -50%) rotate(var(--seed-rotate, 0deg))
+      translateY(0.5rem) scale(0.75);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%) rotate(var(--seed-rotate, 0deg))
+      translateY(0) scale(1);
+  }
+}
+
+@keyframes gallery-football-kick {
+  0% {
+    opacity: 1;
+    transform: translate(-50%, -50%) rotate(var(--seed-rotate, 0deg)) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%)
+      translate(calc(var(--kick-tx, 0px)), calc(var(--kick-ty, 0px)))
+      rotate(calc(var(--seed-rotate, 0deg) + 540deg)) scale(0.55);
+  }
+}
+
+@keyframes gallery-football-burst-particle {
+  0% {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(calc(-50% + var(--tx)), calc(-50% + var(--ty)))
+      scale(0.35) rotate(180deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html[data-gallery-theme="world-cup"] .gallery-football-pop {
+    animation: gallery-football-pop-in 0.01s ease-out forwards;
+  }
+
+  html[data-gallery-theme="world-cup"] .gallery-football-burst-particle {
+    animation-duration: 0.01s;
+  }
+}
+
+@media (max-width: 767px) {
+  html[data-gallery-theme="world-cup"] .gallery-football-pop {
+    transform: translate(-50%, -50%) rotate(var(--seed-rotate, 0deg))
+      scale(0.92);
+  }
+
+  html[data-gallery-theme="world-cup"] .gallery-football-pop-glyph {
+    font-size: 1.75rem !important;
+  }
+}
+
+html[data-gallery-theme="world-cup"] .gallery-header-seasonal {
+  display: block;
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+html[data-gallery-theme="world-cup"] .gallery-header-fleet {
+  position: absolute;
+  bottom: 0;
+  left: 100%;
+  will-change: left, transform;
+  animation: gallery-fleet-sail 18s linear infinite;
+}
+
+html[data-gallery-theme="world-cup"] .gallery-header-fleet--world-cup span {
+  animation: gallery-football-bounce 2.8s ease-in-out infinite;
+}
+
+html[data-gallery-theme="world-cup"]
+  .gallery-header-fleet--world-cup
+  span:nth-child(2) {
+  animation-delay: 0.2s;
+}
+html[data-gallery-theme="world-cup"]
+  .gallery-header-fleet--world-cup
+  span:nth-child(3) {
+  animation-delay: 0.45s;
+}
+html[data-gallery-theme="world-cup"]
+  .gallery-header-fleet--world-cup
+  span:nth-child(4) {
+  animation-delay: 0.2s;
+}
+
+@keyframes gallery-football-bounce {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-3px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html[data-gallery-theme="world-cup"] .gallery-header-fleet {
+    animation: none;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  html[data-gallery-theme="world-cup"] .gallery-header-fleet--world-cup span {
+    animation: none;
+  }
+}
+
+html[data-gallery-theme="world-cup"] .gallery-shell-header::before {
+  content: none;
+}
+
+html[data-gallery-theme="world-cup"] .gallery-shell-header {
+  border-bottom-color: transparent;
+}
+
+html[data-gallery-theme="world-cup"] .gallery-header-pitchline {
+  display: block;
+  position: relative;
+  z-index: 0;
+  width: 100%;
+  height: 0.625rem;
+  overflow: hidden;
+  line-height: 0;
+}
+
+html[data-gallery-theme="world-cup"] .gallery-header-pitch-track {
+  display: flex;
+  width: max-content;
+  height: 100%;
+  will-change: transform;
+  animation: gallery-pitch-scroll 2.2s linear infinite;
+}
+
+html[data-gallery-theme="world-cup"] .gallery-header-pitch-tile {
+  display: block;
+  flex: 0 0 14px;
+  width: 14px;
+  height: 100%;
+}
+
+@keyframes gallery-pitch-scroll {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+  to {
+    transform: translate3d(-14px, 0, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html[data-gallery-theme="world-cup"] .gallery-header-pitch-track {
+    animation: none;
+  }
+}
+
+html[data-gallery-theme="world-cup"] .gallery-pagination a {
+  border-color: rgba(34, 120, 55, 0.38);
+  background: color-mix(in oklch, var(--background) 90%, transparent);
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease,
+    color 0.2s ease;
+}
+
+html[data-gallery-theme="world-cup"] .gallery-pagination a:hover {
+  border-color: rgba(250, 204, 21, 0.55);
+  background: color-mix(in oklch, var(--accent) 70%, var(--background));
+  color: var(--foreground);
+}
+
+html[data-gallery-theme="world-cup"]
+  .gallery-pagination
+  a[aria-current="page"] {
+  border-color: rgba(34, 120, 55, 0.62);
+  background: color-mix(in oklch, var(--primary) 14%, var(--background));
+  color: var(--foreground);
+}
+
+html[data-gallery-theme="world-cup"] .gallery-panel {
+  border-color: rgba(34, 120, 55, 0.3);
+  background: color-mix(in oklch, var(--card) 78%, transparent);
+  box-shadow:
+    0 1px 2px rgba(34, 120, 55, 0.1),
+    0 8px 24px -16px rgba(34, 120, 55, 0.22);
+}
+
+html[data-gallery-theme="world-cup"] .gallery-lightbox::before {
+  content: "";
+  position: fixed;
+  inset-inline: 0;
+  top: 0;
+  z-index: 110;
+  height: 3px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.75) 18%,
+    rgba(250, 204, 21, 0.85) 50%,
+    rgba(255, 255, 255, 0.75) 82%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+
+html[data-gallery-theme="world-cup"] .gallery-page-backdrop {
+  background:
+    radial-gradient(
+      ellipse 90% 60% at 50% -12%,
+      rgba(34, 130, 60, 0.28),
+      transparent 55%
+    ),
+    radial-gradient(
+      ellipse 60% 50% at 100% 100%,
+      rgba(250, 204, 21, 0.18),
+      transparent 50%
+    ),
+    radial-gradient(
+      ellipse 50% 40% at 0% 90%,
+      rgba(255, 255, 255, 0.2),
+      transparent 45%
+    ) !important;
+}
+
+html[data-gallery-theme="world-cup"] .gallery-seasonal-decor {
+  background: linear-gradient(
+    to top,
+    rgba(28, 100, 48, 0.2) 0%,
+    rgba(28, 100, 48, 0.07) 16%,
+    transparent 34%
+  );
+  mask-image: linear-gradient(to bottom, black 0%, black 70%, transparent 100%);
+}
+
+html[data-gallery-theme="world-cup"] .gallery-polaroid {
+  border-color: rgba(34, 120, 55, 0.32);
+  box-shadow:
+    0 1px 2px rgba(34, 120, 55, 0.12),
+    0 12px 32px -14px rgba(34, 120, 55, 0.34);
+}
+
+html[data-gallery-theme="world-cup"] .gallery-polaroid-caption {
+  background: oklch(0.985 0.018 142);
+}
+
+html[data-gallery-theme="world-cup"] .group\/polaroid:hover .gallery-polaroid {
+  box-shadow:
+    0 2px 4px rgba(34, 120, 55, 0.14),
+    0 18px 40px -12px rgba(34, 120, 55, 0.38);
+}
+
+html[data-gallery-theme="world-cup"] .gallery-footer::after {
+  content: " · 世足加油 ⚽";
+  color: oklch(0.4 0.11 145);
   font-style: normal;
   font-weight: 500;
 }

--- a/apps/gallery/app/page.tsx
+++ b/apps/gallery/app/page.tsx
@@ -1,6 +1,6 @@
 import { GalleryGrid } from "@/app/_components/gallery-grid"
 import { GalleryPagination } from "@/app/_components/gallery-pagination"
-import { GalleryShell } from "@/components/gallery-shell"
+import { GalleryThemedShell } from "@/components/gallery-shell"
 import { loadGalleryHomePage } from "@/lib/gallery/load-home-page"
 import { createClient } from "@/lib/supabase/server"
 import { getCurrentUser } from "@/lib/user"
@@ -27,7 +27,7 @@ export default async function GalleryHomePage({
     })
 
   return (
-    <GalleryShell active="home" signedIn={Boolean(user)}>
+    <GalleryThemedShell active="home" signedIn={Boolean(user)}>
       <div className="overflow-x-clip">
         <GalleryGrid
           images={images}
@@ -38,6 +38,6 @@ export default async function GalleryHomePage({
         />
         <GalleryPagination page={currentPage} totalPages={totalPages} />
       </div>
-    </GalleryShell>
+    </GalleryThemedShell>
   )
 }

--- a/apps/gallery/app/upload/_components/seasonal-theme-panel.tsx
+++ b/apps/gallery/app/upload/_components/seasonal-theme-panel.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useTransition } from "react"
 
-import { Switch } from "@workspace/ui/components/switch"
 import { cn } from "@workspace/ui/lib/utils"
 import { toast } from "sonner"
 
@@ -14,9 +13,20 @@ import {
   gallerySectionTitleClass,
 } from "@/components/gallery-chrome"
 import {
+  GALLERY_SEASONAL_THEME_IDS,
   GALLERY_SEASONAL_THEMES,
   type GallerySeasonalThemeId,
 } from "@/lib/gallery/seasonal-themes"
+
+type ThemeChoice = GallerySeasonalThemeId | "off"
+
+const THEME_OPTIONS: Array<{ value: ThemeChoice; label: string }> = [
+  { value: "off", label: "Off" },
+  ...GALLERY_SEASONAL_THEME_IDS.map((id) => ({
+    value: id,
+    label: GALLERY_SEASONAL_THEMES[id].label,
+  })),
+]
 
 export function SeasonalThemePanel({
   activeThemeId,
@@ -25,68 +35,85 @@ export function SeasonalThemePanel({
   activeThemeId: GallerySeasonalThemeId | null
   settingsReady?: boolean
 }) {
-  const theme = GALLERY_SEASONAL_THEMES["dragon-boat"]
-  const [enabled, setEnabled] = useState(activeThemeId === theme.id)
+  const [selected, setSelected] = useState<ThemeChoice>(activeThemeId ?? "off")
   const [isPending, startTransition] = useTransition()
 
-  const onToggle = (next: boolean) => {
-    setEnabled(next)
+  const onSelect = (next: ThemeChoice) => {
+    const previous = selected
+    setSelected(next)
     startTransition(async () => {
-      const result = await setGallerySeasonalTheme(next ? theme.id : null)
+      const themeId = next === "off" ? null : next
+      const result = await setGallerySeasonalTheme(themeId)
       if (!result.ok) {
-        setEnabled(!next)
+        setSelected(previous)
         toast.error(result.error)
         return
       }
-      toast.success(
-        next ? `${theme.label} theme is on.` : "Seasonal theme off."
-      )
+      if (themeId) {
+        toast.success(`${GALLERY_SEASONAL_THEMES[themeId].label} theme is on.`)
+      } else {
+        toast.success("Seasonal theme off.")
+      }
     })
   }
 
   return (
     <section className={galleryPanelClass()}>
-      <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0 space-y-1">
-          <h2
-            className={cn(gallerySectionTitleClass(), "text-2xl sm:text-3xl")}
-          >
-            Site theme
-          </h2>
-          <p className={gallerySectionLeadClass()}>
-            Toggle a limited-time look for everyone visiting the gallery wall.
-          </p>
-        </div>
-        <Switch
-          checked={enabled}
-          disabled={isPending}
-          onCheckedChange={onToggle}
-          aria-label={`${theme.label} theme`}
-        />
+      <div className="space-y-1">
+        <h2 className={cn(gallerySectionTitleClass(), "text-2xl sm:text-3xl")}>
+          Site theme
+        </h2>
+        <p className={gallerySectionLeadClass()}>
+          Pick a limited-time look for everyone visiting the gallery wall.
+        </p>
       </div>
+
       <div
         className={cn(
           gallerySans(),
-          "mt-4 rounded-xl border border-border/60 bg-muted/30 px-4 py-3"
+          "mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap"
         )}
+        role="radiogroup"
+        aria-label="Seasonal site theme"
       >
-        <p className="text-sm font-medium text-foreground">{theme.label}</p>
-        <p className="mt-0.5 text-xs text-muted-foreground">
-          {theme.description}
-        </p>
-        {!settingsReady ? (
-          <p className="mt-2 text-xs text-amber-800 dark:text-amber-200">
-            Database settings not ready — apply{" "}
-            <code className="text-[10px]">2026-06-12-gallery-settings.sql</code>
-            , or set{" "}
-            <code className="text-[10px]">
-              GALLERY_SEASONAL_THEME=dragon-boat
-            </code>{" "}
-            in <code className="text-[10px]">.env.local</code> for local
-            preview.
-          </p>
-        ) : null}
+        {THEME_OPTIONS.map((option) => {
+          const checked = selected === option.value
+
+          return (
+            <button
+              key={option.value}
+              type="button"
+              role="radio"
+              aria-checked={checked}
+              disabled={isPending}
+              onClick={() => onSelect(option.value)}
+              className={cn(
+                "min-w-[8.5rem] flex-1 rounded-xl border px-4 py-3 text-left transition-colors",
+                checked
+                  ? "border-foreground/25 bg-foreground/[0.07] text-foreground"
+                  : "border-border/60 bg-muted/20 text-muted-foreground hover:border-foreground/15 hover:bg-muted/40 hover:text-foreground"
+              )}
+            >
+              <span className="text-sm font-medium">{option.label}</span>
+            </button>
+          )
+        })}
       </div>
+
+      {!settingsReady ? (
+        <p
+          className={cn(
+            gallerySans(),
+            "mt-3 text-xs text-amber-800 dark:text-amber-200"
+          )}
+        >
+          Database settings not ready — apply{" "}
+          <code className="text-[10px]">2026-06-12-gallery-settings.sql</code>,
+          or set{" "}
+          <code className="text-[10px]">GALLERY_SEASONAL_THEME=world-cup</code>{" "}
+          in <code className="text-[10px]">.env.local</code> for local preview.
+        </p>
+      ) : null}
     </section>
   )
 }

--- a/apps/gallery/app/upload/page.tsx
+++ b/apps/gallery/app/upload/page.tsx
@@ -11,7 +11,7 @@ import {
   gallerySectionLeadClass,
   gallerySectionTitleClass,
 } from "@/components/gallery-chrome"
-import { GalleryShell } from "@/components/gallery-shell"
+import { GalleryThemedShell } from "@/components/gallery-shell"
 import { createClient } from "@/lib/supabase/server"
 import type { GalleryImage } from "@/lib/gallery/types"
 import {
@@ -57,7 +57,7 @@ export default async function UploadPage() {
   >
 
   return (
-    <GalleryShell active="manage" signedIn containerClassName="max-w-3xl">
+    <GalleryThemedShell active="manage" signedIn containerClassName="max-w-3xl">
       <div className="flex flex-col gap-10 sm:gap-12">
         <header>
           <h1 className={gallerySectionTitleClass()}>Manage</h1>
@@ -147,6 +147,6 @@ export default async function UploadPage() {
           )}
         </section>
       </div>
-    </GalleryShell>
+    </GalleryThemedShell>
   )
 }

--- a/apps/gallery/components/gallery-football-seeds.tsx
+++ b/apps/gallery/components/gallery-football-seeds.tsx
@@ -1,0 +1,175 @@
+"use client"
+
+import type { CSSProperties, MouseEvent } from "react"
+import { useCallback, useEffect, useState } from "react"
+
+import {
+  FOOTBALL_RESPAWN_MS,
+  footballSpotKey,
+  makeFootballKickParticles,
+  makeFootballKickVector,
+  pickPoppableFootballCount,
+  pickPoppableFootballs,
+  spawnPoppableFootball,
+  type FootballKickVector,
+  type PoppableFootballSpec,
+} from "@/lib/gallery/football-seeds"
+
+const MOBILE_MQ = "(max-width: 767px)"
+
+function useMobileFootballLayout() {
+  const [isMobile, setIsMobile] = useState(false)
+
+  useEffect(() => {
+    const media = window.matchMedia(MOBILE_MQ)
+    const sync = () => setIsMobile(media.matches)
+    sync()
+    media.addEventListener("change", sync)
+    return () => media.removeEventListener("change", sync)
+  }, [])
+
+  return isMobile
+}
+
+type ActiveKickBurst = {
+  id: string
+  x: number
+  y: number
+  particles: ReturnType<typeof makeFootballKickParticles>
+}
+
+function FootballKickBurst({ burst }: { burst: ActiveKickBurst }) {
+  return (
+    <div
+      className="gallery-football-burst pointer-events-none"
+      style={{ left: burst.x, top: burst.y }}
+      aria-hidden
+    >
+      {burst.particles.map((particle, index) => (
+        <span
+          key={`${burst.id}-${index}`}
+          className="gallery-football-burst-particle"
+          style={
+            {
+              "--tx": `${particle.tx}px`,
+              "--ty": `${particle.ty}px`,
+              "--delay": `${particle.delay}s`,
+              fontSize: particle.size,
+            } as CSSProperties
+          }
+        >
+          ⚽
+        </span>
+      ))}
+    </div>
+  )
+}
+
+export function GalleryFootballSeeds() {
+  const isMobile = useMobileFootballLayout()
+  const [balls, setBalls] = useState<PoppableFootballSpec[]>([])
+  const [bursts, setBursts] = useState<ActiveKickBurst[]>([])
+  const [kickingIds, setKickingIds] = useState<Set<string>>(() => new Set())
+  const [kickVectors, setKickVectors] = useState<
+    Record<string, FootballKickVector>
+  >({})
+
+  useEffect(() => {
+    setBalls(
+      pickPoppableFootballs(pickPoppableFootballCount(), Math.random, isMobile)
+    )
+  }, [isMobile])
+
+  const removeBurst = useCallback((id: string) => {
+    setBursts((current) => current.filter((burst) => burst.id !== id))
+  }, [])
+
+  const respawnFootball = useCallback(
+    (removedId: string) => {
+      setBalls((current) => {
+        const remaining = current.filter((item) => item.id !== removedId)
+        const occupied = new Set(remaining.map(footballSpotKey))
+        const next = spawnPoppableFootball(
+          occupied,
+          Math.random,
+          undefined,
+          isMobile
+        )
+        return next ? [...remaining, next] : remaining
+      })
+      setKickingIds((current) => {
+        const next = new Set(current)
+        next.delete(removedId)
+        return next
+      })
+      setKickVectors((current) => {
+        const next = { ...current }
+        delete next[removedId]
+        return next
+      })
+    },
+    [isMobile]
+  )
+
+  const kickFootball = useCallback(
+    (event: MouseEvent<HTMLButtonElement>, id: string) => {
+      if (kickingIds.has(id)) return
+
+      const rect = event.currentTarget.getBoundingClientRect()
+      const kick = makeFootballKickVector()
+      const burstId = `${id}-burst-${Date.now()}`
+      const burst: ActiveKickBurst = {
+        id: burstId,
+        x: rect.left + rect.width / 2,
+        y: rect.top + rect.height / 2,
+        particles: makeFootballKickParticles(),
+      }
+
+      setKickVectors((current) => ({ ...current, [id]: kick }))
+      setKickingIds((current) => new Set(current).add(id))
+      setBursts((current) => [...current, burst])
+      window.setTimeout(() => removeBurst(burstId), 680)
+      window.setTimeout(() => respawnFootball(id), FOOTBALL_RESPAWN_MS)
+    },
+    [kickingIds, removeBurst, respawnFootball]
+  )
+
+  return (
+    <div className="gallery-football-field pointer-events-none fixed inset-0 z-[35]">
+      {balls.map((seed) => {
+        const kick = kickVectors[seed.id]
+        return (
+          <button
+            key={seed.id}
+            type="button"
+            aria-label="Kick the football"
+            className="gallery-football-pop pointer-events-auto"
+            style={
+              {
+                left: seed.left,
+                top: seed.top,
+                "--seed-rotate": `${seed.rotate}deg`,
+                "--seed-delay": `${seed.delay}s`,
+                "--kick-tx": kick ? `${kick.tx}px` : "0px",
+                "--kick-ty": kick ? `${kick.ty}px` : "0px",
+              } as CSSProperties
+            }
+            data-kicking={kickingIds.has(seed.id) ? "true" : undefined}
+            onClick={(event) => kickFootball(event, seed.id)}
+          >
+            <span
+              className="gallery-football-pop-glyph"
+              aria-hidden
+              style={{ fontSize: seed.size * 0.9 }}
+            >
+              ⚽
+            </span>
+          </button>
+        )
+      })}
+      {bursts.map((burst) => (
+        <FootballKickBurst key={burst.id} burst={burst} />
+      ))}
+    </div>
+  )
+}

--- a/apps/gallery/components/gallery-header-pitchline.tsx
+++ b/apps/gallery/components/gallery-header-pitchline.tsx
@@ -1,0 +1,41 @@
+const VIEW_HEIGHT = 10
+/** Fixed px per tile — matches waterline tile rhythm. */
+const TILE_PX = 14
+const TILE_COUNT = 160
+
+function PitchTile() {
+  return (
+    <svg
+      aria-hidden
+      width={TILE_PX}
+      height={VIEW_HEIGHT}
+      viewBox={`0 0 ${TILE_PX} ${VIEW_HEIGHT}`}
+      preserveAspectRatio="none"
+      className="gallery-header-pitch-tile"
+    >
+      <line
+        x1="0"
+        y1="5"
+        x2={TILE_PX}
+        y2="5"
+        stroke="rgba(34, 140, 62, 0.92)"
+        strokeWidth="1.1"
+        strokeLinecap="round"
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  )
+}
+
+/** Single turf line — same pattern as the dragon-boat waterline (stroke only, no fill band). */
+export function GalleryHeaderPitchline() {
+  return (
+    <div className="gallery-header-pitchline" aria-hidden>
+      <div className="gallery-header-pitch-track">
+        {Array.from({ length: TILE_COUNT }, (_, index) => (
+          <PitchTile key={index} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/gallery/components/gallery-header-seasonal.tsx
+++ b/apps/gallery/components/gallery-header-seasonal.tsx
@@ -1,30 +1,65 @@
 import { cn } from "@workspace/ui/lib/utils"
 
 import { gallerySans } from "@/components/gallery-chrome"
-import { DRAGON_BOAT_FLEET } from "@/lib/gallery/seasonal-stickers"
+import {
+  DRAGON_BOAT_FLEET,
+  WORLD_CUP_HEADER_GLYPHS,
+} from "@/lib/gallery/seasonal-stickers"
+import type { GallerySeasonalThemeId } from "@/lib/gallery/seasonal-themes"
 
-export function GalleryHeaderSeasonal() {
+function SeasonalGlyphFleet({
+  glyphs,
+  className,
+}: {
+  glyphs: readonly string[]
+  className?: string
+}) {
+  return (
+    <div
+      className={cn(
+        "gallery-header-fleet flex items-end gap-0.5 sm:gap-1",
+        className
+      )}
+    >
+      {glyphs.map((glyph, i) => (
+        <span
+          key={`${glyph}-${i}`}
+          className={cn(
+            "leading-none drop-shadow-sm select-none",
+            i === 2 ? "text-lg sm:text-xl" : "text-sm opacity-90 sm:text-base"
+          )}
+        >
+          {glyph}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+export function GalleryHeaderSeasonal({
+  themeId,
+}: {
+  themeId: GallerySeasonalThemeId | null
+}) {
+  if (!themeId) return null
+
   return (
     <div
       className={cn(
         gallerySans(),
-        "gallery-header-seasonal pointer-events-none"
+        "gallery-header-seasonal pointer-events-none",
+        themeId === "world-cup" && "gallery-header-seasonal--world-cup"
       )}
       aria-hidden
     >
-      <div className="gallery-header-fleet flex items-end gap-0.5 sm:gap-1">
-        {DRAGON_BOAT_FLEET.map((glyph, i) => (
-          <span
-            key={`${glyph}-${i}`}
-            className={cn(
-              "leading-none drop-shadow-sm select-none",
-              i === 2 ? "text-lg sm:text-xl" : "text-sm opacity-90 sm:text-base"
-            )}
-          >
-            {glyph}
-          </span>
-        ))}
-      </div>
+      {themeId === "dragon-boat" ? (
+        <SeasonalGlyphFleet glyphs={DRAGON_BOAT_FLEET} />
+      ) : (
+        <SeasonalGlyphFleet
+          glyphs={WORLD_CUP_HEADER_GLYPHS}
+          className="gallery-header-fleet--world-cup"
+        />
+      )}
     </div>
   )
 }

--- a/apps/gallery/components/gallery-shell.tsx
+++ b/apps/gallery/components/gallery-shell.tsx
@@ -3,6 +3,8 @@ import Link from "next/link"
 
 import { cn } from "@workspace/ui/lib/utils"
 
+import { GalleryFootballSeeds } from "@/components/gallery-football-seeds"
+import { GalleryHeaderPitchline } from "@/components/gallery-header-pitchline"
 import { GalleryHeaderSeasonal } from "@/components/gallery-header-seasonal"
 import { GalleryHeaderWaterline } from "@/components/gallery-header-waterline"
 import { GalleryZongziSeeds } from "@/components/gallery-zongzi-seeds"
@@ -16,6 +18,12 @@ import {
   GalleryShellNav,
   type GalleryShellActive,
 } from "@/components/gallery-shell-nav"
+import {
+  GALLERY_SEASONAL_THEMES,
+  type GallerySeasonalThemeId,
+} from "@/lib/gallery/seasonal-themes"
+import { getGallerySeasonalThemeId } from "@/lib/gallery/settings"
+import { createClient } from "@/lib/supabase/server"
 
 export type { GalleryShellActive } from "@/components/gallery-shell-nav"
 
@@ -23,13 +31,19 @@ export function GalleryShell({
   children,
   active = "home",
   signedIn = false,
+  seasonalThemeId = null,
   containerClassName,
 }: {
   children: ReactNode
   active?: GalleryShellActive
   signedIn?: boolean
+  seasonalThemeId?: GallerySeasonalThemeId | null
   containerClassName?: string
 }) {
+  const theme = seasonalThemeId
+    ? GALLERY_SEASONAL_THEMES[seasonalThemeId]
+    : null
+
   return (
     <div className="relative min-h-dvh bg-background text-foreground">
       <div className={galleryPageBackdropClass()} aria-hidden />
@@ -48,23 +62,30 @@ export function GalleryShell({
               )}
             >
               Gallery
-              <span
-                className={cn(
-                  gallerySans(),
-                  "gallery-seasonal-badge shrink-0 rounded-full border border-emerald-700/25 bg-emerald-600/10 px-1.5 py-0.5 text-[9px] tracking-wide text-emerald-800 uppercase not-italic sm:px-2 sm:text-[10px]"
-                )}
-                aria-hidden
-              >
-                端午
-              </span>
+              {theme ? (
+                <span
+                  className={cn(
+                    gallerySans(),
+                    "gallery-seasonal-badge shrink-0 rounded-full border px-1.5 py-0.5 text-[9px] tracking-wide uppercase not-italic sm:px-2 sm:text-[10px]",
+                    seasonalThemeId === "dragon-boat" &&
+                      "border-emerald-700/25 bg-emerald-600/10 text-emerald-800",
+                    seasonalThemeId === "world-cup" &&
+                      "border-lime-800/25 bg-lime-600/12 text-lime-950"
+                  )}
+                  aria-hidden
+                >
+                  {theme.badge}
+                </span>
+              ) : null}
             </Link>
             <div className="gallery-header-seasonal-row min-w-0 flex-1 overflow-hidden">
-              <GalleryHeaderSeasonal />
+              <GalleryHeaderSeasonal themeId={seasonalThemeId} />
             </div>
             <GalleryShellNav active={active} signedIn={signedIn} />
           </div>
         </div>
-        <GalleryHeaderWaterline />
+        {seasonalThemeId === "dragon-boat" ? <GalleryHeaderWaterline /> : null}
+        {seasonalThemeId === "world-cup" ? <GalleryHeaderPitchline /> : null}
       </header>
       <main
         className={cn(
@@ -77,7 +98,34 @@ export function GalleryShell({
           <GalleryFooter />
         </div>
       </main>
-      <GalleryZongziSeeds />
+      {seasonalThemeId === "dragon-boat" ? <GalleryZongziSeeds /> : null}
+      {seasonalThemeId === "world-cup" ? <GalleryFootballSeeds /> : null}
     </div>
+  )
+}
+
+export async function GalleryThemedShell({
+  children,
+  active = "home",
+  signedIn = false,
+  containerClassName,
+}: {
+  children: ReactNode
+  active?: GalleryShellActive
+  signedIn?: boolean
+  containerClassName?: string
+}) {
+  const supabase = await createClient()
+  const seasonalThemeId = await getGallerySeasonalThemeId(supabase)
+
+  return (
+    <GalleryShell
+      active={active}
+      signedIn={signedIn}
+      seasonalThemeId={seasonalThemeId}
+      containerClassName={containerClassName}
+    >
+      {children}
+    </GalleryShell>
   )
 }

--- a/apps/gallery/lib/gallery/football-seeds.test.ts
+++ b/apps/gallery/lib/gallery/football-seeds.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  makeFootballKickParticles,
+  makeFootballKickVector,
+  pickPoppableFootballs,
+  pickPoppableFootballCount,
+  spawnPoppableFootball,
+  footballSpotKey,
+} from "@/lib/gallery/football-seeds"
+import { POPPABLE_ZONGZI_SPOTS } from "@/lib/gallery/zongzi-seeds"
+
+describe("pickPoppableFootballs", () => {
+  test("count is always 2 or 3", () => {
+    for (let i = 0; i < 20; i += 1) {
+      const count = pickPoppableFootballCount()
+      expect(count === 2 || count === 3).toBe(true)
+    }
+  })
+
+  test("returns unique spots", () => {
+    const seeds = pickPoppableFootballs(3, () => 0.99)
+    expect(seeds).toHaveLength(3)
+    expect(new Set(seeds.map(footballSpotKey)).size).toBe(3)
+  })
+
+  test("never returns more than the pool size", () => {
+    expect(pickPoppableFootballs(99)).toHaveLength(POPPABLE_ZONGZI_SPOTS.length)
+  })
+})
+
+describe("spawnPoppableFootball", () => {
+  test("avoids occupied spots", () => {
+    const occupied = new Set([footballSpotKey(POPPABLE_ZONGZI_SPOTS[0]!)])
+    const next = spawnPoppableFootball(occupied, () => 0)
+    expect(next).not.toBeNull()
+    expect(occupied.has(footballSpotKey(next!))).toBe(false)
+  })
+
+  test("returns null when every spot is taken", () => {
+    const occupied = new Set(POPPABLE_ZONGZI_SPOTS.map(footballSpotKey))
+    expect(spawnPoppableFootball(occupied)).toBeNull()
+  })
+})
+
+describe("makeFootballKickVector", () => {
+  test("returns non-zero displacement", () => {
+    const kick = makeFootballKickVector(() => 0.25)
+    expect(Math.abs(kick.tx) + Math.abs(kick.ty)).toBeGreaterThan(0)
+  })
+})
+
+describe("makeFootballKickParticles", () => {
+  test("returns emoji-only particles", () => {
+    const particles = makeFootballKickParticles(6)
+    expect(particles).toHaveLength(6)
+    expect(particles.every((particle) => particle.glyph === "emoji")).toBe(true)
+  })
+})

--- a/apps/gallery/lib/gallery/football-seeds.ts
+++ b/apps/gallery/lib/gallery/football-seeds.ts
@@ -1,0 +1,69 @@
+import {
+  makeZongziBurstParticles,
+  pickPoppableZongzi,
+  pickPoppableZongziCount,
+  spawnPoppableZongzi,
+  zongziSpotKey,
+  type PoppableZongziSpec,
+} from "@/lib/gallery/zongzi-seeds"
+
+export const FOOTBALL_RESPAWN_MS = 1500
+
+export type PoppableFootballSpec = PoppableZongziSpec
+
+export type FootballKickVector = {
+  tx: number
+  ty: number
+}
+
+export function footballSpotKey(spot: { left: string; top: string }) {
+  return zongziSpotKey(spot)
+}
+
+export function pickPoppableFootballCount(random: () => number = Math.random) {
+  return pickPoppableZongziCount(random)
+}
+
+export function pickPoppableFootballs(
+  count: number,
+  random: () => number = Math.random,
+  isMobile = false
+): PoppableFootballSpec[] {
+  return pickPoppableZongzi(count, random, isMobile).map((seed, index) => ({
+    ...seed,
+    id: `football-${index}-${seed.left}-${seed.top}`,
+  }))
+}
+
+export function spawnPoppableFootball(
+  occupied: ReadonlySet<string>,
+  random: () => number = Math.random,
+  idSuffix = `${Date.now()}-${Math.floor(random() * 1_000_000)}`,
+  isMobile = false
+): PoppableFootballSpec | null {
+  const next = spawnPoppableZongzi(occupied, random, idSuffix, isMobile)
+  if (!next) return null
+  return { ...next, id: `football-${idSuffix}` }
+}
+
+export function makeFootballKickVector(
+  random: () => number = Math.random
+): FootballKickVector {
+  const angle = random() * Math.PI * 2
+  const distance = 72 + random() * 88
+  return {
+    tx: Math.cos(angle) * distance,
+    ty: Math.sin(angle) * distance,
+  }
+}
+
+/** Reuse burst layout for confetti-style ⚽ scatter on kick. */
+export function makeFootballKickParticles(
+  count = 8,
+  random: () => number = Math.random
+) {
+  return makeZongziBurstParticles(count, random).map((particle) => ({
+    ...particle,
+    glyph: "emoji" as const,
+  }))
+}

--- a/apps/gallery/lib/gallery/seasonal-stickers.ts
+++ b/apps/gallery/lib/gallery/seasonal-stickers.ts
@@ -1,2 +1,5 @@
 /** Dragon boat fleet shown in the header when the seasonal theme is on. */
 export const DRAGON_BOAT_FLEET = ["🐲", "🛶", "🚣", "🛶", "🐲"] as const
+
+/** Rolling footballs across the header lane for World Cup theme. */
+export const WORLD_CUP_HEADER_GLYPHS = ["⚽", "⚽", "🥅", "⚽", "⚽"] as const

--- a/apps/gallery/lib/gallery/seasonal-themes.test.ts
+++ b/apps/gallery/lib/gallery/seasonal-themes.test.ts
@@ -11,6 +11,10 @@ describe("isGallerySeasonalThemeId", () => {
     expect(isGallerySeasonalThemeId("dragon-boat")).toBe(true)
   })
 
+  test("accepts world-cup", () => {
+    expect(isGallerySeasonalThemeId("world-cup")).toBe(true)
+  })
+
   test("rejects unknown ids", () => {
     expect(isGallerySeasonalThemeId("christmas")).toBe(false)
     expect(isGallerySeasonalThemeId(null)).toBe(false)
@@ -26,6 +30,7 @@ describe("parseSeasonalThemeSetting", () => {
 
   test("returns theme id when valid", () => {
     expect(parseSeasonalThemeSetting({ id: "dragon-boat" })).toBe("dragon-boat")
+    expect(parseSeasonalThemeSetting({ id: "world-cup" })).toBe("world-cup")
   })
 
   test("returns null for invalid id", () => {
@@ -37,6 +42,12 @@ describe("getSeasonalThemeEnvOverride", () => {
   test("reads dragon-boat from env", () => {
     process.env.GALLERY_SEASONAL_THEME = "dragon-boat"
     expect(getSeasonalThemeEnvOverride()).toBe("dragon-boat")
+    delete process.env.GALLERY_SEASONAL_THEME
+  })
+
+  test("reads world-cup from env", () => {
+    process.env.GALLERY_SEASONAL_THEME = "world-cup"
+    expect(getSeasonalThemeEnvOverride()).toBe("world-cup")
     delete process.env.GALLERY_SEASONAL_THEME
   })
 

--- a/apps/gallery/lib/gallery/seasonal-themes.ts
+++ b/apps/gallery/lib/gallery/seasonal-themes.ts
@@ -1,10 +1,11 @@
 export const GALLERY_SEASONAL_THEME_KEY = "seasonal_theme" as const
 
-export type GallerySeasonalThemeId = "dragon-boat"
+export type GallerySeasonalThemeId = "dragon-boat" | "world-cup"
 
 export type GallerySeasonalTheme = {
   id: GallerySeasonalThemeId
   label: string
+  badge: string
   description: string
 }
 
@@ -15,10 +16,22 @@ export const GALLERY_SEASONAL_THEMES: Record<
   "dragon-boat": {
     id: "dragon-boat",
     label: "Dragon Boat Festival",
+    badge: "端午",
     description:
-      "Dragon boat header, green wash, pagination and manage panels, lightbox stripe, and waterline.",
+      "Dragon boat header, green wash, waterline, zongzi easter egg, and 端午安康 footer.",
+  },
+  "world-cup": {
+    id: "world-cup",
+    label: "World Cup",
+    badge: "世足",
+    description:
+      "Pitch-green palette, rolling football header, turf stripe, kickable ⚽ easter egg, and 加油 footer.",
   },
 }
+
+export const GALLERY_SEASONAL_THEME_IDS = Object.keys(
+  GALLERY_SEASONAL_THEMES
+) as GallerySeasonalThemeId[]
 
 export function isGallerySeasonalThemeId(
   value: unknown

--- a/apps/gallery/next.config.mjs
+++ b/apps/gallery/next.config.mjs
@@ -1,6 +1,17 @@
+import path from "path"
+import { fileURLToPath } from "url"
+
+const monorepoRoot = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../.."
+)
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   transpilePackages: ["@workspace/ui"],
+  turbopack: {
+    root: monorepoRoot,
+  },
   images: {
     remotePatterns: [
       {

--- a/apps/gallery/package.json
+++ b/apps/gallery/package.json
@@ -39,6 +39,7 @@
     "@workspace/eslint-config": "workspace:^",
     "@workspace/typescript-config": "workspace:*",
     "eslint": "^9.39.2",
+    "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3"
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,9 @@
         "@tanstack/react-query": "^5.99.2",
         "date-fns": "^4.1.0",
         "lucide-react": "^1.8.0",
+        "shadcn": "^4.3.1",
         "sonner": "^2.0.7",
+        "tw-animate-css": "^1.4.0",
       },
       "devDependencies": {
         "@commitlint/cli": "^20.5.0",
@@ -19,6 +21,7 @@
         "lint-staged": "^16.4.0",
         "prettier": "^3.8.1",
         "prettier-plugin-tailwindcss": "^0.7.2",
+        "tailwindcss": "^4.1.18",
         "turbo": "^2.8.17",
         "typescript": "5.9.3",
       },
@@ -49,6 +52,7 @@
         "@workspace/eslint-config": "workspace:^",
         "@workspace/typescript-config": "workspace:*",
         "eslint": "^9.39.2",
+        "tailwindcss": "^4.1.18",
         "typescript": "^5.9.3",
       },
     },
@@ -437,9 +441,9 @@
 
     "@inquirer/checkbox": ["@inquirer/checkbox@4.3.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/core": "^10.3.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA=="],
 
-    "@inquirer/confirm": ["@inquirer/confirm@5.1.21", "", { "dependencies": { "@inquirer/core": "^10.3.2", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ=="],
+    "@inquirer/confirm": ["@inquirer/confirm@6.0.12", "", { "dependencies": { "@inquirer/core": "^11.1.9", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og=="],
 
-    "@inquirer/core": ["@inquirer/core@10.3.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A=="],
+    "@inquirer/core": ["@inquirer/core@11.1.9", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg=="],
 
     "@inquirer/editor": ["@inquirer/editor@4.2.23", "", { "dependencies": { "@inquirer/core": "^10.3.2", "@inquirer/external-editor": "^1.0.3", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ=="],
 
@@ -463,7 +467,7 @@
 
     "@inquirer/select": ["@inquirer/select@4.4.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/core": "^10.3.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w=="],
 
-    "@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
+    "@inquirer/type": ["@inquirer/type@4.0.5", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -1173,7 +1177,7 @@
 
     "fast-equals": ["fast-equals@5.4.0", "", {}, "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw=="],
 
-    "fast-glob": ["fast-glob@3.3.1", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.4" } }, "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg=="],
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
@@ -1403,7 +1407,7 @@
 
     "isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
-    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+    "isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
 
     "iterator.prototype": ["iterator.prototype@1.1.5", "", { "dependencies": { "define-data-property": "^1.1.4", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "get-proto": "^1.0.0", "has-symbols": "^1.1.0", "set-function-name": "^2.0.2" } }, "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g=="],
 
@@ -1529,7 +1533,7 @@
 
     "msw": ["msw@2.14.2", "", { "dependencies": { "@inquirer/confirm": "^6.0.11", "@mswjs/interceptors": "^0.41.3", "@open-draft/deferred-promise": "^3.0.0", "@types/statuses": "^2.0.6", "cookie": "^1.1.1", "graphql": "^16.13.2", "headers-polyfill": "^5.0.1", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "path-to-regexp": "^6.3.0", "picocolors": "^1.1.1", "rettime": "^0.11.7", "statuses": "^2.0.2", "strict-event-emitter": "^0.5.1", "tough-cookie": "^6.0.1", "type-fest": "^5.5.0", "until-async": "^3.0.2", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": ">= 4.8.x" }, "optionalPeers": ["typescript"], "bin": { "msw": "cli/index.js" } }, "sha512-D2bTe0tpuf9nw4DA39wFaqUD/hRPKj0DKpo2lAqu+A47Ifg4+h0hbfn6QxVOsiUY2uhgEN6TTpGSHDsc+ysYNg=="],
 
-    "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
+    "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
     "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
@@ -1913,7 +1917,7 @@
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
-    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+    "which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
     "which-boxed-primitive": ["which-boxed-primitive@1.1.1", "", { "dependencies": { "is-bigint": "^1.1.0", "is-boolean-object": "^1.2.1", "is-number-object": "^1.1.1", "is-string": "^1.1.1", "is-symbol": "^1.1.1" } }, "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA=="],
 
@@ -1971,19 +1975,59 @@
 
     "@dotenvx/dotenvx/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
-    "@dotenvx/dotenvx/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
-
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
-    "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+    "@inquirer/checkbox/@inquirer/core": ["@inquirer/core@10.3.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A=="],
+
+    "@inquirer/checkbox/@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
+
+    "@inquirer/core/@inquirer/ansi": ["@inquirer/ansi@2.0.5", "", {}, "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw=="],
+
+    "@inquirer/core/@inquirer/figures": ["@inquirer/figures@2.0.5", "", {}, "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ=="],
+
+    "@inquirer/editor/@inquirer/core": ["@inquirer/core@10.3.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A=="],
+
+    "@inquirer/editor/@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
+
+    "@inquirer/expand/@inquirer/core": ["@inquirer/core@10.3.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A=="],
+
+    "@inquirer/expand/@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
+
+    "@inquirer/input/@inquirer/core": ["@inquirer/core@10.3.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A=="],
+
+    "@inquirer/input/@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
+
+    "@inquirer/number/@inquirer/core": ["@inquirer/core@10.3.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A=="],
+
+    "@inquirer/number/@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
+
+    "@inquirer/password/@inquirer/core": ["@inquirer/core@10.3.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A=="],
+
+    "@inquirer/password/@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
+
+    "@inquirer/prompts/@inquirer/confirm": ["@inquirer/confirm@5.1.21", "", { "dependencies": { "@inquirer/core": "^10.3.2", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ=="],
+
+    "@inquirer/rawlist/@inquirer/core": ["@inquirer/core@10.3.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A=="],
+
+    "@inquirer/rawlist/@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
+
+    "@inquirer/search/@inquirer/core": ["@inquirer/core@10.3.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A=="],
+
+    "@inquirer/search/@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
+
+    "@inquirer/select/@inquirer/core": ["@inquirer/core@10.3.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A=="],
+
+    "@inquirer/select/@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
 
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
+
+    "@next/eslint-plugin-next/fast-glob": ["fast-glob@3.3.1", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.4" } }, "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg=="],
 
     "@radix-ui/react-accordion/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
@@ -2079,8 +2123,6 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@ts-morph/common/fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
-
     "@ts-morph/common/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
@@ -2096,6 +2138,8 @@
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "dot-prop/is-obj": ["is-obj@2.0.0", "", {}, "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="],
 
@@ -2119,8 +2163,6 @@
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "msw/@inquirer/confirm": ["@inquirer/confirm@6.0.12", "", { "dependencies": { "@inquirer/core": "^11.1.9", "@inquirer/type": "^4.0.5" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og=="],
-
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
@@ -2138,8 +2180,6 @@
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
-
-    "shadcn/fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
     "sharp/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -2167,13 +2207,49 @@
 
     "@dotenvx/dotenvx/execa/strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
 
-    "@dotenvx/dotenvx/which/isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
+    "@inquirer/checkbox/@inquirer/core/mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
 
-    "@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "@inquirer/checkbox/@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@inquirer/editor/@inquirer/core/mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
+
+    "@inquirer/editor/@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@inquirer/expand/@inquirer/core/mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
+
+    "@inquirer/expand/@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@inquirer/input/@inquirer/core/mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
+
+    "@inquirer/input/@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@inquirer/number/@inquirer/core/mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
+
+    "@inquirer/number/@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@inquirer/password/@inquirer/core/mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
+
+    "@inquirer/password/@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@inquirer/prompts/@inquirer/confirm/@inquirer/core": ["@inquirer/core@10.3.2", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A=="],
+
+    "@inquirer/prompts/@inquirer/confirm/@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
+
+    "@inquirer/rawlist/@inquirer/core/mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
+
+    "@inquirer/rawlist/@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@inquirer/search/@inquirer/core/mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
+
+    "@inquirer/search/@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@inquirer/select/@inquirer/core/mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
+
+    "@inquirer/select/@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "@ts-morph/common/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+    "@next/eslint-plugin-next/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "@ts-morph/common/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
@@ -2183,32 +2259,64 @@
 
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
+    "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
     "log-update/slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "log-update/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
-    "msw/@inquirer/confirm/@inquirer/core": ["@inquirer/core@11.1.9", "", { "dependencies": { "@inquirer/ansi": "^2.0.5", "@inquirer/figures": "^2.0.5", "@inquirer/type": "^4.0.5", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg=="],
-
-    "msw/@inquirer/confirm/@inquirer/type": ["@inquirer/type@4.0.5", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q=="],
-
     "ora/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
-
-    "shadcn/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
-    "@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "@inquirer/checkbox/@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@inquirer/editor/@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@inquirer/expand/@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@inquirer/input/@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@inquirer/number/@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@inquirer/password/@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@inquirer/prompts/@inquirer/confirm/@inquirer/core/mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
+
+    "@inquirer/prompts/@inquirer/confirm/@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@inquirer/rawlist/@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@inquirer/search/@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@inquirer/select/@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@ts-morph/common/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "msw/@inquirer/confirm/@inquirer/core/@inquirer/ansi": ["@inquirer/ansi@2.0.5", "", {}, "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw=="],
+    "@inquirer/checkbox/@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "msw/@inquirer/confirm/@inquirer/core/@inquirer/figures": ["@inquirer/figures@2.0.5", "", {}, "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ=="],
+    "@inquirer/editor/@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "msw/@inquirer/confirm/@inquirer/core/mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
+    "@inquirer/expand/@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@inquirer/input/@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@inquirer/number/@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@inquirer/password/@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@inquirer/prompts/@inquirer/confirm/@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@inquirer/rawlist/@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@inquirer/search/@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@inquirer/select/@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@inquirer/prompts/@inquirer/confirm/@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
+    "tailwindcss": "^4.1.18",
     "turbo": "^2.8.17",
     "typescript": "5.9.3"
   },
@@ -40,7 +41,9 @@
     "@tanstack/react-query": "^5.99.2",
     "date-fns": "^4.1.0",
     "lucide-react": "^1.8.0",
-    "sonner": "^2.0.7"
+    "shadcn": "^4.3.1",
+    "sonner": "^2.0.7",
+    "tw-animate-css": "^1.4.0"
   },
   "overrides": {
     "tslib": "^2.8.1",


### PR DESCRIPTION
Closes #215

## Summary
- Add `world-cup` seasonal theme alongside dragon-boat: pitch-green palette, rolling football header, green turf line, kickable ⚽ easter egg, and 世足加油 footer
- Super-admin Site theme picker: Off / Dragon Boat Festival / World Cup (labels only)
- `GalleryThemedShell` loads active theme for all gallery pages; hoist Tailwind CSS deps + `turbopack.root` for monorepo dev

## Test plan
- [ ] Manage → Site theme: switch Off / Dragon Boat / World Cup
- [ ] World Cup: green header line, football fleet, kickable balls, footer copy
- [ ] Dragon Boat unchanged when selected
- [ ] `cd apps/gallery && bun test` — all pass