### PR TITLE
fix(mcp): prevent OAuth authorization code burning via PKCE bypass

### DIFF
--- a/apps/mcp/app/oauth/token/route.test.ts
+++ b/apps/mcp/app/oauth/token/route.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from "bun:test"
+
+import type { PeekedAuthData, StoredAuthData } from "@/lib/auth/auth-codes"
+import type { OAuthClientRow, OAuthClientStore } from "@/lib/auth/oauth-clients"
+
+import { handleAuthorizationCode } from "./route"
+
+// RFC 7636 Appendix B canonical S256 example (same pair used in pkce.test.ts).
+const RFC_VERIFIER = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+const RFC_CHALLENGE = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+const CLIENT_ID = "client-abc"
+const REDIRECT_URI = "https://app.example.com/callback"
+
+function fakeClientStore(): OAuthClientStore {
+  const row: OAuthClientRow = {
+    client_id: CLIENT_ID,
+    client_name: "Test Client",
+    redirect_uris: [REDIRECT_URI],
+    grant_types: ["authorization_code"],
+    response_types: ["code"],
+  }
+  return {
+    async insert() {},
+    async selectById(clientId) {
+      return clientId === CLIENT_ID ? row : null
+    },
+  }
+}
+
+function fakeAuthCodeBackend(peeked: PeekedAuthData | null) {
+  let consumed = false
+  const calls = { peek: 0, exchange: 0 }
+
+  const storedAfterConsume: StoredAuthData = {
+    accessToken: "real-access-token",
+    refreshToken: "real-refresh-token",
+    expiresIn: 3600,
+    codeChallenge: peeked?.codeChallenge ?? "",
+    redirectUri: REDIRECT_URI,
+    clientId: CLIENT_ID,
+  }
+
+  return {
+    calls,
+    isConsumed: () => consumed,
+    peek: async () => {
+      calls.peek += 1
+      return peeked
+    },
+    exchange: async () => {
+      calls.exchange += 1
+      if (consumed || !peeked) return null
+      consumed = true
+      return storedAfterConsume
+    },
+  }
+}
+
+function tokenRequestBody(overrides: Record<string, string> = {}) {
+  const body = new FormData()
+  body.set("grant_type", "authorization_code")
+  body.set("code", "the-auth-code")
+  body.set("code_verifier", RFC_VERIFIER)
+  body.set("client_id", CLIENT_ID)
+  body.set("redirect_uri", REDIRECT_URI)
+  for (const [key, value] of Object.entries(overrides)) body.set(key, value)
+  return body
+}
+
+describe("handleAuthorizationCode — code-burning DoS regression (audit #182)", () => {
+  test("wrong code_verifier: peek is called, exchange (consume) is NOT called", async () => {
+    const peeked: PeekedAuthData = {
+      codeChallenge: RFC_CHALLENGE,
+      redirectUri: REDIRECT_URI,
+      clientId: CLIENT_ID,
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    }
+    const backend = fakeAuthCodeBackend(peeked)
+
+    const body = tokenRequestBody({ code_verifier: "totally-wrong-verifier" })
+    const response = await handleAuthorizationCode(body, {
+      peek: backend.peek,
+      exchange: backend.exchange,
+      clientStore: fakeClientStore(),
+    })
+
+    expect(response.status).toBe(400)
+    const json = await response.json()
+    expect(json.error).toBe("invalid_grant")
+
+    expect(backend.calls.peek).toBe(1)
+    expect(backend.calls.exchange).toBe(0)
+    expect(backend.isConsumed()).toBe(false)
+  })
+
+  test("wrong verifier followed by the correct verifier still succeeds (code was not burned)", async () => {
+    const peeked: PeekedAuthData = {
+      codeChallenge: RFC_CHALLENGE,
+      redirectUri: REDIRECT_URI,
+      clientId: CLIENT_ID,
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    }
+    const backend = fakeAuthCodeBackend(peeked)
+    const clientStore = fakeClientStore()
+
+    const attack = await handleAuthorizationCode(
+      tokenRequestBody({ code_verifier: "attacker-guess" }),
+      { peek: backend.peek, exchange: backend.exchange, clientStore }
+    )
+    expect(attack.status).toBe(400)
+
+    const legit = await handleAuthorizationCode(
+      tokenRequestBody({ code_verifier: RFC_VERIFIER }),
+      { peek: backend.peek, exchange: backend.exchange, clientStore }
+    )
+    expect(legit.status).toBe(200)
+    const json = await legit.json()
+    expect(json.access_token).toBe("real-access-token")
+
+    expect(backend.calls.exchange).toBe(1)
+    expect(backend.isConsumed()).toBe(true)
+  })
+
+  test("correct verifier: peek → validate → exchange all run, token is returned", async () => {
+    const peeked: PeekedAuthData = {
+      codeChallenge: RFC_CHALLENGE,
+      redirectUri: REDIRECT_URI,
+      clientId: CLIENT_ID,
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    }
+    const backend = fakeAuthCodeBackend(peeked)
+
+    const response = await handleAuthorizationCode(
+      tokenRequestBody({ code_verifier: RFC_VERIFIER }),
+      {
+        peek: backend.peek,
+        exchange: backend.exchange,
+        clientStore: fakeClientStore(),
+      }
+    )
+
+    expect(response.status).toBe(200)
+    const json = await response.json()
+    expect(json).toEqual({
+      access_token: "real-access-token",
+      refresh_token: "real-refresh-token",
+      token_type: "Bearer",
+      expires_in: 3600,
+    })
+    expect(backend.calls.peek).toBe(1)
+    expect(backend.calls.exchange).toBe(1)
+  })
+
+  test("unknown code: peek returns null, exchange is never called", async () => {
+    const backend = fakeAuthCodeBackend(null)
+
+    const response = await handleAuthorizationCode(tokenRequestBody(), {
+      peek: backend.peek,
+      exchange: backend.exchange,
+      clientStore: fakeClientStore(),
+    })
+
+    expect(response.status).toBe(400)
+    const json = await response.json()
+    expect(json.error_description).toBe("Invalid or expired authorization code")
+    expect(backend.calls.exchange).toBe(0)
+  })
+})

--- a/apps/mcp/app/oauth/token/route.ts
+++ b/apps/mcp/app/oauth/token/route.ts
@@ -1,6 +1,12 @@
 import { createClient } from "@supabase/supabase-js"
 
-import { exchangeAuthCode } from "@/lib/auth/auth-codes"
+import {
+  exchangeAuthCode,
+  peekAuthCode,
+  type PeekedAuthData,
+  type StoredAuthData,
+} from "@/lib/auth/auth-codes"
+import type { OAuthClientStore } from "@/lib/auth/oauth-clients"
 import {
   parseTokenAuthorizationCodeRequest,
   validateOAuthClientRequest,
@@ -19,7 +25,19 @@ export async function POST(request: Request) {
   return Response.json({ error: "unsupported_grant_type" }, { status: 400 })
 }
 
-async function handleAuthorizationCode(body: FormData) {
+// Deps are injectable for testing; production callers (POST above) always
+// use the defaults, so behaviour is unchanged from before this refactor.
+export async function handleAuthorizationCode(
+  body: FormData,
+  deps: {
+    peek?: (code: string) => Promise<PeekedAuthData | null>
+    exchange?: (code: string) => Promise<StoredAuthData | null>
+    clientStore?: OAuthClientStore
+  } = {}
+) {
+  const peek = deps.peek ?? peekAuthCode
+  const exchange = deps.exchange ?? exchangeAuthCode
+
   let request: ReturnType<typeof parseTokenAuthorizationCodeRequest>
 
   try {
@@ -30,17 +48,21 @@ async function handleAuthorizationCode(body: FormData) {
     )
   }
 
-  const stored = await exchangeAuthCode(request.code)
-  if (!stored) return invalidGrant("Invalid or expired authorization code")
+  // Peek only — the code is *not* consumed yet, so a request that fails
+  // validation below (in particular PKCE) never burns it. This is the fix
+  // for the code-burning DoS: previously exchangeAuthCode (atomic
+  // delete-consume) ran before PKCE was checked.
+  const peeked = await peek(request.code)
+  if (!peeked) return invalidGrant("Invalid or expired authorization code")
 
-  if (request.redirectUri !== stored.redirectUri)
+  if (request.redirectUri !== peeked.redirectUri)
     return invalidGrant("redirect_uri mismatch")
-  if (request.clientId !== stored.clientId)
+  if (request.clientId !== peeked.clientId)
     return invalidGrant("client_id mismatch")
   if (
     request.resource &&
-    stored.resource &&
-    request.resource !== stored.resource
+    peeked.resource &&
+    request.resource !== peeked.resource
   )
     return invalidGrant("resource mismatch")
 
@@ -51,7 +73,7 @@ async function handleAuthorizationCode(body: FormData) {
         redirectUri: request.redirectUri,
         resource: request.resource,
       },
-      { expectedResource: getMcpResourceUrl() }
+      { expectedResource: getMcpResourceUrl(), store: deps.clientStore }
     )
   } catch (error) {
     return invalidGrant(
@@ -59,8 +81,12 @@ async function handleAuthorizationCode(body: FormData) {
     )
   }
 
-  if (!verifyPkce(request.codeVerifier, stored.codeChallenge))
+  if (!verifyPkce(request.codeVerifier, peeked.codeChallenge))
     return invalidGrant("PKCE verification failed")
+
+  // All validation passed — only now do we consume the code.
+  const stored = await exchange(request.code)
+  if (!stored) return invalidGrant("Invalid or expired authorization code")
 
   return Response.json({
     access_token: stored.accessToken,

--- a/apps/mcp/lib/auth/auth-codes.ts
+++ b/apps/mcp/lib/auth/auth-codes.ts
@@ -13,9 +13,29 @@ export interface StoredAuthData {
   resource?: string
 }
 
-interface AuthCodeStore {
+// Metadata needed to validate a token request *before* the code is consumed.
+// Deliberately excludes accessToken/refreshToken — mcp_peek_oauth_auth_code
+// never returns them (see the migration), so this type can't carry them either.
+export interface PeekedAuthData {
+  codeChallenge: string
+  redirectUri: string
+  clientId: string
+  resource?: string
+  expiresAt: string
+}
+
+interface PeekedAuthCodeRow {
+  client_id: string
+  redirect_uri: string
+  resource: string | null
+  code_challenge: string
+  expires_at: string
+}
+
+export interface AuthCodeStore {
   insert(code: string, data: StoredAuthData): Promise<void>
   exchange(code: string): Promise<StoredAuthData | null>
+  peek(code: string): Promise<PeekedAuthData | null>
 }
 
 export function createAuthCodeStore(client: {
@@ -23,7 +43,7 @@ export function createAuthCodeStore(client: {
     functionName: string,
     args: Record<string, unknown>
   ): PromiseLike<{
-    data?: StoredAuthData | null
+    data?: unknown
     error: { message: string } | null
   }>
 }): AuthCodeStore {
@@ -41,15 +61,35 @@ export function createAuthCodeStore(client: {
       })
       if (error)
         throw new Error(`Failed to exchange auth code: ${error.message}`)
-      return data ?? null
+      return (data as StoredAuthData | null) ?? null
+    },
+    async peek(code: string) {
+      const { data, error } = await client.rpc("mcp_peek_oauth_auth_code", {
+        p_code: code,
+      })
+      if (error) throw new Error(`Failed to peek auth code: ${error.message}`)
+      const rows = (data as PeekedAuthCodeRow[] | null) ?? []
+      const row = rows[0]
+      if (!row) return null
+      return {
+        codeChallenge: row.code_challenge,
+        redirectUri: row.redirect_uri,
+        clientId: row.client_id,
+        resource: row.resource ?? undefined,
+        expiresAt: row.expires_at,
+      }
     },
   }
 }
 
+function createDatabaseAuthCodeStore(): AuthCodeStore {
+  const supabase = createClient(supabaseUrl, supabasePublishableKey)
+  return createAuthCodeStore(supabase)
+}
+
 export async function createAuthCode(data: StoredAuthData): Promise<string> {
   const code = randomBytes(32).toString("hex")
-  const supabase = createClient(supabaseUrl, supabasePublishableKey)
-  const store = createAuthCodeStore(supabase)
+  const store = createDatabaseAuthCodeStore()
   await store.insert(code, data)
   return code
 }
@@ -57,7 +97,16 @@ export async function createAuthCode(data: StoredAuthData): Promise<string> {
 export async function exchangeAuthCode(
   code: string
 ): Promise<StoredAuthData | null> {
-  const supabase = createClient(supabaseUrl, supabasePublishableKey)
-  const store = createAuthCodeStore(supabase)
+  const store = createDatabaseAuthCodeStore()
   return store.exchange(code)
+}
+
+// Read-only lookup used by the token route to validate redirect_uri /
+// client_id / resource / PKCE *before* burning the code via exchangeAuthCode.
+// See mcp_peek_oauth_auth_code — it never returns tokens.
+export async function peekAuthCode(
+  code: string
+): Promise<PeekedAuthData | null> {
+  const store = createDatabaseAuthCodeStore()
+  return store.peek(code)
 }

--- a/supabase/migrations/2026-07-02-mcp-peek-oauth-auth-code.sql
+++ b/supabase/migrations/2026-07-02-mcp-peek-oauth-auth-code.sql
@@ -1,0 +1,40 @@
+-- Fix OAuth code-burning DoS (audit #182): mcp_exchange_oauth_auth_code is an
+-- atomic delete-on-read RPC, so any /oauth/token attempt (even with a wrong
+-- code_verifier) permanently consumes the code before PKCE is checked. Add a
+-- read-only peek RPC so the token route can validate everything (redirect_uri,
+-- client_id, resource, PKCE) *before* the code is ever consumed.
+--
+-- Security-critical: this function must only ever return the metadata needed
+-- to validate the request. It must NEVER return access_token, refresh_token,
+-- or the raw `data` payload — doing so would leak tokens without a valid PKCE
+-- verifier, which is strictly worse than the bug it fixes.
+CREATE OR REPLACE FUNCTION public.mcp_peek_oauth_auth_code(p_code text)
+ RETURNS TABLE (
+   client_id text,
+   redirect_uri text,
+   resource text,
+   code_challenge text,
+   expires_at timestamp with time zone
+ )
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+begin
+  return query
+  select
+    (c.data ->> 'clientId')::text,
+    (c.data ->> 'redirectUri')::text,
+    (c.data ->> 'resource')::text,
+    (c.data ->> 'codeChallenge')::text,
+    c.expires_at
+  from public.mcp_oauth_auth_codes c
+  where c.code = p_code
+    and c.expires_at >= now();
+end;
+$function$
+;
+
+grant execute on function public.mcp_peek_oauth_auth_code(p_code text) to anon;
+grant execute on function public.mcp_peek_oauth_auth_code(p_code text) to authenticated;
+grant execute on function public.mcp_peek_oauth_auth_code(p_code text) to service_role;


### PR DESCRIPTION
## Root cause

`handleAuthorizationCode()` in `apps/mcp/app/oauth/token/route.ts` called `exchangeAuthCode()` — which wraps the atomic delete-on-read RPC `mcp_exchange_oauth_auth_code` (`supabase/migrations/00000000000000_remote_baseline.sql:1796-1817`) — **before** verifying the PKCE `code_verifier`. Field comparisons, `validateOAuthClientRequest`, and `verifyPkce` all ran afterward.

Since the exchange RPC deletes the row as it reads it, any `/oauth/token` request carrying a victim's `code` — even with a wrong `code_verifier` — permanently burned the code. The PKCE check existed but ran too late to prevent the DoS. Closes #182 (MEDIUM).

## Fix

1. **New migration** (`supabase/migrations/2026-07-02-mcp-peek-oauth-auth-code.sql`): adds `mcp_peek_oauth_auth_code(p_code text)`, a `SECURITY DEFINER` function that **only `SELECT`s** `client_id`, `redirect_uri`, `resource`, `code_challenge`, and `expires_at` from `mcp_oauth_auth_codes`. It never deletes and never returns `access_token`/`refresh_token`/the raw `data` payload — returning tokens here would let an attacker skip PKCE entirely and steal tokens outright, which is strictly worse than the bug being fixed. Expired/missing codes return no rows. Grants mirror the existing `mcp_exchange_oauth_auth_code`/`mcp_create_oauth_auth_code` grants (anon/authenticated/service_role), and `SECURITY DEFINER` hardening (`SET search_path TO 'public'`) matches the existing RPCs.

2. **`apps/mcp/lib/auth/auth-codes.ts`**: adds `peekAuthCode()` (and a `peek()` method on the `AuthCodeStore` returned by `createAuthCodeStore()`), calling the new RPC. Returns `PeekedAuthData` — deliberately a narrower type than `StoredAuthData`, with no token fields.

3. **`apps/mcp/app/oauth/token/route.ts`**: `handleAuthorizationCode()` is reordered to **parse → peek → redirect_uri/client_id/resource checks → `validateOAuthClientRequest` → `verifyPkce` (against the peeked `code_challenge`) → only on full success, `exchangeAuthCode()` (the existing atomic delete-consume) → return token**. Any validation failure now returns before the code is ever consumed. The atomic single-use property of `mcp_exchange_oauth_auth_code` is untouched — a second request (or a race) still fails cleanly since exchange remains delete-on-read.

`handleAuthorizationCode` now takes an optional `deps` param (`peek`/`exchange`/`clientStore`) for injection in tests; production callers (`POST`) don't pass it, so production behavior is unchanged.

## Tests

New `apps/mcp/app/oauth/token/route.test.ts`, using the same fake-store/DI pattern as `oauth-clients.test.ts`:
- Wrong `code_verifier` → `peek` called once, `exchange` called **zero** times, code not consumed (the DoS regression test).
- Wrong verifier followed by the correct verifier still succeeds — proves the code survives a failed attempt.
- Correct verifier → full peek → validate → exchange → token flow.
- Unknown/expired code → `peek` returns null, `exchange` never called.

`bun test`: 51 pass / 0 fail. `bun run typecheck` and `bun run build` both green across all workspaces.

## Security note

The core safety boundary of this PR: `mcp_peek_oauth_auth_code` is read-only metadata-only — no tokens, no `data` blob, no delete. Please double check the migration's `RETURNS TABLE` column list during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)