### PR TITLE
chore(db): drop dead debit_*/egress tables and orphan functions

### DIFF
--- a/supabase/migrations/2026-07-02-drop-dead-debit-egress.sql
+++ b/supabase/migrations/2026-07-02-drop-dead-debit-egress.sql
@@ -1,0 +1,45 @@
+-- Tier 1 dead-object cleanup (audit follow-up):
+--   * debit_* tables + old un-prefixed debit functions — superseded by the debt_*
+--     rename (live /debt route uses debt_create_expense etc.)
+--   * egress / ingress tables + prevent_egress_status_change — superseded by
+--     reimburse_egress / reimburse_ingress (live lib/reimburse/*.ts)
+--   * orphan functions referencing already-dropped tables (documents/document_signers)
+--     and unbound helpers with no code/trigger/policy usage
+-- All confirmed zero code refs; no live FK points into these tables (verified
+-- against live DB). Tables dropped first so their triggers/policies release the
+-- functions; then the now-unreferenced functions.
+
+-- 1. dead tables (debit_expense_items FKs debit_expenses → items first)
+drop table if exists public.debit_expense_items;
+drop table if exists public.debit_expenses;
+drop table if exists public.debit_settlements;
+drop table if exists public.egress;
+drop table if exists public.ingress;
+
+-- 2. dead functions (by name, any signature; NO cascade — if one is still
+--    referenced by a live policy the drop errors and the whole tx rolls back,
+--    which is the safe failure mode).
+do $$
+declare r record;
+begin
+  for r in
+    select p.oid::regprocedure as sig
+    from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public'
+      and p.prokind = 'f'
+      and p.proname in (
+        -- old debit feature (replaced by debt_*)
+        'check_debtor_not_creator','is_expense_debtor','confirm_settlement_from',
+        'confirm_settlement_to','create_expense','update_expense','mark_item_paid',
+        'generate_monthly_settlements',
+        -- old egress feature (replaced by reimburse_*)
+        'prevent_egress_status_change',
+        -- orphans referencing dropped documents/document_signers tables
+        'can_sign_document','can_view_document_signers','can_view_signature_boxes',
+        -- unbound helpers (no code/trigger/policy usage)
+        'generate_short_id','has_any_role_in_system','update_invoice_invoices_updated_at'
+      )
+  loop
+    execute 'drop function if exists ' || r.sig;
+  end loop;
+end $$;


### PR DESCRIPTION
Removes schema objects with zero code references — leftovers from two feature renames plus dangling helpers. Companion to the mcp removal cleanup.

## What's dropped
**Tables** (superseded by live equivalents):
- `debit_expenses` / `debit_expense_items` / `debit_settlements` → replaced by `debt_*` (live `/debt` route)
- `egress` / `ingress` → replaced by `reimburse_egress` / `reimburse_ingress` (live `lib/reimburse/*.ts`)

**Functions** (15): old debit fns (`create_expense`, `update_expense`, `mark_item_paid`, `generate_monthly_settlements`, `confirm_settlement_from/to`, `is_expense_debtor`, `check_debtor_not_creator`), `prevent_egress_status_change`, orphans referencing dropped `documents`/`document_signers` (`can_sign_document`, `can_view_document_signers`, `can_view_signature_boxes`), and unbound helpers (`generate_short_id`, `has_any_role_in_system`, `update_invoice_invoices_updated_at`).

## Verification
- Zero `.from()`/`.rpc()` references across `portal.winlab.tw` + `bento.winlab.tw` (only in generated `database.types.ts`).
- Live DB checked: no FK from any surviving table into the dropped tables; the only policy/trigger references to the dropped functions were on the dropped tables themselves.
- Live successors intact: `debt_*`, `reimburse_*`, `has_role`, `update_updated_at_column`.

**Already applied to prod** via the `supabase-winlab` migration of the same name; this file keeps `db reset` / fresh envs consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)