### PR TITLE
fix(portal): require auth on meetings/schedule, drop wildcard CORS

### DIFF
--- a/apps/portal/app/api/meetings/schedule/route.ts
+++ b/apps/portal/app/api/meetings/schedule/route.ts
@@ -1,20 +1,25 @@
 import { NextRequest, NextResponse } from "next/server"
 
-import { createClient } from "@supabase/supabase-js"
+import { createClient as createServiceRoleClient } from "@supabase/supabase-js"
 
+import { createClient } from "@/lib/supabase/server"
 import type { DbMeeting, DbMeetingGroup } from "@/lib/meetings/types"
 
 function createServiceClient() {
-  return createClient(
+  return createServiceRoleClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.SUPABASE_SECRET_KEY!
   )
 }
 
+const SITE_ORIGIN =
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://portal.winlab.tw"
+
 const CORS = {
-  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Origin": SITE_ORIGIN,
   "Access-Control-Allow-Methods": "GET, OPTIONS",
   "Access-Control-Allow-Headers": "Content-Type",
+  "Access-Control-Allow-Credentials": "true",
   "Content-Type": "application/json; charset=utf-8",
 }
 
@@ -23,6 +28,17 @@ export async function OPTIONS() {
 }
 
 export async function GET(request: NextRequest) {
+  const authClient = await createClient()
+  const {
+    data: { user },
+  } = await authClient.auth.getUser()
+  if (!user) {
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      { status: 401, headers: CORS }
+    )
+  }
+
   const { searchParams } = new URL(request.url)
   const date = searchParams.get("date")
 


### PR DESCRIPTION
## Summary

Fixes the **HIGH** unauthenticated PII exposure identified in [security audit #182](#182).

- **Add session auth guard** to `GET /api/meetings/schedule`: the handler now calls `createClient().auth.getUser()` and returns `401` for unauthenticated requests. Previously it ran the service-role client (RLS bypass) with zero authentication, exposing presenter emails, locations, and meeting-group membership to any caller.
- **Drop wildcard CORS**: `Access-Control-Allow-Origin: *` replaced with `NEXT_PUBLIC_SITE_URL` (defaults to `https://portal.winlab.tw`); added `Access-Control-Allow-Credentials: true` for credentialed same-site requests.

## What was not changed

- The service-role client itself is retained — it is still used server-side after authentication to query tables across the meeting schema. Only the missing auth gate is added.
- `bulletin/*` routes were audited and confirmed already protected (BULLETIN_API_SECRET shared-secret guard on all cron-facing routes; user-session guard on `messages`).
- `meetings/check-video` and `meetings/upload` have no user auth but do not touch Supabase PII — tracked separately, out of scope for this PR.

## Test plan

- [ ] `GET /api/meetings/schedule?date=2026-07-02` without a session cookie → `401 Unauthorized`
- [ ] Same request with a valid WinLab session cookie → `200` with meeting data
- [ ] CORS preflight `OPTIONS` returns `portal.winlab.tw` origin (not `*`)
- [ ] Browser fetch from portal frontend still works (same-origin, credentialed)

Closes #182 (HIGH — unauthenticated PII via service-role API routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)