### PR TITLE
fix(gallery): lay out wall photos left-to-right

### DIFF
--- a/apps/gallery/app/_components/gallery-grid.tsx
+++ b/apps/gallery/app/_components/gallery-grid.tsx
@@ -27,12 +27,9 @@ export function GalleryGrid({
   }
 
   return (
-    <div className="columns-1 gap-x-5 sm:columns-2 sm:gap-x-7 lg:columns-3 lg:gap-x-8">
+    <div className="grid grid-cols-1 gap-x-5 gap-y-9 sm:grid-cols-2 sm:gap-x-7 sm:gap-y-11 lg:grid-cols-3 lg:gap-x-8 lg:gap-y-12">
       {images.map((image, index) => (
-        <div
-          key={image.id}
-          className="mb-9 w-full max-w-full break-inside-avoid sm:mb-11 lg:mb-12"
-        >
+        <div key={image.id} className="w-full max-w-full">
           <GalleryCard
             image={image}
             isSignedIn={isSignedIn}


### PR DESCRIPTION
Closes #219

## Summary
- Replace CSS multi-column masonry with a row-major grid so home-page photo order reads left-to-right (newest top-left) instead of filling each column top-to-bottom first
- Polaroid thumb cropping unchanged (`object-cover` + fixed aspect frames)

## Test plan
- [ ] Open gallery home with 6+ photos — row 1 left→right is newest batch, not column 1 stacked vertically
- [ ] Mobile 1-col / tablet 2-col / desktop 3-col still look fine
- [ ] Lightbox still shows full uncropped image on click