### PR TITLE
fix(bento): mobile-first layout for add-order-item dialog

### DIFF
--- a/apps/portal/app/bento/_components/add-order-item-dialog.tsx
+++ b/apps/portal/app/bento/_components/add-order-item-dialog.tsx
@@ -224,8 +224,8 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
               </Select>
             </div>
           )}
-          <div className="flex flex-col gap-3 pb-4 sm:flex-row sm:items-center sm:gap-4">
-            <div className="flex-1">
+          <div className="flex flex-col gap-3 pb-4">
+            <div>
               <Select value={selectedItem} onValueChange={setSelectedItem}>
                 <SelectTrigger id="menuItem" className="w-full">
                   <SelectValue placeholder="選擇品項" />
@@ -294,7 +294,7 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
                     setSelectedAdditional(parseInt(value))
                   }
                 >
-                  <SelectTrigger className="w-32">
+                  <SelectTrigger className="w-full">
                     <SelectValue placeholder="選項" />
                   </SelectTrigger>
                   <SelectContent>


### PR DESCRIPTION
## Summary

- Replaced `sm:flex-row sm:items-center sm:gap-4` with a single `flex-col` column — controls (item select, 不醬 checkbox, additional option select) now always stack vertically on narrow screens instead of squeezing into one row at the 640px breakpoint.
- Changed additional-option `SelectTrigger` from hardcoded `w-32` to `w-full` so it respects the parent column width on mobile.

Fixes #237.

> Note: #238 (multi-select batch add) targets the same file. This PR makes the baseline layout mobile-first so the multi-select refactor can build on it cleanly.

## Test plan

- [ ] Open `/bento` on a phone-width viewport (375–430px) → confirm controls stack cleanly and no overflow
- [ ] Open with additional options present → confirm the option Select is full-width, not truncated
- [ ] Open on desktop (>= 768px) → controls still readable in a single column

🤖 Generated with [Claude Code](https://claude.com/claude-code)