### PR TITLE
chore(db): drop dead tier-2 tables and views

### DIFF
--- a/supabase/migrations/2026-07-02-drop-dead-tier2.sql
+++ b/supabase/migrations/2026-07-02-drop-dead-tier2.sql
@@ -1,0 +1,14 @@
+-- Tier 2 dead-object cleanup (audit follow-up): schema objects with zero code
+-- references across all zyx1121 + NYCU-WinLab repos (72 non-fork/non-coursework
+-- repos grepped) and no live DB dependency (no FK-in, trigger, or fn/view ref).
+--   * invoice / claims / items / images — orphaned feature tables, no consumer
+--   * pending_bot_bindings — bot-binding table, no consumer bot exists
+--   * bento_order_stats / bento_user_rankings — views with no reader (app or function)
+-- NOTE: notepads is deliberately NOT dropped — it is LIVE (temp.winlab.tw uses it).
+drop view if exists public.bento_order_stats;
+drop view if exists public.bento_user_rankings;
+drop table if exists public.invoice;
+drop table if exists public.claims;
+drop table if exists public.items;
+drop table if exists public.images;
+drop table if exists public.pending_bot_bindings;


### PR DESCRIPTION
Second dead-schema cleanup pass. All objects here have **zero code references across all zyx1121 + NYCU-WinLab repos** (72 non-fork, non-coursework repos cloned and grepped) and no live DB dependency (no FK-in, trigger, or function/view reference — verified against live DB).

## Dropped
- Tables: `invoice`, `claims`, `items`, `images` (orphaned feature tables), `pending_bot_bindings` (bot-binding table, no consumer bot exists)
- Views: `bento_order_stats`, `bento_user_rankings` (no reader — not queried by any app or function)

## Kept (correction from the scan)
- `notepads` is **live** — `temp.winlab.tw/app/[notepad]/page.tsx` queries it. NOT dropped.

**Already applied to prod** via the `supabase-winlab` migration of the same name; this file keeps `db reset` / fresh envs consistent. Companion to #243 (debit_*/egress cleanup) and the mcp removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)