### PR TITLE
feat(gallery): in-app @mention notifications and deep links

### DIFF
--- a/apps/gallery/app/_components/gallery-card.tsx
+++ b/apps/gallery/app/_components/gallery-card.tsx
@@ -9,6 +9,7 @@ import {
 } from "react"
 
 import Image from "next/image"
+import { useRouter, useSearchParams } from "next/navigation"
 
 import {
   IconChevronLeft,
@@ -129,6 +130,8 @@ export function GalleryCard({
   viewerName,
   members,
   priorityLcp = false,
+  initialOpen = false,
+  highlightCommentId = null,
 }: {
   image: GalleryImage
   isSignedIn: boolean
@@ -136,7 +139,11 @@ export function GalleryCard({
   viewerName: string
   members: GalleryMember[]
   priorityLcp?: boolean
+  initialOpen?: boolean
+  highlightCommentId?: string | null
 }) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
   const rotation = getRotation(image.id)
   const frame = getPolaroidFrame(image.id)
   const sequenceMedia: GallerySequenceItem[] =
@@ -153,7 +160,7 @@ export function GalleryCard({
           },
         ]
   const isSequence = sequenceMedia.length > 1
-  const [isDialogOpen, setIsDialogOpen] = useState(false)
+  const [isDialogOpen, setIsDialogOpen] = useState(initialOpen)
   const [mobileDetailsOpen, setMobileDetailsOpen] = useState(false)
   const [activeIndex, setActiveIndex] = useState(0)
   const activeItem = sequenceMedia[activeIndex] ?? sequenceMedia[0]
@@ -175,6 +182,25 @@ export function GalleryCard({
   useEffect(() => {
     setComments(image.comments)
   }, [image.comments])
+
+  useEffect(() => {
+    if (initialOpen) {
+      setIsDialogOpen(true)
+      if (highlightCommentId) setMobileDetailsOpen(true)
+    }
+  }, [initialOpen, highlightCommentId])
+
+  const handleDialogOpenChange = (open: boolean) => {
+    setIsDialogOpen(open)
+    if (open) return
+    if (!searchParams.has("photo")) return
+
+    const params = new URLSearchParams(searchParams.toString())
+    params.delete("photo")
+    params.delete("comment")
+    const qs = params.toString()
+    router.replace(qs ? `/?${qs}` : "/", { scroll: false })
+  }
 
   useEffect(() => {
     if (isDialogOpen) return
@@ -230,7 +256,7 @@ export function GalleryCard({
             } as React.CSSProperties
           }
         >
-          <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+          <Dialog open={isDialogOpen} onOpenChange={handleDialogOpenChange}>
             <DialogTrigger asChild>
               <button
                 type="button"
@@ -494,6 +520,7 @@ export function GalleryCard({
                       viewerId={viewerId}
                       viewerName={viewerName}
                       members={members}
+                      highlightCommentId={highlightCommentId}
                     />
                   </div>
                 </aside>

--- a/apps/gallery/app/_components/gallery-comments.tsx
+++ b/apps/gallery/app/_components/gallery-comments.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, useRef, useState, useTransition } from "react"
+import { useEffect, useMemo, useRef, useState, useTransition } from "react"
 
 import { Avatar, AvatarFallback } from "@workspace/ui/components/avatar"
 import { Button } from "@workspace/ui/components/button"
@@ -23,6 +23,7 @@ export function GalleryComments({
   viewerId,
   viewerName,
   members,
+  highlightCommentId = null,
 }: {
   imageId: string
   comments: GalleryComment[]
@@ -31,14 +32,39 @@ export function GalleryComments({
   viewerId: string | null
   viewerName: string
   members: GalleryMember[]
+  highlightCommentId?: string | null
 }) {
   const [draft, setDraft] = useState("")
   const [replyTarget, setReplyTarget] = useState<string | null>(null)
   const [mentionQuery, setMentionQuery] = useState<string | null>(null)
+  const [highlightedId, setHighlightedId] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
 
   const flattened = useMemo(() => flattenComments(comments), [comments])
+
+  useEffect(() => {
+    if (!highlightCommentId) return
+    const exists = flattened.some(
+      (comment) => comment.id === highlightCommentId
+    )
+    if (!exists) return
+
+    const frame = requestAnimationFrame(() => {
+      const node = listRef.current?.querySelector<HTMLElement>(
+        `[data-comment-id="${highlightCommentId}"]`
+      )
+      node?.scrollIntoView({ behavior: "smooth", block: "center" })
+      setHighlightedId(highlightCommentId)
+    })
+
+    const timer = window.setTimeout(() => setHighlightedId(null), 2400)
+    return () => {
+      cancelAnimationFrame(frame)
+      window.clearTimeout(timer)
+    }
+  }, [flattened, highlightCommentId])
 
   const filteredMembers = useMemo(() => {
     if (mentionQuery === null) return []
@@ -120,7 +146,10 @@ export function GalleryComments({
 
   return (
     <div className={cn("flex min-h-0 flex-1 flex-col", gallerySans())}>
-      <div className="min-h-0 flex-1 space-y-2.5 overflow-y-auto pr-0.5">
+      <div
+        ref={listRef}
+        className="min-h-0 flex-1 space-y-2.5 overflow-y-auto pr-0.5"
+      >
         {flattened.length === 0 ? (
           <p className="py-6 text-center text-xs text-muted-foreground">
             No comments yet — say something?
@@ -132,9 +161,12 @@ export function GalleryComments({
               return (
                 <li
                   key={comment.id}
+                  data-comment-id={comment.id}
                   className={cn(
-                    "rounded-xl border border-border/50 bg-muted/30 px-3 py-2.5",
-                    comment.depth > 0 && "ml-4 border-l-2 border-l-border"
+                    "rounded-xl border border-border/50 bg-muted/30 px-3 py-2.5 transition-colors duration-700",
+                    comment.depth > 0 && "ml-4 border-l-2 border-l-border",
+                    highlightedId === comment.id &&
+                      "gallery-comment-highlight border-amber-500/40 bg-amber-500/10"
                   )}
                 >
                   <div className="flex items-center gap-2 text-[11px] text-muted-foreground">

--- a/apps/gallery/app/_components/gallery-grid.tsx
+++ b/apps/gallery/app/_components/gallery-grid.tsx
@@ -10,12 +10,16 @@ export function GalleryGrid({
   viewerId,
   viewerName,
   members,
+  openPhotoId = null,
+  openCommentId = null,
 }: {
   images: GalleryImage[]
   isSignedIn: boolean
   viewerId: string | null
   viewerName: string
   members: GalleryMember[]
+  openPhotoId?: string | null
+  openCommentId?: string | null
 }) {
   if (images.length === 0) {
     return (
@@ -37,6 +41,8 @@ export function GalleryGrid({
             viewerName={viewerName}
             members={members}
             priorityLcp={index === 0}
+            initialOpen={openPhotoId === image.id}
+            highlightCommentId={openPhotoId === image.id ? openCommentId : null}
           />
         </div>
       ))}

--- a/apps/gallery/app/actions.ts
+++ b/apps/gallery/app/actions.ts
@@ -6,7 +6,7 @@ import {
   type GalleryReaction,
   isGalleryReaction,
 } from "@/lib/gallery/reactions"
-import { parseMentions } from "@/lib/gallery/mentions"
+import { parseMentions, resolveMentionedProfiles } from "@/lib/gallery/mentions"
 import {
   type GallerySeasonalThemeId,
   isGallerySeasonalThemeId,
@@ -143,9 +143,10 @@ export async function addGalleryComment(
     const { data: profiles } = await admin
       .from("user_profiles")
       .select("id, name")
-      .in("name", mentionNames)
+      .not("name", "is", null)
 
-    const others = (profiles ?? []).filter((p) => p.id !== userId)
+    const matched = resolveMentionedProfiles(mentionNames, profiles ?? [])
+    const others = matched.filter((p) => p.id !== userId)
     if (others.length > 0) {
       const { error: mentionError } = await admin
         .from("gallery_comment_mentions")
@@ -161,7 +162,7 @@ export async function addGalleryComment(
     }
   }
 
-  revalidatePath("/")
+  revalidatePath("/", "layout")
   return { ok: true, data }
 }
 
@@ -186,6 +187,38 @@ export async function deleteGalleryComment(
   }
 
   revalidatePath("/")
+  return { ok: true }
+}
+
+export async function markGalleryMentionsRead(
+  commentIds: string[]
+): Promise<ReactionActionResult> {
+  const uniqueIds = Array.from(
+    new Set(commentIds.filter((id) => typeof id === "string" && id.length > 0))
+  )
+  if (uniqueIds.length === 0) return { ok: true }
+
+  const supabase = await createClient()
+  const { data: claimsData } = await supabase.auth.getClaims()
+  const userId = claimsData?.claims?.sub
+  if (!userId) return { ok: false, error: "Please sign in first." }
+
+  const { error } = await supabase
+    .from("gallery_comment_mentions")
+    .update({ read_at: new Date().toISOString() })
+    .eq("mentioned_user_id", userId)
+    .in("comment_id", uniqueIds)
+    .is("read_at", null)
+
+  if (error) {
+    return {
+      ok: false,
+      error: `Could not mark mentions read: ${error.message}`,
+    }
+  }
+
+  revalidatePath("/", "layout")
+  revalidatePath("/upload")
   return { ok: true }
 }
 

--- a/apps/gallery/app/page.tsx
+++ b/apps/gallery/app/page.tsx
@@ -1,41 +1,87 @@
+import { Suspense } from "react"
+import { redirect } from "next/navigation"
+
 import { GalleryGrid } from "@/app/_components/gallery-grid"
 import { GalleryPagination } from "@/app/_components/gallery-pagination"
 import { GalleryThemedShell } from "@/components/gallery-shell"
 import { loadGalleryHomePage } from "@/lib/gallery/load-home-page"
+import {
+  buildGalleryPhotoHref,
+  resolveGalleryPhotoDeepLink,
+} from "@/lib/gallery/photo-deep-link"
 import { createClient } from "@/lib/supabase/server"
 import { getCurrentUser } from "@/lib/user"
 
 export const dynamic = "force-dynamic"
 
 type GalleryHomePageProps = {
-  searchParams: Promise<{ page?: string }>
+  searchParams: Promise<{ page?: string; photo?: string; comment?: string }>
 }
 
 export default async function GalleryHomePage({
   searchParams,
 }: GalleryHomePageProps) {
-  const { page } = await searchParams
+  const { page, photo, comment } = await searchParams
   const parsedPage = Number.parseInt(page ?? "1", 10)
+  const requestedPage =
+    Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1
+  const photoId = photo?.trim() || null
+  const commentId = comment?.trim() || null
 
   const supabase = await createClient()
   const user = await getCurrentUser()
 
+  let openPhotoId = photoId
+  let openCommentId = commentId
+  let loadPage = requestedPage
+
+  if (photoId) {
+    const resolved = await resolveGalleryPhotoDeepLink(supabase, photoId)
+    if (resolved) {
+      openPhotoId = resolved.coverId
+      if (resolved.page !== requestedPage) {
+        redirect(
+          buildGalleryPhotoHref({
+            photoId: resolved.coverId,
+            commentId,
+            page: resolved.page,
+          })
+        )
+      }
+      loadPage = resolved.page
+    }
+  }
+
   const { images, members, totalPages, currentPage } =
     await loadGalleryHomePage(supabase, {
-      page: parsedPage,
+      page: loadPage,
       userId: user?.id ?? null,
     })
 
   return (
     <GalleryThemedShell active="home" signedIn={Boolean(user)}>
       <div className="overflow-x-clip">
-        <GalleryGrid
-          images={images}
-          isSignedIn={Boolean(user)}
-          viewerId={user?.id ?? null}
-          viewerName={user?.name ?? "You"}
-          members={members}
-        />
+        <Suspense
+          fallback={
+            <GalleryGrid
+              images={images}
+              isSignedIn={Boolean(user)}
+              viewerId={user?.id ?? null}
+              viewerName={user?.name ?? "You"}
+              members={members}
+            />
+          }
+        >
+          <GalleryGrid
+            images={images}
+            isSignedIn={Boolean(user)}
+            viewerId={user?.id ?? null}
+            viewerName={user?.name ?? "You"}
+            members={members}
+            openPhotoId={openPhotoId}
+            openCommentId={openCommentId}
+          />
+        </Suspense>
         <GalleryPagination page={currentPage} totalPages={totalPages} />
       </div>
     </GalleryThemedShell>

--- a/apps/gallery/components/gallery-mention-bell.tsx
+++ b/apps/gallery/components/gallery-mention-bell.tsx
@@ -59,8 +59,10 @@ export function GalleryMentionBell({
 
   useEffect(() => {
     const supabase = createClient()
-    const channel = supabase
-      .channel(`gallery-mentions:${viewerId}`)
+    const channelName = `gallery-mentions:${viewerId}:${crypto.randomUUID()}`
+    const channel = supabase.channel(channelName)
+
+    channel
       .on(
         "postgres_changes",
         {
@@ -110,7 +112,7 @@ export function GalleryMentionBell({
       .subscribe()
 
     return () => {
-      supabase.removeChannel(channel)
+      void supabase.removeChannel(channel)
     }
   }, [viewerId])
 

--- a/apps/gallery/components/gallery-mention-bell.tsx
+++ b/apps/gallery/components/gallery-mention-bell.tsx
@@ -1,0 +1,219 @@
+"use client"
+
+import { useEffect, useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+import { IconBell } from "@tabler/icons-react"
+
+import { Button } from "@workspace/ui/components/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@workspace/ui/components/dropdown-menu"
+import { cn } from "@workspace/ui/lib/utils"
+
+import { markGalleryMentionsRead } from "@/app/actions"
+import {
+  gallerySans,
+  galleryShellIconButtonClass,
+} from "@/components/gallery-chrome"
+import { formatUploadedAt } from "@/lib/gallery/format-uploaded-at"
+import {
+  fetchGalleryMentionNotification,
+  type GalleryMentionNotification,
+} from "@/lib/gallery/mention-notifications"
+import { buildGalleryPhotoHref } from "@/lib/gallery/photo-deep-link"
+import { createClient } from "@/lib/supabase/client"
+
+function truncateBody(body: string, max = 72): string {
+  const trimmed = body.trim()
+  if (trimmed.length <= max) return trimmed
+  return `${trimmed.slice(0, max - 1)}…`
+}
+
+function sortNotifications(items: GalleryMentionNotification[]) {
+  return [...items].sort(
+    (a, b) =>
+      new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+  )
+}
+
+export function GalleryMentionBell({
+  viewerId,
+  initialNotifications,
+}: {
+  viewerId: string
+  initialNotifications: GalleryMentionNotification[]
+}) {
+  const router = useRouter()
+  const [notifications, setNotifications] = useState(initialNotifications)
+  const [isPending, startTransition] = useTransition()
+  const unreadCount = notifications.length
+
+  useEffect(() => {
+    setNotifications(initialNotifications)
+  }, [initialNotifications])
+
+  useEffect(() => {
+    const supabase = createClient()
+    const channel = supabase
+      .channel(`gallery-mentions:${viewerId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "gallery_comment_mentions",
+          filter: `mentioned_user_id=eq.${viewerId}`,
+        },
+        async (payload) => {
+          const commentId = (payload.new as { comment_id?: string }).comment_id
+          if (!commentId) return
+
+          const notification = await fetchGalleryMentionNotification(
+            supabase,
+            commentId,
+            viewerId
+          )
+          if (!notification) return
+
+          setNotifications((current) => {
+            if (current.some((item) => item.comment_id === commentId)) {
+              return current
+            }
+            return sortNotifications([notification, ...current])
+          })
+        }
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "gallery_comment_mentions",
+          filter: `mentioned_user_id=eq.${viewerId}`,
+        },
+        (payload) => {
+          const row = payload.new as {
+            comment_id?: string
+            read_at?: string | null
+          }
+          if (!row.comment_id || !row.read_at) return
+          setNotifications((current) =>
+            current.filter((item) => item.comment_id !== row.comment_id)
+          )
+        }
+      )
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [viewerId])
+
+  const openMention = (notification: GalleryMentionNotification) => {
+    startTransition(async () => {
+      const result = await markGalleryMentionsRead([notification.comment_id])
+      if (!result.ok) return
+      setNotifications((current) =>
+        current.filter((item) => item.comment_id !== notification.comment_id)
+      )
+      router.push(
+        buildGalleryPhotoHref({
+          photoId: notification.image_id,
+          commentId: notification.comment_id,
+        })
+      )
+    })
+  }
+
+  const markAllRead = () => {
+    if (notifications.length === 0) return
+    startTransition(async () => {
+      const result = await markGalleryMentionsRead(
+        notifications.map((item) => item.comment_id)
+      )
+      if (!result.ok) return
+      setNotifications([])
+    })
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className={cn(galleryShellIconButtonClass(), "relative")}
+          aria-label={
+            unreadCount > 0
+              ? `${unreadCount} unread mention${unreadCount === 1 ? "" : "s"}`
+              : "Mentions"
+          }
+          disabled={isPending}
+        >
+          <IconBell className="size-4" aria-hidden />
+          {unreadCount > 0 ? (
+            <span
+              className={cn(
+                gallerySans(),
+                "absolute -top-0.5 -right-0.5 flex min-w-[1rem] items-center justify-center rounded-full bg-foreground px-1 py-0.5 text-[9px] leading-none font-medium text-background"
+              )}
+            >
+              {unreadCount > 9 ? "9+" : unreadCount}
+            </span>
+          ) : null}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className={cn(gallerySans(), "w-80 max-w-[calc(100vw-2rem)]")}
+      >
+        <DropdownMenuLabel className="flex items-center justify-between gap-2">
+          <span>Mentions</span>
+          {unreadCount > 0 ? (
+            <button
+              type="button"
+              className="text-[10px] tracking-wide text-muted-foreground uppercase transition-colors hover:text-foreground"
+              onClick={markAllRead}
+              disabled={isPending}
+            >
+              Mark all read
+            </button>
+          ) : null}
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {unreadCount === 0 ? (
+          <div className="px-2 py-3 text-xs text-muted-foreground">
+            No unread @mentions.
+          </div>
+        ) : (
+          notifications.map((notification) => (
+            <DropdownMenuItem
+              key={notification.comment_id}
+              className="flex cursor-pointer flex-col items-start gap-1 py-2"
+              onClick={() => openMention(notification)}
+              disabled={isPending}
+            >
+              <span className="text-xs text-foreground">
+                <span className="font-medium">{notification.author_name}</span>
+                {" mentioned you on "}
+                <span className="font-medium">{notification.image_name}</span>
+              </span>
+              <span className="line-clamp-2 text-[11px] text-muted-foreground">
+                {truncateBody(notification.body)}
+              </span>
+              <span className="text-[10px] text-muted-foreground/80">
+                {formatUploadedAt(notification.created_at)}
+              </span>
+            </DropdownMenuItem>
+          ))
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/gallery/components/gallery-shell-nav.tsx
+++ b/apps/gallery/components/gallery-shell-nav.tsx
@@ -43,25 +43,24 @@ export function GalleryShellNav({
 }) {
   return (
     <>
+      {signedIn && viewerId ? (
+        <GalleryMentionBell
+          viewerId={viewerId}
+          initialNotifications={mentionNotifications}
+        />
+      ) : null}
+
       <nav
         className={cn(
           gallerySans(),
           "relative z-10 hidden shrink-0 items-center justify-end gap-4 md:flex"
         )}
       >
-        {signedIn && viewerId ? (
+        <GalleryNavLink href="https://portal.winlab.tw" external tone="shell">
+          Portal
+        </GalleryNavLink>
+        {signedIn ? (
           <>
-            <GalleryMentionBell
-              viewerId={viewerId}
-              initialNotifications={mentionNotifications}
-            />
-            <GalleryNavLink
-              href="https://portal.winlab.tw"
-              external
-              tone="shell"
-            >
-              Portal
-            </GalleryNavLink>
             {active !== "manage" ? (
               <GalleryNavLink href="/upload" tone="shell">
                 Manage
@@ -70,15 +69,10 @@ export function GalleryShellNav({
             <SignOutButton className={galleryShellNavLinkClass()} />
           </>
         ) : (
-          <GalleryNavLink href="https://portal.winlab.tw" external tone="shell">
-            Portal
-          </GalleryNavLink>
-        )}
-        {!signedIn ? (
           <GalleryNavLink href="/auth/login?next=/upload" tone="shell">
             Sign in
           </GalleryNavLink>
-        ) : null}
+        )}
       </nav>
 
       <div
@@ -87,14 +81,8 @@ export function GalleryShellNav({
           "relative z-10 flex shrink-0 items-center gap-0.5 md:hidden"
         )}
       >
-        {signedIn && viewerId ? (
-          <>
-            <GalleryMentionBell
-              viewerId={viewerId}
-              initialNotifications={mentionNotifications}
-            />
-            <SignOutButton iconOnly className={galleryShellIconButtonClass()} />
-          </>
+        {signedIn ? (
+          <SignOutButton iconOnly className={galleryShellIconButtonClass()} />
         ) : (
           <Link
             href="/auth/login?next=/upload"

--- a/apps/gallery/components/gallery-shell-nav.tsx
+++ b/apps/gallery/components/gallery-shell-nav.tsx
@@ -24,16 +24,22 @@ import {
   galleryShellIconButtonClass,
   galleryShellNavLinkClass,
 } from "@/components/gallery-chrome"
+import { GalleryMentionBell } from "@/components/gallery-mention-bell"
 import { SignOutButton } from "@/components/sign-out-button"
+import type { GalleryMentionNotification } from "@/lib/gallery/mention-notifications"
 
 export type GalleryShellActive = "home" | "manage"
 
 export function GalleryShellNav({
   active,
   signedIn,
+  viewerId = null,
+  mentionNotifications = [],
 }: {
   active: GalleryShellActive
   signedIn: boolean
+  viewerId?: string | null
+  mentionNotifications?: GalleryMentionNotification[]
 }) {
   return (
     <>
@@ -43,11 +49,19 @@ export function GalleryShellNav({
           "relative z-10 hidden shrink-0 items-center justify-end gap-4 md:flex"
         )}
       >
-        <GalleryNavLink href="https://portal.winlab.tw" external tone="shell">
-          Portal
-        </GalleryNavLink>
-        {signedIn ? (
+        {signedIn && viewerId ? (
           <>
+            <GalleryMentionBell
+              viewerId={viewerId}
+              initialNotifications={mentionNotifications}
+            />
+            <GalleryNavLink
+              href="https://portal.winlab.tw"
+              external
+              tone="shell"
+            >
+              Portal
+            </GalleryNavLink>
             {active !== "manage" ? (
               <GalleryNavLink href="/upload" tone="shell">
                 Manage
@@ -56,10 +70,15 @@ export function GalleryShellNav({
             <SignOutButton className={galleryShellNavLinkClass()} />
           </>
         ) : (
+          <GalleryNavLink href="https://portal.winlab.tw" external tone="shell">
+            Portal
+          </GalleryNavLink>
+        )}
+        {!signedIn ? (
           <GalleryNavLink href="/auth/login?next=/upload" tone="shell">
             Sign in
           </GalleryNavLink>
-        )}
+        ) : null}
       </nav>
 
       <div
@@ -68,8 +87,14 @@ export function GalleryShellNav({
           "relative z-10 flex shrink-0 items-center gap-0.5 md:hidden"
         )}
       >
-        {signedIn ? (
-          <SignOutButton iconOnly className={galleryShellIconButtonClass()} />
+        {signedIn && viewerId ? (
+          <>
+            <GalleryMentionBell
+              viewerId={viewerId}
+              initialNotifications={mentionNotifications}
+            />
+            <SignOutButton iconOnly className={galleryShellIconButtonClass()} />
+          </>
         ) : (
           <Link
             href="/auth/login?next=/upload"

--- a/apps/gallery/components/gallery-shell.tsx
+++ b/apps/gallery/components/gallery-shell.tsx
@@ -18,12 +18,15 @@ import {
   GalleryShellNav,
   type GalleryShellActive,
 } from "@/components/gallery-shell-nav"
+import type { GalleryMentionNotification } from "@/lib/gallery/mention-notifications"
 import {
   GALLERY_SEASONAL_THEMES,
   type GallerySeasonalThemeId,
 } from "@/lib/gallery/seasonal-themes"
 import { getGallerySeasonalThemeId } from "@/lib/gallery/settings"
+import { loadUnreadGalleryMentions } from "@/lib/gallery/mention-notifications"
 import { createClient } from "@/lib/supabase/server"
+import { getCurrentUser } from "@/lib/user"
 
 export type { GalleryShellActive } from "@/components/gallery-shell-nav"
 
@@ -31,13 +34,17 @@ export function GalleryShell({
   children,
   active = "home",
   signedIn = false,
+  viewerId = null,
   seasonalThemeId = null,
+  mentionNotifications = [],
   containerClassName,
 }: {
   children: ReactNode
   active?: GalleryShellActive
   signedIn?: boolean
+  viewerId?: string | null
   seasonalThemeId?: GallerySeasonalThemeId | null
+  mentionNotifications?: GalleryMentionNotification[]
   containerClassName?: string
 }) {
   const theme = seasonalThemeId
@@ -81,7 +88,12 @@ export function GalleryShell({
             <div className="gallery-header-seasonal-row min-w-0 flex-1 overflow-hidden">
               <GalleryHeaderSeasonal themeId={seasonalThemeId} />
             </div>
-            <GalleryShellNav active={active} signedIn={signedIn} />
+            <GalleryShellNav
+              active={active}
+              signedIn={signedIn}
+              viewerId={viewerId}
+              mentionNotifications={mentionNotifications}
+            />
           </div>
         </div>
         {seasonalThemeId === "dragon-boat" ? <GalleryHeaderWaterline /> : null}
@@ -116,13 +128,19 @@ export async function GalleryThemedShell({
   containerClassName?: string
 }) {
   const supabase = await createClient()
-  const seasonalThemeId = await getGallerySeasonalThemeId(supabase)
+  const user = await getCurrentUser()
+  const [seasonalThemeId, mentionNotifications] = await Promise.all([
+    getGallerySeasonalThemeId(supabase),
+    user ? loadUnreadGalleryMentions(supabase, user.id) : Promise.resolve([]),
+  ])
 
   return (
     <GalleryShell
       active={active}
-      signedIn={signedIn}
+      signedIn={Boolean(user)}
+      viewerId={user?.id ?? null}
       seasonalThemeId={seasonalThemeId}
+      mentionNotifications={mentionNotifications}
       containerClassName={containerClassName}
     >
       {children}

--- a/apps/gallery/lib/gallery/mention-notifications.ts
+++ b/apps/gallery/lib/gallery/mention-notifications.ts
@@ -1,0 +1,104 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+export type GalleryMentionNotification = {
+  comment_id: string
+  image_id: string
+  image_name: string
+  body: string
+  author_name: string
+  created_at: string
+}
+
+type MentionRow = {
+  comment_id: string
+  gallery_comments: {
+    id: string
+    body: string
+    created_at: string
+    image_id: string
+    gallery_images: { id: string; name: string } | null
+    user_profiles: { name: string | null } | null
+  } | null
+}
+
+function mapMentionRow(row: MentionRow): GalleryMentionNotification | null {
+  const comment = row.gallery_comments
+  if (!comment) return null
+  return {
+    comment_id: row.comment_id,
+    image_id: comment.image_id,
+    image_name: comment.gallery_images?.name ?? "Photo",
+    body: comment.body,
+    author_name: comment.user_profiles?.name?.trim() || "Someone",
+    created_at: comment.created_at,
+  }
+}
+
+const MENTION_SELECT = `
+  comment_id,
+  gallery_comments!inner(
+    id,
+    body,
+    created_at,
+    image_id,
+    gallery_images!inner(id, name),
+    user_profiles!gallery_comments_created_by_fkey(name)
+  )
+`
+
+export function isGalleryMentionReadAtUnavailable(
+  error: { code?: string; message?: string } | null
+): boolean {
+  if (!error) return false
+  const message = error.message ?? ""
+  return (
+    error.code === "42703" ||
+    /read_at/i.test(message) ||
+    /column.*does not exist/i.test(message)
+  )
+}
+
+export async function loadUnreadGalleryMentions(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<GalleryMentionNotification[]> {
+  const { data, error } = await supabase
+    .from("gallery_comment_mentions")
+    .select(MENTION_SELECT)
+    .eq("mentioned_user_id", userId)
+    .is("read_at", null)
+
+  if (error) {
+    if (isGalleryMentionReadAtUnavailable(error)) return []
+    console.error("[gallery] failed to load mention notifications", error)
+    return []
+  }
+
+  const notifications = ((data ?? []) as unknown as MentionRow[])
+    .map(mapMentionRow)
+    .filter((row): row is GalleryMentionNotification => row !== null)
+
+  notifications.sort(
+    (a, b) =>
+      new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+  )
+
+  return notifications
+}
+
+export async function fetchGalleryMentionNotification(
+  supabase: SupabaseClient,
+  commentId: string,
+  userId: string
+): Promise<GalleryMentionNotification | null> {
+  const { data, error } = await supabase
+    .from("gallery_comment_mentions")
+    .select(MENTION_SELECT)
+    .eq("comment_id", commentId)
+    .eq("mentioned_user_id", userId)
+    .is("read_at", null)
+    .maybeSingle()
+
+  if (error || !data) return null
+  return mapMentionRow(data as unknown as MentionRow)
+}

--- a/apps/gallery/lib/gallery/mentions.test.ts
+++ b/apps/gallery/lib/gallery/mentions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 
-import { parseMentions } from "@/lib/gallery/mentions"
+import { parseMentions, resolveMentionedProfiles } from "@/lib/gallery/mentions"
 
 describe("parseMentions", () => {
   test("extracts names from a simple two-mention comment", () => {
@@ -19,5 +19,38 @@ describe("parseMentions", () => {
   test("stops at punctuation", () => {
     expect(parseMentions("@alice!")).toEqual(["alice"])
     expect(parseMentions("@alice, @bob")).toEqual(["alice", "bob"])
+  })
+})
+
+describe("resolveMentionedProfiles", () => {
+  const profiles = [
+    { id: "1", name: "Alice" },
+    { id: "2", name: "Bob" },
+    { id: "3", name: "mike" },
+  ]
+
+  test("matches names case-insensitively", () => {
+    expect(resolveMentionedProfiles(["alice", "MIKE"], profiles)).toEqual([
+      { id: "1", name: "Alice" },
+      { id: "3", name: "mike" },
+    ])
+  })
+
+  test("returns empty when nothing matches", () => {
+    expect(resolveMentionedProfiles(["ghost"], profiles)).toEqual([])
+  })
+
+  test("dedups duplicate ids when the same user is mentioned twice", () => {
+    expect(resolveMentionedProfiles(["Alice", "ALICE"], profiles)).toEqual([
+      { id: "1", name: "Alice" },
+    ])
+  })
+
+  test("mentions every profile that shares the same name", () => {
+    const dupes = [
+      { id: "a", name: "Sam" },
+      { id: "b", name: "sam" },
+    ]
+    expect(resolveMentionedProfiles(["SAM"], dupes)).toEqual(dupes)
   })
 })

--- a/apps/gallery/lib/gallery/mentions.ts
+++ b/apps/gallery/lib/gallery/mentions.ts
@@ -11,3 +11,38 @@ export function parseMentions(content: string): string[] {
   }
   return Array.from(names)
 }
+
+export type MentionProfile = {
+  id: string
+  name: string | null
+}
+
+/** Case-insensitive name match; returns one row per matched user id. */
+export function resolveMentionedProfiles(
+  mentionNames: string[],
+  profiles: MentionProfile[]
+): MentionProfile[] {
+  if (mentionNames.length === 0) return []
+
+  const byLowerName = new Map<string, MentionProfile[]>()
+  for (const profile of profiles) {
+    const trimmed = profile.name?.trim()
+    if (!trimmed) continue
+    const key = trimmed.toLowerCase()
+    const bucket = byLowerName.get(key) ?? []
+    bucket.push(profile)
+    byLowerName.set(key, bucket)
+  }
+
+  const seen = new Set<string>()
+  const resolved: MentionProfile[] = []
+  for (const raw of mentionNames) {
+    const matches = byLowerName.get(raw.toLowerCase()) ?? []
+    for (const profile of matches) {
+      if (seen.has(profile.id)) continue
+      seen.add(profile.id)
+      resolved.push(profile)
+    }
+  }
+  return resolved
+}

--- a/apps/gallery/lib/gallery/photo-deep-link.test.ts
+++ b/apps/gallery/lib/gallery/photo-deep-link.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+
+import { GALLERY_PAGE_SIZE } from "@/lib/gallery/load-home-page"
+import { galleryPhotoPageFromRank } from "@/lib/gallery/photo-deep-link"
+
+describe("galleryPhotoPageFromRank", () => {
+  test("first photo is page 1", () => {
+    expect(galleryPhotoPageFromRank(1)).toBe(1)
+  })
+
+  test("last slot on page 1 stays on page 1", () => {
+    expect(galleryPhotoPageFromRank(GALLERY_PAGE_SIZE)).toBe(1)
+  })
+
+  test("first photo on page 2", () => {
+    expect(galleryPhotoPageFromRank(GALLERY_PAGE_SIZE + 1)).toBe(2)
+  })
+
+  test("guards invalid ranks", () => {
+    expect(galleryPhotoPageFromRank(0)).toBe(1)
+    expect(galleryPhotoPageFromRank(-3)).toBe(1)
+  })
+})

--- a/apps/gallery/lib/gallery/photo-deep-link.ts
+++ b/apps/gallery/lib/gallery/photo-deep-link.ts
@@ -1,0 +1,95 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import { GALLERY_PAGE_SIZE } from "@/lib/gallery/load-home-page"
+
+export function galleryPhotoPageFromRank(
+  rank: number,
+  pageSize = GALLERY_PAGE_SIZE
+): number {
+  if (!Number.isFinite(rank) || rank < 1) return 1
+  return Math.max(1, Math.ceil(rank / pageSize))
+}
+
+type ImageRow = {
+  id: string
+  created_at: string
+  sequence_id: string | null
+  sequence_index: number | null
+}
+
+export type GalleryPhotoDeepLink = {
+  coverId: string
+  page: number
+}
+
+/** Resolve a photo id to its wall cover row and 1-based pagination page. */
+export async function resolveGalleryPhotoDeepLink(
+  supabase: SupabaseClient,
+  photoId: string
+): Promise<GalleryPhotoDeepLink | null> {
+  const { data: row, error } = await supabase
+    .from("gallery_images")
+    .select("id, created_at, sequence_id, sequence_index")
+    .eq("id", photoId)
+    .maybeSingle()
+
+  if (error || !row) {
+    if (error) {
+      console.error("[gallery] failed to resolve photo deep link", error)
+    }
+    return null
+  }
+
+  const image = row as ImageRow
+  let coverId = image.id
+  let sortCreatedAt = image.created_at
+
+  if (
+    image.sequence_id &&
+    typeof image.sequence_index === "number" &&
+    image.sequence_index !== 0
+  ) {
+    const { data: cover } = await supabase
+      .from("gallery_images")
+      .select("id, created_at")
+      .eq("sequence_id", image.sequence_id)
+      .eq("sequence_index", 0)
+      .maybeSingle()
+
+    if (cover) {
+      coverId = cover.id
+      sortCreatedAt = cover.created_at
+    }
+  }
+
+  const { count, error: countError } = await supabase
+    .from("gallery_images")
+    .select("id", { count: "exact", head: true })
+    .or("sequence_id.is.null,sequence_index.eq.0")
+    .gt("created_at", sortCreatedAt)
+
+  if (countError) {
+    console.error("[gallery] failed to count newer wall photos", countError)
+    return { coverId, page: 1 }
+  }
+
+  const page = galleryPhotoPageFromRank((count ?? 0) + 1)
+  return { coverId, page }
+}
+
+export function buildGalleryPhotoHref({
+  photoId,
+  commentId,
+  page,
+}: {
+  photoId: string
+  commentId?: string | null
+  page?: number | null
+}): string {
+  const params = new URLSearchParams()
+  if (page && page > 1) params.set("page", String(page))
+  params.set("photo", photoId)
+  if (commentId) params.set("comment", commentId)
+  const qs = params.toString()
+  return qs ? `/?${qs}` : "/"
+}

--- a/supabase/migrations/2026-06-24-gallery-mention-read-at.sql
+++ b/supabase/migrations/2026-06-24-gallery-mention-read-at.sql
@@ -1,0 +1,14 @@
+-- In-app read state for gallery @mentions (email still uses notified_at).
+
+alter table public.gallery_comment_mentions
+  add column if not exists read_at timestamptz;
+
+create index if not exists gallery_comment_mentions_unread
+  on public.gallery_comment_mentions (mentioned_user_id, comment_id)
+  where (read_at is null);
+
+create policy "gallery_comment_mentions_update_own_read"
+on public.gallery_comment_mentions for update
+to authenticated
+using (mentioned_user_id = auth.uid())
+with check (mentioned_user_id = auth.uid());

--- a/supabase/migrations/2026-06-25-gallery-mention-realtime.sql
+++ b/supabase/migrations/2026-06-25-gallery-mention-realtime.sql
@@ -1,0 +1,3 @@
+-- Realtime updates for in-app mention notifications.
+
+alter publication supabase_realtime add table public.gallery_comment_mentions;


### PR DESCRIPTION
Closes #221

## Summary
- Add header mention bell with unread badge; Realtime subscribe on `gallery_comment_mentions`
- DB: `read_at` for in-app read state (email keeps `notified_at`) + Realtime publication
- Fix @mention resolution: case-insensitive match → `mentioned_user_id`
- Deep links: `/?photo=id&comment=id` with cross-page redirect, URL cleanup on lightbox close, scroll + highlight target comment

## Test plan
- [ ] A comments @B → B's bell updates without page refresh
- [ ] @Mike / @mike both resolve to the same user
- [ ] Click notification opens correct page, lightbox, and highlighted comment
- [ ] Close lightbox clears `photo` / `comment` from URL
- [ ] Run migrations: `2026-06-24-gallery-mention-read-at.sql`, `2026-06-25-gallery-mention-realtime.sql`
- [ ] `cd apps/gallery && bun test lib/gallery/mentions.test.ts lib/gallery/photo-deep-link.test.ts`
