### PR TITLE
fix(security): add baseline security response headers to all apps

### DIFF
--- a/apps/gallery/next.config.mjs
+++ b/apps/gallery/next.config.mjs
@@ -33,6 +33,22 @@ const nextConfig = {
       bodySizeLimit: "20mb",
     },
   },
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          {
+            key: "Content-Security-Policy",
+            value: "frame-ancestors 'none'; base-uri 'self'; object-src 'none'",
+          },
+        ],
+      },
+    ]
+  },
 }
 
 export default nextConfig

--- a/apps/mcp/next.config.mjs
+++ b/apps/mcp/next.config.mjs
@@ -1,6 +1,22 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   transpilePackages: ["@workspace/ui"],
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          {
+            key: "Content-Security-Policy",
+            value: "frame-ancestors 'none'; base-uri 'self'; object-src 'none'",
+          },
+        ],
+      },
+    ]
+  },
 }
 
 export default nextConfig

--- a/apps/portal/next.config.mjs
+++ b/apps/portal/next.config.mjs
@@ -1,6 +1,22 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   transpilePackages: ["@workspace/ui"],
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          {
+            key: "Content-Security-Policy",
+            value: "frame-ancestors 'none'; base-uri 'self'; object-src 'none'",
+          },
+        ],
+      },
+    ]
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary

Adds `async headers()` to all three `next.config.mjs` (gallery, mcp, portal) with a zero-breakage set of security response headers:

- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: DENY`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Content-Security-Policy: frame-ancestors 'none'; base-uri 'self'; object-src 'none'`

Addresses #182 (MEDIUM: "Missing security headers on the gallery host") — the audit named gallery specifically, but all three apps' `next.config.mjs` were confirmed to have zero `headers()` config, so the fix is applied consistently across the monorepo.

## Why content-type CSP directives are deferred

This PR intentionally **does not** set `default-src`/`script-src`/`style-src`/`img-src`/`connect-src`. Those directives are the ones that actually break pages when wrong (blocked scripts, blocked Supabase Storage images, blocked hydration, blocked Supabase API calls), and none of the three apps could be tested against their live/deployed resource origins in this environment. Shipping a restrictive CSP without a live resource inventory + real-browser test risks silently breaking gallery image rendering, Supabase auth flows, or third-party embeds.

The headers shipped here (`frame-ancestors`, `base-uri`, `object-src`, `nosniff`, `X-Frame-Options`, `Referrer-Policy`) only add protection (clickjacking, MIME sniffing, base-tag injection, plugin objects, referrer leakage) and cannot break existing resource loading, since they don't constrain what the page is allowed to *fetch* — only what can *embed* it or execute via legacy vectors.

`X-Frame-Options: DENY` is included alongside `frame-ancestors 'none'` for defense-in-depth on older browsers that don't honor the CSP directive.

`Strict-Transport-Security` (HSTS) is intentionally **not** included — `includeSubDomains` would affect the entire shared `*.winlab.tw` domain, which is out of scope for this fix.

Follow-up (separate PR, out of scope here): live resource audit per app → tightened `script-src`/`style-src`/`img-src`/`connect-src` CSP directives.

## Test plan

- [x] `bun install`
- [x] `bun run typecheck` — all 3 apps pass
- [x] `bun run build` — gallery, mcp, portal all build successfully with the new `headers()` config
- [x] Live verification: started `mcp` and `gallery` with `next start` and confirmed via `curl -sI` that all 4 headers are present on the actual HTTP response (not just config)

Closes #182 (MEDIUM finding only — the two HIGH findings in that audit were already fixed in #232 and #233).

🤖 Generated with [Claude Code](https://claude.com/claude-code)