### PR TITLE
chore(db): 補回 drop-bento-mcp migration 至版控

### DIFF
--- a/supabase/migrations/2026-07-02-drop-bento-mcp.sql
+++ b/supabase/migrations/2026-07-02-drop-bento-mcp.sql
@@ -1,0 +1,6 @@
+-- Remove the orphaned bento MCP OAuth tables: the bento.winlab.tw MCP server is
+-- no longer in the codebase (no routes, no edge function, no RPCs reference these),
+-- and the audit flagged bento_mcp_auth_codes as having no RLS policy (token-harvest
+-- risk). Drop auth_codes first (it FKs to clients), then clients.
+drop table if exists public.bento_mcp_auth_codes;
+drop table if exists public.bento_mcp_clients;


### PR DESCRIPTION
## Summary

補回**唯一還沒進版控**的 2026-07-02 稽核 drop migration：`2026-07-02-drop-bento-mcp`。

背景：2026-07-02 依安全稽核（#182 後續）有 4 支 dead-object 清理直接套用到線上 Supabase。其中 3 支已經陸續進版控 —— `drop-mcp-oauth`、`drop-dead-debit-egress`（#243）、`drop-dead-tier2`（#244）都已在 `main`。**只剩 `drop-bento-mcp` 還缺**，本 PR 補上它，讓版控與線上對齊。

移除的物件：`bento_mcp_auth_codes`、`bento_mcp_clients`（稽核標記 `bento_mcp_auth_codes` 無 RLS，token-harvest 風險）。SQL 從線上 `supabase_migrations.schema_migrations.statements` 原封不動取回。

## ⚠️ 注意

- 這支 SQL **已經在線上執行過**（version `20260702035807`），本 PR 只補檔，合併後不需再 apply。
- `drop ... if exists`，冪等。
- baseline（`00000000000000_remote_baseline.sql`）仍保留這些物件定義（歷史快照），此 migration 疊上去負責移除。

## 背景
- 稽核 issue：#182（已關閉）
- 手足 PR：#243、#244
