### PR TITLE
fix(mcp): harden OAuth DCR redirect_uri validation and consent UX

### DIFF
--- a/apps/mcp/app/oauth/authorize/authorize-form.tsx
+++ b/apps/mcp/app/oauth/authorize/authorize-form.tsx
@@ -7,6 +7,7 @@ import { createClient } from "@/lib/supabase/browser"
 
 type AuthorizeFormProps = {
   clientId: string
+  clientName: string
   redirectUri: string
   codeChallenge: string
   resource?: string
@@ -15,6 +16,7 @@ type AuthorizeFormProps = {
 
 export function AuthorizeForm({
   clientId,
+  clientName,
   redirectUri,
   codeChallenge,
   resource,
@@ -22,6 +24,18 @@ export function AuthorizeForm({
 }: AuthorizeFormProps) {
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
+
+  let redirectHost = ""
+  let isExternalRedirect = false
+  try {
+    const parsed = new URL(redirectUri)
+    redirectHost = parsed.host
+    isExternalRedirect = !redirectHost.endsWith(".winlab.tw")
+  } catch {
+    // malformed URI — server validation already caught this; show as-is
+    redirectHost = redirectUri
+    isExternalRedirect = true
+  }
 
   async function onClick() {
     setLoading(true)
@@ -62,10 +76,23 @@ export function AuthorizeForm({
   return (
     <main className="mx-auto flex min-h-screen w-full max-w-md flex-col justify-center px-6 py-20">
       <h1 className="mb-2 text-2xl">Authorize MCP client</h1>
-      <p className="mb-8 text-sm text-muted-foreground">
-        Sign in with your WinLab account to let this MCP client reach your
-        portal data.
+      <p className="mb-6 text-sm text-muted-foreground">
+        Sign in with your WinLab account to grant{" "}
+        <span className="font-semibold text-foreground">{clientName}</span>{" "}
+        access to your portal data.
       </p>
+
+      {isExternalRedirect ? (
+        <div
+          role="alert"
+          className="mb-6 rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+        >
+          <strong>Warning:</strong> This client will redirect your authorization
+          to an external domain:{" "}
+          <span className="font-mono font-semibold">{redirectHost}</span>.
+          Only continue if you trust this application.
+        </div>
+      ) : null}
 
       <Button onClick={onClick} disabled={loading} className="w-full">
         {loading ? "Redirecting…" : "Continue with Keycloak"}
@@ -80,11 +107,17 @@ export function AuthorizeForm({
       <dl className="mt-8 space-y-1 text-xs text-muted-foreground">
         <div className="flex gap-2">
           <dt>Client</dt>
-          <dd className="font-mono break-all">{clientId}</dd>
+          <dd className="break-all font-mono">{clientName}</dd>
         </div>
         <div className="flex gap-2">
           <dt>Redirects to</dt>
-          <dd className="font-mono break-all">{redirectUri}</dd>
+          <dd className="break-all font-mono font-semibold text-foreground">
+            {redirectHost}
+          </dd>
+        </div>
+        <div className="flex gap-2">
+          <dt>Client ID</dt>
+          <dd className="break-all font-mono opacity-60">{clientId}</dd>
         </div>
       </dl>
     </main>

--- a/apps/mcp/app/oauth/authorize/page.tsx
+++ b/apps/mcp/app/oauth/authorize/page.tsx
@@ -32,6 +32,7 @@ export default async function AuthorizePage({
   return (
     <AuthorizeForm
       clientId={result.clientId}
+      clientName={result.clientName}
       redirectUri={result.redirectUri}
       codeChallenge={result.codeChallenge}
       resource={result.resource}
@@ -49,10 +50,10 @@ async function loadAuthorize(searchParams: AuthorizePageProps["searchParams"]) {
     }
 
     const request = parseAuthorizeRequest(params)
-    await validateOAuthClientRequest(request, {
+    const client = await validateOAuthClientRequest(request, {
       expectedResource: getMcpResourceUrl(),
     })
-    return request
+    return { ...request, clientName: client.client_name }
   } catch (error) {
     return {
       error:

--- a/apps/mcp/lib/auth/oauth-clients.ts
+++ b/apps/mcp/lib/auth/oauth-clients.ts
@@ -12,9 +12,21 @@ const oauthClientSchema = z.object({
   created_at: z.string().optional(),
 })
 
+const safeRedirectUri = z
+  .string()
+  .url()
+  .refine(
+    (u) =>
+      /^https:\/\//.test(u) || /^http:\/\/localhost(:\d+)?(\/|$)/.test(u),
+    {
+      message:
+        "redirect_uri must use https:// (http://localhost allowed for development)",
+    }
+  )
+
 const registrationRequestSchema = z.object({
   client_name: z.string().min(1).default("MCP Client"),
-  redirect_uris: z.array(z.string().url()).min(1),
+  redirect_uris: z.array(safeRedirectUri).min(1),
   grant_types: z
     .array(z.enum(["authorization_code", "refresh_token"]))
     .min(1)

--- a/apps/mcp/lib/auth/oauth-request.ts
+++ b/apps/mcp/lib/auth/oauth-request.ts
@@ -2,9 +2,21 @@ import { z } from "zod"
 
 import { getOAuthClient, type OAuthClientStore } from "@/lib/auth/oauth-clients"
 
+const safeRedirectUri = z
+  .string()
+  .url()
+  .refine(
+    (u) =>
+      /^https:\/\//.test(u) || /^http:\/\/localhost(:\d+)?(\/|$)/.test(u),
+    {
+      message:
+        "redirect_uri must use https:// (http://localhost allowed for development)",
+    }
+  )
+
 const authorizeRequestSchema = z.object({
   client_id: z.string().min(1),
-  redirect_uri: z.string().url(),
+  redirect_uri: safeRedirectUri,
   response_type: z.literal("code"),
   code_challenge: z.string().min(1),
   code_challenge_method: z.literal("S256"),


### PR DESCRIPTION
## Summary

Fixes the **HIGH** OAuth confused-deputy / token-theft chain identified in [security audit #182](#182).

- **redirect_uri scheme allowlist** at both DCR and authorize time: the bare `z.string().url()` accepted `javascript:`, `data:`, and arbitrary external `https://` hosts. Both `registrationRequestSchema` (DCR endpoint) and `authorizeRequestSchema` (authorize page) now `.refine()` to reject anything that isn't `https://` or `http://localhost[:<port>][/]`.
- **Consent screen hardening**: the authorize page now passes the registered `client_name` (previously lost; only the opaque UUID was shown). `AuthorizeForm` displays the human-readable client name prominently, extracts the redirect hostname and renders it in bold, and shows a destructive-styled warning banner when the redirect host is external to `winlab.tw`.

## Files changed

| File | Change |
|---|---|
| `apps/mcp/lib/auth/oauth-clients.ts` | `safeRedirectUri` refine on `registrationRequestSchema.redirect_uris` |
| `apps/mcp/lib/auth/oauth-request.ts` | Same `safeRedirectUri` refine on `authorizeRequestSchema.redirect_uri` |
| `apps/mcp/app/oauth/authorize/page.tsx` | Return `clientName` from `validateOAuthClientRequest` → `AuthorizeForm` |
| `apps/mcp/app/oauth/authorize/authorize-form.tsx` | Show `clientName`, redirect hostname (bold), external-domain warning |

## What was not changed / why

- The DCR endpoint (`/oauth/register`) remains unauthenticated — this is inherent to MCP's public-client model (RFC 9728). Adding auth would break MCP clients that auto-register. The redirect_uri allowlist + consent hardening are the correct mitigations for this design constraint.
- No host allowlist beyond the scheme check — `winlab.tw` is used only for the consent-screen warning, not to reject clients. A full allowlist would block legitimate external MCP clients (e.g. Claude Desktop). The warning is the right UX control here.

## Test plan

- [ ] `POST /oauth/register` with `redirect_uris: ["javascript:alert(1)"]` → `400 invalid_client_metadata`
- [ ] `POST /oauth/register` with `redirect_uris: ["http://evil.example/cb"]` → `400 invalid_client_metadata`
- [ ] `POST /oauth/register` with `redirect_uris: ["https://claude.ai/callback"]` → `201` (external https allowed)
- [ ] `POST /oauth/register` with `redirect_uris: ["http://localhost:3000/callback"]` → `201` (localhost allowed)
- [ ] Authorize page for an external client shows the red warning banner with the redirect host
- [ ] Authorize page for a `*.winlab.tw` client shows no warning banner
- [ ] Consent page shows `clientName` ("MCP Client" or registered name) instead of raw UUID

Closes #182 (HIGH — OAuth confused-deputy / token-theft chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)