### PR TITLE
fix(gallery): push nav to top-right when seasonal theme is off

### DIFF
--- a/apps/gallery/app/gallery.css
+++ b/apps/gallery/app/gallery.css
@@ -161,7 +161,6 @@ html::-webkit-scrollbar {
 
 .gallery-seasonal-badge,
 .gallery-header-seasonal,
-.gallery-header-seasonal-row,
 .gallery-header-waterline,
 .gallery-header-pitchline,
 .gallery-zongzi-field,

--- a/apps/gallery/components/gallery-shell-nav.tsx
+++ b/apps/gallery/components/gallery-shell-nav.tsx
@@ -45,7 +45,7 @@ export function GalleryShellNav({
     <div
       className={cn(
         gallerySans(),
-        "relative z-10 flex shrink-0 items-center justify-end gap-2 sm:gap-3 md:gap-4"
+        "relative z-10 ml-auto flex shrink-0 items-center justify-end gap-2 sm:gap-3 md:gap-4"
       )}
     >
       {signedIn && viewerId ? (


### PR DESCRIPTION
Closes #225

## Summary
- Stop hiding \.gallery-header-seasonal-row\ by default — it is the flex spacer that pushes nav to the right
- Add \ml-auto\ on the nav cluster as a fallback

## Root cause
Without a seasonal theme, \gallery.css\ set \.gallery-header-seasonal-row { display: none }\, so Portal / Manage / Sign out sat immediately after the Gallery logo on the left.

## Test plan
- [ ] Default theme (no seasonal): nav links appear top-right
- [ ] Dragon Boat / World Cup themes: header decor unchanged, nav still top-right

Made with [Cursor](https://cursor.com)