### PR TITLE
feat(gallery): polish wall UX with notifications, filters, and lightbox shortcuts

### DIFF
--- a/apps/gallery/app/_components/gallery-card.tsx
+++ b/apps/gallery/app/_components/gallery-card.tsx
@@ -15,6 +15,7 @@ import {
   IconChevronLeft,
   IconChevronRight,
   IconChevronUp,
+  IconLink,
   IconX,
 } from "@tabler/icons-react"
 
@@ -45,6 +46,7 @@ import {
 import { setGalleryReaction } from "@/app/actions"
 import { formatUploadedAt } from "@/lib/gallery/format-uploaded-at"
 import { getPolaroidFrame } from "@/lib/gallery/polaroid-frame"
+import { buildGalleryPhotoHref } from "@/lib/gallery/photo-deep-link"
 import { getRotation } from "@/lib/gallery/rotation"
 import {
   GALLERY_REACTIONS,
@@ -213,6 +215,41 @@ export function GalleryCard({
     setLightboxFailed(false)
   }, [activeIndex])
 
+  useEffect(() => {
+    if (!isDialogOpen) return
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "ArrowLeft" && isSequence) {
+        event.preventDefault()
+        setActiveIndex((idx) =>
+          idx === 0 ? sequenceMedia.length - 1 : idx - 1
+        )
+        return
+      }
+      if (event.key === "ArrowRight" && isSequence) {
+        event.preventDefault()
+        setActiveIndex((idx) => (idx + 1) % sequenceMedia.length)
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown)
+    return () => window.removeEventListener("keydown", onKeyDown)
+  }, [isDialogOpen, isSequence, sequenceMedia.length])
+
+  const copyShareLink = async () => {
+    const href = buildGalleryPhotoHref({
+      photoId: image.id,
+      commentId: highlightCommentId,
+    })
+    const url = `${window.location.origin}${href}`
+    try {
+      await navigator.clipboard.writeText(url)
+      toast.success("Link copied.")
+    } catch {
+      toast.error("Could not copy link.")
+    }
+  }
+
   const onReact = (reaction: GalleryReaction) => {
     if (!isSignedIn) {
       toast.error("Please sign in before reacting.")
@@ -349,6 +386,20 @@ export function GalleryCard({
               >
                 <IconX className="h-5 w-5" />
               </DialogClose>
+              <button
+                type="button"
+                onClick={() => void copyShareLink()}
+                aria-label="Copy share link"
+                className={cn(
+                  "absolute top-[max(env(safe-area-inset-top),0.75rem)] right-[calc(max(env(safe-area-inset-right),0.75rem)+3rem)] z-20",
+                  "inline-flex h-11 w-11 items-center justify-center rounded-full",
+                  "bg-white/85 text-foreground shadow-lg backdrop-blur-sm",
+                  "transition-colors hover:bg-white",
+                  "focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none"
+                )}
+              >
+                <IconLink className="h-5 w-5" />
+              </button>
               <div className="gallery-lightbox-layout">
                 <div className="gallery-lightbox-media">
                   {lightboxFailed ? (

--- a/apps/gallery/app/_components/gallery-comments.tsx
+++ b/apps/gallery/app/_components/gallery-comments.tsx
@@ -10,7 +10,7 @@ import { toast } from "sonner"
 
 import { addGalleryComment, deleteGalleryComment } from "@/app/actions"
 import { galleryPillClass, gallerySans } from "@/components/gallery-chrome"
-import { parseMentions } from "@/lib/gallery/mentions"
+import { FormattedCommentMentions } from "@/lib/gallery/format-comment-mentions"
 import type { GalleryComment, GalleryMember } from "@/lib/gallery/types"
 
 type CommentNode = GalleryComment & { depth: number }
@@ -182,7 +182,7 @@ export function GalleryComments({
                     </time>
                   </div>
                   <p className="mt-1.5 text-sm leading-relaxed break-words whitespace-pre-wrap text-foreground/90">
-                    <FormattedComment
+                    <FormattedCommentMentions
                       content={comment.body}
                       members={members}
                     />
@@ -307,43 +307,6 @@ export function GalleryComments({
         </div>
       </div>
     </div>
-  )
-}
-
-function FormattedComment({
-  content,
-  members,
-}: {
-  content: string
-  members: GalleryMember[]
-}) {
-  const mentionNames = new Set(parseMentions(content))
-  const knownNames = new Set(
-    members.map((m) => m.name).filter((n): n is string => Boolean(n))
-  )
-
-  if (mentionNames.size === 0) return <>{content}</>
-
-  const parts = content.split(/(@[\p{L}\p{N}._-]+)/gu)
-  return (
-    <>
-      {parts.map((part, i) => {
-        if (part.startsWith("@")) {
-          const name = part.slice(1)
-          if (mentionNames.has(name) && knownNames.has(name)) {
-            return (
-              <span
-                key={i}
-                className="rounded bg-blue-500/15 px-1 py-0.5 text-blue-700 dark:text-blue-300"
-              >
-                {part}
-              </span>
-            )
-          }
-        }
-        return <span key={i}>{part}</span>
-      })}
-    </>
   )
 }
 

--- a/apps/gallery/app/_components/gallery-home-filters.tsx
+++ b/apps/gallery/app/_components/gallery-home-filters.tsx
@@ -1,0 +1,247 @@
+"use client"
+
+import { useMemo, useTransition, type ReactNode } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
+import { IconChevronDown, IconX } from "@tabler/icons-react"
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@workspace/ui/components/dropdown-menu"
+import { cn } from "@workspace/ui/lib/utils"
+
+import { galleryNavLinkClass, gallerySans } from "@/components/gallery-chrome"
+import {
+  buildGalleryHomeHref,
+  hasActiveGalleryFilters,
+  type GalleryHomeFilters,
+  type GalleryMediaFilter,
+} from "@/lib/gallery/home-filters"
+import type { GalleryMember } from "@/lib/gallery/types"
+
+const MEDIA_OPTIONS: { value: GalleryMediaFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "image", label: "Photos" },
+  { value: "video", label: "Videos" },
+]
+
+const DATE_OPTIONS = [
+  { value: "all", label: "Any time" },
+  { value: "7d", label: "Week" },
+  { value: "30d", label: "Month" },
+  { value: "365d", label: "Year" },
+] as const
+
+function dateAfterFromPreset(preset: string): string | null {
+  const days =
+    preset === "7d" ? 7 : preset === "30d" ? 30 : preset === "365d" ? 365 : 0
+  if (!days) return null
+  const date = new Date()
+  date.setDate(date.getDate() - days)
+  return date.toISOString()
+}
+
+function datePresetFromAfter(after: string | null): string {
+  if (!after) return "all"
+  const target = new Date(after).getTime()
+  if (!Number.isFinite(target)) return "all"
+  for (const preset of ["7d", "30d", "365d"] as const) {
+    const iso = dateAfterFromPreset(preset)
+    if (!iso) continue
+    const diff = Math.abs(new Date(iso).getTime() - target)
+    if (diff < 60_000) return preset
+  }
+  return "custom"
+}
+
+function FilterDivider() {
+  return (
+    <span
+      aria-hidden
+      className="mx-0.5 hidden h-3 w-px shrink-0 bg-border/70 sm:mx-1 sm:block"
+    />
+  )
+}
+
+function FilterPill({
+  active,
+  disabled,
+  onClick,
+  children,
+}: {
+  active: boolean
+  disabled?: boolean
+  onClick: () => void
+  children: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(galleryNavLinkClass(active), disabled && "opacity-50")}
+    >
+      {children}
+    </button>
+  )
+}
+
+export function GalleryHomeFiltersBar({
+  filters,
+  members,
+}: {
+  filters: GalleryHomeFilters
+  members: GalleryMember[]
+}) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [isPending, startTransition] = useTransition()
+
+  const apply = (next: GalleryHomeFilters) => {
+    const photo = searchParams.get("photo")
+    const comment = searchParams.get("comment")
+    const href = buildGalleryHomeHref({
+      filters: next,
+      photoId: photo,
+      commentId: comment,
+    })
+    startTransition(() => {
+      router.replace(href, { scroll: false })
+    })
+  }
+
+  const datePreset = datePresetFromAfter(filters.uploadedAfter)
+  const active = hasActiveGalleryFilters(filters)
+
+  const uploaderLabel = useMemo(() => {
+    if (!filters.uploaderId) return "Anyone"
+    const member = members.find((item) => item.id === filters.uploaderId)
+    return member?.name ?? member?.email ?? "Member"
+  }, [filters.uploaderId, members])
+
+  return (
+    <nav
+      aria-label="Filter gallery"
+      className={cn(
+        gallerySans(),
+        "gallery-home-filters mb-9 flex flex-col items-center gap-3 sm:mb-10"
+      )}
+    >
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        {MEDIA_OPTIONS.map((option) => (
+          <FilterPill
+            key={option.value}
+            active={filters.media === option.value}
+            disabled={isPending}
+            onClick={() =>
+              apply({
+                ...filters,
+                media: option.value,
+              })
+            }
+          >
+            {option.label}
+          </FilterPill>
+        ))}
+
+        <FilterDivider />
+
+        {DATE_OPTIONS.map((option) => (
+          <FilterPill
+            key={option.value}
+            active={datePreset === option.value}
+            disabled={isPending}
+            onClick={() =>
+              apply({
+                ...filters,
+                uploadedAfter: dateAfterFromPreset(option.value),
+              })
+            }
+          >
+            {option.label}
+          </FilterPill>
+        ))}
+
+        <FilterDivider />
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              disabled={isPending}
+              className={cn(
+                galleryNavLinkClass(filters.uploaderId !== null),
+                "inline-flex items-center gap-1",
+                isPending && "opacity-50"
+              )}
+            >
+              <span className="max-w-[8rem] truncate sm:max-w-[10rem]">
+                {uploaderLabel}
+              </span>
+              <IconChevronDown className="size-3 shrink-0 opacity-60" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="center"
+            className={cn(gallerySans(), "max-h-64 w-48 overflow-y-auto")}
+          >
+            <DropdownMenuItem
+              className="cursor-pointer text-xs"
+              onClick={() =>
+                apply({
+                  ...filters,
+                  uploaderId: null,
+                })
+              }
+            >
+              Anyone
+            </DropdownMenuItem>
+            {members.map((member) => (
+              <DropdownMenuItem
+                key={member.id}
+                className="cursor-pointer text-xs"
+                onClick={() =>
+                  apply({
+                    ...filters,
+                    uploaderId: member.id,
+                  })
+                }
+              >
+                <span className="truncate">
+                  {member.name ?? member.email ?? "Member"}
+                </span>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {active ? (
+          <>
+            <FilterDivider />
+            <button
+              type="button"
+              disabled={isPending}
+              onClick={() =>
+                apply({
+                  uploaderId: null,
+                  media: "all",
+                  uploadedAfter: null,
+                })
+              }
+              className={cn(
+                galleryNavLinkClass(),
+                "inline-flex items-center gap-1",
+                isPending && "opacity-50"
+              )}
+            >
+              <IconX className="size-3" aria-hidden />
+              Clear
+            </button>
+          </>
+        ) : null}
+      </div>
+    </nav>
+  )
+}

--- a/apps/gallery/app/_components/gallery-pagination.tsx
+++ b/apps/gallery/app/_components/gallery-pagination.tsx
@@ -3,18 +3,23 @@ import Link from "next/link"
 import { cn } from "@workspace/ui/lib/utils"
 
 import { galleryNavLinkClass, gallerySans } from "@/components/gallery-chrome"
+import {
+  buildGalleryHomeHref,
+  type GalleryHomeFilters,
+} from "@/lib/gallery/home-filters"
 
-function buildPageHref(page: number) {
-  if (page <= 1) return "/"
-  return `/?page=${page}`
+function buildPageHref(page: number, filters?: GalleryHomeFilters) {
+  return buildGalleryHomeHref({ page, filters })
 }
 
 export function GalleryPagination({
   page,
   totalPages,
+  filters,
 }: {
   page: number
   totalPages: number
+  filters?: GalleryHomeFilters
 }) {
   if (totalPages <= 1) return null
 
@@ -31,7 +36,7 @@ export function GalleryPagination({
       )}
     >
       <Link
-        href={buildPageHref(page - 1)}
+        href={buildPageHref(page - 1, filters)}
         className={cn(
           galleryNavLinkClass(),
           page <= 1 && "pointer-events-none opacity-40"
@@ -43,7 +48,7 @@ export function GalleryPagination({
       {visible.map((p) => (
         <Link
           key={p}
-          href={buildPageHref(p)}
+          href={buildPageHref(p, filters)}
           className={galleryNavLinkClass(p === page)}
           aria-current={p === page ? "page" : undefined}
         >
@@ -51,7 +56,7 @@ export function GalleryPagination({
         </Link>
       ))}
       <Link
-        href={buildPageHref(page + 1)}
+        href={buildPageHref(page + 1, filters)}
         className={cn(
           galleryNavLinkClass(),
           page >= totalPages && "pointer-events-none opacity-40"

--- a/apps/gallery/app/actions.ts
+++ b/apps/gallery/app/actions.ts
@@ -73,6 +73,31 @@ export async function setGalleryReaction(
     if (insertError) {
       return { ok: false, error: `Reaction failed: ${insertError.message}` }
     }
+
+    const admin = createAdminClient()
+    const { data: image } = await admin
+      .from("gallery_images")
+      .select("created_by")
+      .eq("id", imageId)
+      .maybeSingle()
+
+    if (image?.created_by && image.created_by !== userId) {
+      const { error: notifyError } = await admin
+        .from("gallery_activity_notifications")
+        .insert({
+          recipient_user_id: image.created_by,
+          kind: "reaction",
+          image_id: imageId,
+          actor_user_id: userId,
+          reaction,
+        })
+      if (notifyError && notifyError.code !== "23505") {
+        console.error(
+          "[gallery] failed to save reaction notification",
+          notifyError
+        )
+      }
+    }
   }
 
   revalidatePath("/")
@@ -105,10 +130,11 @@ export async function addGalleryComment(
   const userId = claimsData?.claims?.sub
   if (!userId) return { ok: false, error: "Please sign in first." }
 
+  let parentAuthorId: string | null = null
   if (parentId) {
     const { data: parent, error: parentError } = await supabase
       .from("gallery_comments")
-      .select("id, image_id")
+      .select("id, image_id, created_by")
       .eq("id", parentId)
       .maybeSingle()
     if (parentError) {
@@ -117,6 +143,7 @@ export async function addGalleryComment(
     if (!parent || parent.image_id !== imageId) {
       return { ok: false, error: "Invalid parent comment." }
     }
+    parentAuthorId = parent.created_by
   }
 
   const { data, error } = await supabase
@@ -137,9 +164,29 @@ export async function addGalleryComment(
     }
   }
 
+  const admin = createAdminClient()
+
+  if (parentAuthorId && parentAuthorId !== userId) {
+    const { error: replyNotifyError } = await admin
+      .from("gallery_activity_notifications")
+      .insert({
+        recipient_user_id: parentAuthorId,
+        kind: "reply",
+        image_id: imageId,
+        comment_id: data.id,
+        actor_user_id: userId,
+        body: trimmed.slice(0, 200),
+      })
+    if (replyNotifyError && replyNotifyError.code !== "23505") {
+      console.error(
+        "[gallery] failed to save reply notification",
+        replyNotifyError
+      )
+    }
+  }
+
   const mentionNames = parseMentions(trimmed)
   if (mentionNames.length > 0) {
-    const admin = createAdminClient()
     const { data: profiles } = await admin
       .from("user_profiles")
       .select("id, name")
@@ -187,6 +234,38 @@ export async function deleteGalleryComment(
   }
 
   revalidatePath("/")
+  return { ok: true }
+}
+
+export async function markGalleryActivityNotificationsRead(
+  activityIds: string[]
+): Promise<ReactionActionResult> {
+  const uniqueIds = Array.from(
+    new Set(activityIds.filter((id) => typeof id === "string" && id.length > 0))
+  )
+  if (uniqueIds.length === 0) return { ok: true }
+
+  const supabase = await createClient()
+  const { data: claimsData } = await supabase.auth.getClaims()
+  const userId = claimsData?.claims?.sub
+  if (!userId) return { ok: false, error: "Please sign in first." }
+
+  const { error } = await supabase
+    .from("gallery_activity_notifications")
+    .update({ read_at: new Date().toISOString() })
+    .eq("recipient_user_id", userId)
+    .in("id", uniqueIds)
+    .is("read_at", null)
+
+  if (error) {
+    return {
+      ok: false,
+      error: `Could not mark notifications read: ${error.message}`,
+    }
+  }
+
+  revalidatePath("/", "layout")
+  revalidatePath("/upload")
   return { ok: true }
 }
 

--- a/apps/gallery/app/page.tsx
+++ b/apps/gallery/app/page.tsx
@@ -2,8 +2,10 @@ import { Suspense } from "react"
 import { redirect } from "next/navigation"
 
 import { GalleryGrid } from "@/app/_components/gallery-grid"
+import { GalleryHomeFiltersBar } from "@/app/_components/gallery-home-filters"
 import { GalleryPagination } from "@/app/_components/gallery-pagination"
 import { GalleryThemedShell } from "@/components/gallery-shell"
+import { parseGalleryHomeFilters } from "@/lib/gallery/home-filters"
 import { loadGalleryHomePage } from "@/lib/gallery/load-home-page"
 import {
   buildGalleryPhotoHref,
@@ -15,13 +17,21 @@ import { getCurrentUser } from "@/lib/user"
 export const dynamic = "force-dynamic"
 
 type GalleryHomePageProps = {
-  searchParams: Promise<{ page?: string; photo?: string; comment?: string }>
+  searchParams: Promise<{
+    page?: string
+    photo?: string
+    comment?: string
+    uploader?: string
+    media?: string
+    after?: string
+  }>
 }
 
 export default async function GalleryHomePage({
   searchParams,
 }: GalleryHomePageProps) {
-  const { page, photo, comment } = await searchParams
+  const { page, photo, comment, uploader, media, after } = await searchParams
+  const filters = parseGalleryHomeFilters({ uploader, media, after })
   const parsedPage = Number.parseInt(page ?? "1", 10)
   const requestedPage =
     Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1
@@ -56,11 +66,17 @@ export default async function GalleryHomePage({
     await loadGalleryHomePage(supabase, {
       page: loadPage,
       userId: user?.id ?? null,
+      filters,
     })
 
   return (
     <GalleryThemedShell active="home" signedIn={Boolean(user)}>
       <div className="overflow-x-clip">
+        {user ? (
+          <Suspense fallback={null}>
+            <GalleryHomeFiltersBar filters={filters} members={members} />
+          </Suspense>
+        ) : null}
         <Suspense
           fallback={
             <GalleryGrid
@@ -82,7 +98,11 @@ export default async function GalleryHomePage({
             openCommentId={openCommentId}
           />
         </Suspense>
-        <GalleryPagination page={currentPage} totalPages={totalPages} />
+        <GalleryPagination
+          page={currentPage}
+          totalPages={totalPages}
+          filters={filters}
+        />
       </div>
     </GalleryThemedShell>
   )

--- a/apps/gallery/app/upload/_components/upload-form.tsx
+++ b/apps/gallery/app/upload/_components/upload-form.tsx
@@ -30,6 +30,7 @@ type Status =
       kind: "working"
       label: string
       ratio: number
+      batch?: { current: number; total: number }
     }
 
 const PHASE_LABEL: Record<CompressPhase, string> = {
@@ -81,10 +82,23 @@ export function UploadForm() {
       const failed: string[] = []
       const sequenceId = files.length > 1 ? crypto.randomUUID() : null
 
+      const batch =
+        files.length > 1 ? { total: files.length, current: 0 } : undefined
+
       for (let i = 0; i < files.length; i++) {
         const file = files[i]!
+        const batchCurrent = i + 1
         const labelPrefix =
-          files.length > 1 ? `(${i + 1}/${files.length}) ` : ""
+          files.length > 1 ? `(${batchCurrent}/${files.length}) ` : ""
+
+        if (batch) {
+          setStatus({
+            kind: "working",
+            label: `Uploading ${batchCurrent} of ${files.length}`,
+            ratio: (i + 0.05) / files.length,
+            batch: { current: batchCurrent, total: files.length },
+          })
+        }
 
         const resolved = resolveMediaMimeType(file)
         if (!resolved) {
@@ -213,6 +227,16 @@ export function UploadForm() {
       </div>
       {status.kind === "working" ? (
         <div className="flex flex-col gap-2">
+          {status.batch ? (
+            <p
+              className={cn(
+                gallerySans(),
+                "text-sm font-medium text-foreground tabular-nums"
+              )}
+            >
+              {status.batch.current}/{status.batch.total}
+            </p>
+          ) : null}
           <p className={cn(gallerySans(), "text-sm text-muted-foreground")}>
             {status.label}
           </p>

--- a/apps/gallery/components/gallery-mention-bell.tsx
+++ b/apps/gallery/components/gallery-mention-bell.tsx
@@ -15,17 +15,24 @@ import {
 } from "@workspace/ui/components/dropdown-menu"
 import { cn } from "@workspace/ui/lib/utils"
 
-import { markGalleryMentionsRead } from "@/app/actions"
+import {
+  markGalleryActivityNotificationsRead,
+  markGalleryMentionsRead,
+} from "@/app/actions"
+import { ReactionGlyph } from "@/app/_components/reaction-glyph"
 import {
   gallerySans,
   galleryShellIconButtonClass,
 } from "@/components/gallery-chrome"
 import { formatUploadedAt } from "@/lib/gallery/format-uploaded-at"
-import {
-  fetchGalleryMentionNotification,
-  type GalleryMentionNotification,
-} from "@/lib/gallery/mention-notifications"
 import { buildGalleryPhotoHref } from "@/lib/gallery/photo-deep-link"
+import {
+  fetchGalleryActivityNotification,
+  fetchGalleryMentionNotification,
+  isActivityNotificationsUnavailable,
+  sortGalleryNotifications,
+  type GalleryNotification,
+} from "@/lib/gallery/notifications"
 import { createClient } from "@/lib/supabase/client"
 
 function truncateBody(body: string, max = 72): string {
@@ -34,11 +41,16 @@ function truncateBody(body: string, max = 72): string {
   return `${trimmed.slice(0, max - 1)}…`
 }
 
-function sortNotifications(items: GalleryMentionNotification[]) {
-  return [...items].sort(
-    (a, b) =>
-      new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-  )
+function notificationSummary(notification: GalleryNotification): string {
+  const actor = notification.actor_name
+  const work = notification.image_name
+  if (notification.kind === "mention") {
+    return `${actor} mentioned you on ${work}`
+  }
+  if (notification.kind === "reply") {
+    return `${actor} replied to your comment on ${work}`
+  }
+  return `${actor} reacted to ${work}`
 }
 
 export function GalleryMentionBell({
@@ -46,7 +58,7 @@ export function GalleryMentionBell({
   initialNotifications,
 }: {
   viewerId: string
-  initialNotifications: GalleryMentionNotification[]
+  initialNotifications: GalleryNotification[]
 }) {
   const router = useRouter()
   const [notifications, setNotifications] = useState(initialNotifications)
@@ -59,7 +71,7 @@ export function GalleryMentionBell({
 
   useEffect(() => {
     const supabase = createClient()
-    const channelName = `gallery-mentions:${viewerId}:${crypto.randomUUID()}`
+    const channelName = `gallery-notifications:${viewerId}:${crypto.randomUUID()}`
     const channel = supabase.channel(channelName)
 
     channel
@@ -83,10 +95,21 @@ export function GalleryMentionBell({
           if (!notification) return
 
           setNotifications((current) => {
-            if (current.some((item) => item.comment_id === commentId)) {
-              return current
+            const mapped: GalleryNotification = {
+              key: `mention:${notification.comment_id}`,
+              kind: "mention",
+              image_id: notification.image_id,
+              image_name: notification.image_name,
+              comment_id: notification.comment_id,
+              actor_name: notification.author_name,
+              body: notification.body,
+              reaction: null,
+              created_at: notification.created_at,
+              mention_comment_id: notification.comment_id,
+              activity_id: null,
             }
-            return sortNotifications([notification, ...current])
+            if (current.some((item) => item.key === mapped.key)) return current
+            return sortGalleryNotifications([mapped, ...current])
           })
         }
       )
@@ -105,23 +128,95 @@ export function GalleryMentionBell({
           }
           if (!row.comment_id || !row.read_at) return
           setNotifications((current) =>
-            current.filter((item) => item.comment_id !== row.comment_id)
+            current.filter((item) => item.mention_comment_id !== row.comment_id)
           )
         }
       )
-      .subscribe()
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "gallery_activity_notifications",
+          filter: `recipient_user_id=eq.${viewerId}`,
+        },
+        async (payload) => {
+          const activityId = (payload.new as { id?: string }).id
+          if (!activityId) return
+
+          const notification = await fetchGalleryActivityNotification(
+            supabase,
+            activityId,
+            viewerId
+          )
+          if (!notification) return
+
+          setNotifications((current) => {
+            if (current.some((item) => item.key === notification.key)) {
+              return current
+            }
+            return sortGalleryNotifications([notification, ...current])
+          })
+        }
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "gallery_activity_notifications",
+          filter: `recipient_user_id=eq.${viewerId}`,
+        },
+        (payload) => {
+          const row = payload.new as { id?: string; read_at?: string | null }
+          if (!row.id || !row.read_at) return
+          setNotifications((current) =>
+            current.filter((item) => item.activity_id !== row.id)
+          )
+        }
+      )
+      .subscribe((status, err) => {
+        if (
+          err &&
+          isActivityNotificationsUnavailable({
+            message: err.message,
+          })
+        ) {
+          return
+        }
+      })
 
     return () => {
       void supabase.removeChannel(channel)
     }
   }, [viewerId])
 
-  const openMention = (notification: GalleryMentionNotification) => {
+  const markRead = async (items: GalleryNotification[]) => {
+    const mentionIds = items
+      .map((item) => item.mention_comment_id)
+      .filter((id): id is string => Boolean(id))
+    const activityIds = items
+      .map((item) => item.activity_id)
+      .filter((id): id is string => Boolean(id))
+
+    const [mentionResult, activityResult] = await Promise.all([
+      mentionIds.length > 0
+        ? markGalleryMentionsRead(mentionIds)
+        : Promise.resolve({ ok: true as const }),
+      activityIds.length > 0
+        ? markGalleryActivityNotificationsRead(activityIds)
+        : Promise.resolve({ ok: true as const }),
+    ])
+
+    return mentionResult.ok && activityResult.ok
+  }
+
+  const openNotification = (notification: GalleryNotification) => {
     startTransition(async () => {
-      const result = await markGalleryMentionsRead([notification.comment_id])
-      if (!result.ok) return
+      const ok = await markRead([notification])
+      if (!ok) return
       setNotifications((current) =>
-        current.filter((item) => item.comment_id !== notification.comment_id)
+        current.filter((item) => item.key !== notification.key)
       )
       router.push(
         buildGalleryPhotoHref({
@@ -135,10 +230,8 @@ export function GalleryMentionBell({
   const markAllRead = () => {
     if (notifications.length === 0) return
     startTransition(async () => {
-      const result = await markGalleryMentionsRead(
-        notifications.map((item) => item.comment_id)
-      )
-      if (!result.ok) return
+      const ok = await markRead(notifications)
+      if (!ok) return
       setNotifications([])
     })
   }
@@ -153,8 +246,8 @@ export function GalleryMentionBell({
           className={cn(galleryShellIconButtonClass(), "relative")}
           aria-label={
             unreadCount > 0
-              ? `${unreadCount} unread mention${unreadCount === 1 ? "" : "s"}`
-              : "Mentions"
+              ? `${unreadCount} unread notification${unreadCount === 1 ? "" : "s"}`
+              : "Notifications"
           }
           disabled={isPending}
         >
@@ -176,7 +269,7 @@ export function GalleryMentionBell({
         className={cn(gallerySans(), "w-80 max-w-[calc(100vw-2rem)]")}
       >
         <DropdownMenuLabel className="flex items-center justify-between gap-2">
-          <span>Mentions</span>
+          <span>Notifications</span>
           {unreadCount > 0 ? (
             <button
               type="button"
@@ -191,24 +284,30 @@ export function GalleryMentionBell({
         <DropdownMenuSeparator />
         {unreadCount === 0 ? (
           <div className="px-2 py-3 text-xs text-muted-foreground">
-            No unread @mentions.
+            You&apos;re all caught up.
           </div>
         ) : (
           notifications.map((notification) => (
             <DropdownMenuItem
-              key={notification.comment_id}
+              key={notification.key}
               className="flex cursor-pointer flex-col items-start gap-1 py-2"
-              onClick={() => openMention(notification)}
+              onClick={() => openNotification(notification)}
               disabled={isPending}
             >
-              <span className="text-xs text-foreground">
-                <span className="font-medium">{notification.author_name}</span>
-                {" mentioned you on "}
-                <span className="font-medium">{notification.image_name}</span>
+              <span className="flex items-center gap-1.5 text-xs text-foreground">
+                {notification.kind === "reaction" && notification.reaction ? (
+                  <ReactionGlyph
+                    reaction={notification.reaction}
+                    className="shrink-0 text-sm"
+                  />
+                ) : null}
+                <span>{notificationSummary(notification)}</span>
               </span>
-              <span className="line-clamp-2 text-[11px] text-muted-foreground">
-                {truncateBody(notification.body)}
-              </span>
+              {notification.body ? (
+                <span className="line-clamp-2 text-[11px] text-muted-foreground">
+                  {truncateBody(notification.body)}
+                </span>
+              ) : null}
               <span className="text-[10px] text-muted-foreground/80">
                 {formatUploadedAt(notification.created_at)}
               </span>

--- a/apps/gallery/components/gallery-shell-nav.tsx
+++ b/apps/gallery/components/gallery-shell-nav.tsx
@@ -26,7 +26,7 @@ import {
 } from "@/components/gallery-chrome"
 import { GalleryMentionBell } from "@/components/gallery-mention-bell"
 import { SignOutButton } from "@/components/sign-out-button"
-import type { GalleryMentionNotification } from "@/lib/gallery/mention-notifications"
+import type { GalleryNotification } from "@/lib/gallery/notifications"
 
 export type GalleryShellActive = "home" | "manage"
 
@@ -39,7 +39,7 @@ export function GalleryShellNav({
   active: GalleryShellActive
   signedIn: boolean
   viewerId?: string | null
-  mentionNotifications?: GalleryMentionNotification[]
+  mentionNotifications?: GalleryNotification[]
 }) {
   return (
     <div

--- a/apps/gallery/components/gallery-shell.tsx
+++ b/apps/gallery/components/gallery-shell.tsx
@@ -18,13 +18,13 @@ import {
   GalleryShellNav,
   type GalleryShellActive,
 } from "@/components/gallery-shell-nav"
-import type { GalleryMentionNotification } from "@/lib/gallery/mention-notifications"
+import type { GalleryNotification } from "@/lib/gallery/notifications"
 import {
   GALLERY_SEASONAL_THEMES,
   type GallerySeasonalThemeId,
 } from "@/lib/gallery/seasonal-themes"
 import { getGallerySeasonalThemeId } from "@/lib/gallery/settings"
-import { loadUnreadGalleryMentions } from "@/lib/gallery/mention-notifications"
+import { loadUnreadGalleryNotifications } from "@/lib/gallery/notifications"
 import { createClient } from "@/lib/supabase/server"
 import { getCurrentUser } from "@/lib/user"
 
@@ -44,7 +44,7 @@ export function GalleryShell({
   signedIn?: boolean
   viewerId?: string | null
   seasonalThemeId?: GallerySeasonalThemeId | null
-  mentionNotifications?: GalleryMentionNotification[]
+  mentionNotifications?: GalleryNotification[]
   containerClassName?: string
 }) {
   const theme = seasonalThemeId
@@ -60,7 +60,7 @@ export function GalleryShell({
       />
       <header className="gallery-shell-header pointer-events-none">
         <div className="gallery-shell-header-inner pointer-events-auto relative mx-auto max-w-6xl px-4 pt-1.5 pb-1 sm:px-6 sm:pb-1.5">
-          <div className="gallery-shell-nav-row relative grid w-full min-h-[1.75rem] grid-cols-[auto_1fr_auto] items-center gap-2 sm:gap-3">
+          <div className="gallery-shell-nav-row relative grid min-h-[1.75rem] w-full grid-cols-[auto_1fr_auto] items-center gap-2 sm:gap-3">
             <Link
               href="/"
               className={cn(
@@ -133,7 +133,9 @@ export async function GalleryThemedShell({
   const user = await getCurrentUser()
   const [seasonalThemeId, mentionNotifications] = await Promise.all([
     getGallerySeasonalThemeId(supabase),
-    user ? loadUnreadGalleryMentions(supabase, user.id) : Promise.resolve([]),
+    user
+      ? loadUnreadGalleryNotifications(supabase, user.id)
+      : Promise.resolve([]),
   ])
 
   return (

--- a/apps/gallery/lib/gallery/format-comment-mentions.test.ts
+++ b/apps/gallery/lib/gallery/format-comment-mentions.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test"
+
+import { isGalleryMemberMention } from "@/lib/gallery/format-comment-mentions"
+import type { GalleryMember } from "@/lib/gallery/types"
+
+const members: GalleryMember[] = [
+  { id: "1", name: "Alice", email: "alice@example.com" },
+]
+
+describe("isGalleryMemberMention", () => {
+  test("matches names case-insensitively", () => {
+    expect(isGalleryMemberMention("alice", members)).toBe(true)
+    expect(isGalleryMemberMention("ALICE", members)).toBe(true)
+  })
+
+  test("rejects unknown handles", () => {
+    expect(isGalleryMemberMention("nobody", members)).toBe(false)
+  })
+})

--- a/apps/gallery/lib/gallery/format-comment-mentions.tsx
+++ b/apps/gallery/lib/gallery/format-comment-mentions.tsx
@@ -1,0 +1,57 @@
+import { parseMentions } from "@/lib/gallery/mentions"
+import type { GalleryMember } from "@/lib/gallery/types"
+
+function buildKnownMentionNames(members: GalleryMember[]): Set<string> {
+  const names = new Set<string>()
+  for (const member of members) {
+    const trimmed = member.name?.trim()
+    if (trimmed) names.add(trimmed.toLowerCase())
+  }
+  return names
+}
+
+function isKnownMention(name: string, knownLower: Set<string>): boolean {
+  return knownLower.has(name.toLowerCase())
+}
+
+export function isGalleryMemberMention(
+  name: string,
+  members: GalleryMember[]
+): boolean {
+  return buildKnownMentionNames(members).has(name.toLowerCase())
+}
+
+export function FormattedCommentMentions({
+  content,
+  members,
+}: {
+  content: string
+  members: GalleryMember[]
+}) {
+  const mentionNames = parseMentions(content)
+  const knownLower = buildKnownMentionNames(members)
+
+  if (mentionNames.length === 0) return <>{content}</>
+
+  const parts = content.split(/(@[\p{L}\p{N}._-]+)/gu)
+  return (
+    <>
+      {parts.map((part, i) => {
+        if (part.startsWith("@")) {
+          const name = part.slice(1)
+          if (isKnownMention(name, knownLower)) {
+            return (
+              <span
+                key={i}
+                className="rounded bg-blue-500/15 px-1 py-0.5 text-blue-700 dark:text-blue-300"
+              >
+                {part}
+              </span>
+            )
+          }
+        }
+        return <span key={i}>{part}</span>
+      })}
+    </>
+  )
+}

--- a/apps/gallery/lib/gallery/home-filters.test.ts
+++ b/apps/gallery/lib/gallery/home-filters.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  buildGalleryHomeHref,
+  hasActiveGalleryFilters,
+  parseGalleryHomeFilters,
+} from "@/lib/gallery/home-filters"
+
+describe("parseGalleryHomeFilters", () => {
+  test("defaults to empty filters", () => {
+    expect(parseGalleryHomeFilters({})).toEqual({
+      uploaderId: null,
+      media: "all",
+      uploadedAfter: null,
+    })
+  })
+
+  test("parses uploader, media, and after", () => {
+    expect(
+      parseGalleryHomeFilters({
+        uploader: "user-1",
+        media: "video",
+        after: "2026-01-01T00:00:00.000Z",
+      })
+    ).toEqual({
+      uploaderId: "user-1",
+      media: "video",
+      uploadedAfter: "2026-01-01T00:00:00.000Z",
+    })
+  })
+
+  test("ignores invalid media values", () => {
+    expect(parseGalleryHomeFilters({ media: "gif" }).media).toBe("all")
+  })
+})
+
+describe("hasActiveGalleryFilters", () => {
+  test("detects active filters", () => {
+    expect(
+      hasActiveGalleryFilters({
+        uploaderId: "x",
+        media: "all",
+        uploadedAfter: null,
+      })
+    ).toBe(true)
+    expect(
+      hasActiveGalleryFilters({
+        uploaderId: null,
+        media: "image",
+        uploadedAfter: null,
+      })
+    ).toBe(true)
+  })
+})
+
+describe("buildGalleryHomeHref", () => {
+  test("builds filter and deep-link query string", () => {
+    expect(
+      buildGalleryHomeHref({
+        page: 2,
+        photoId: "photo-1",
+        commentId: "comment-1",
+        filters: {
+          uploaderId: "user-1",
+          media: "image",
+          uploadedAfter: "2026-01-01T00:00:00.000Z",
+        },
+      })
+    ).toBe(
+      "/?page=2&uploader=user-1&media=image&after=2026-01-01T00%3A00%3A00.000Z&photo=photo-1&comment=comment-1"
+    )
+  })
+})

--- a/apps/gallery/lib/gallery/home-filters.ts
+++ b/apps/gallery/lib/gallery/home-filters.ts
@@ -1,0 +1,57 @@
+export type GalleryMediaFilter = "all" | "image" | "video"
+
+export type GalleryHomeFilters = {
+  uploaderId: string | null
+  media: GalleryMediaFilter
+  uploadedAfter: string | null
+}
+
+export const EMPTY_GALLERY_HOME_FILTERS: GalleryHomeFilters = {
+  uploaderId: null,
+  media: "all",
+  uploadedAfter: null,
+}
+
+export function parseGalleryHomeFilters(params: {
+  uploader?: string
+  media?: string
+  after?: string
+}): GalleryHomeFilters {
+  const media =
+    params.media === "image" || params.media === "video" ? params.media : "all"
+  const uploaderId = params.uploader?.trim() || null
+  const uploadedAfter = params.after?.trim() || null
+  return { uploaderId, media, uploadedAfter }
+}
+
+export function hasActiveGalleryFilters(filters: GalleryHomeFilters): boolean {
+  return (
+    filters.uploaderId !== null ||
+    filters.media !== "all" ||
+    filters.uploadedAfter !== null
+  )
+}
+
+export function buildGalleryHomeHref({
+  page,
+  photoId,
+  commentId,
+  filters,
+}: {
+  page?: number
+  photoId?: string | null
+  commentId?: string | null
+  filters?: GalleryHomeFilters
+}): string {
+  const params = new URLSearchParams()
+  if (page && page > 1) params.set("page", String(page))
+  if (filters?.uploaderId) params.set("uploader", filters.uploaderId)
+  if (filters?.media && filters.media !== "all") {
+    params.set("media", filters.media)
+  }
+  if (filters?.uploadedAfter) params.set("after", filters.uploadedAfter)
+  if (photoId) params.set("photo", photoId)
+  if (commentId) params.set("comment", commentId)
+  const qs = params.toString()
+  return qs ? `/?${qs}` : "/"
+}

--- a/apps/gallery/lib/gallery/load-home-page.ts
+++ b/apps/gallery/lib/gallery/load-home-page.ts
@@ -11,6 +11,7 @@ import type {
   GalleryImage,
   GalleryMember,
 } from "@/lib/gallery/types"
+import type { GalleryHomeFilters } from "@/lib/gallery/home-filters"
 
 export const GALLERY_PAGE_SIZE = 36
 
@@ -55,9 +56,11 @@ export async function loadGalleryHomePage(
   {
     page,
     userId,
+    filters = { uploaderId: null, media: "all", uploadedAfter: null },
   }: {
     page: number
     userId: string | null
+    filters?: GalleryHomeFilters
   }
 ): Promise<{
   images: GalleryImage[]
@@ -76,15 +79,27 @@ export async function loadGalleryHomePage(
           .select("id, name, email")
           .order("name", { ascending: true })
       : Promise.resolve({ data: [] as ProfileRow[], error: null }),
-    supabase
-      .from("gallery_images")
-      .select(
-        "id, name, image_path, media_type, poster_path, duration_seconds, created_by, created_at, sequence_id, sequence_index",
-        { count: "exact" }
-      )
-      .or("sequence_id.is.null,sequence_index.eq.0")
-      .order("created_at", { ascending: false })
-      .range(from, to),
+    (() => {
+      let query = supabase
+        .from("gallery_images")
+        .select(
+          "id, name, image_path, media_type, poster_path, duration_seconds, created_by, created_at, sequence_id, sequence_index",
+          { count: "exact" }
+        )
+        .or("sequence_id.is.null,sequence_index.eq.0")
+
+      if (filters.uploaderId) {
+        query = query.eq("created_by", filters.uploaderId)
+      }
+      if (filters.media === "image" || filters.media === "video") {
+        query = query.eq("media_type", filters.media)
+      }
+      if (filters.uploadedAfter) {
+        query = query.gte("created_at", filters.uploadedAfter)
+      }
+
+      return query.order("created_at", { ascending: false }).range(from, to)
+    })(),
   ])
 
   if (imagesResult.error) {

--- a/apps/gallery/lib/gallery/notifications.ts
+++ b/apps/gallery/lib/gallery/notifications.ts
@@ -1,0 +1,156 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import type { GalleryReaction } from "@/lib/gallery/reactions"
+import {
+  fetchGalleryMentionNotification,
+  loadUnreadGalleryMentions,
+  type GalleryMentionNotification,
+} from "@/lib/gallery/mention-notifications"
+
+export type GalleryNotificationKind = "mention" | "reply" | "reaction"
+
+export type GalleryNotification = {
+  key: string
+  kind: GalleryNotificationKind
+  image_id: string
+  image_name: string
+  comment_id: string | null
+  actor_name: string
+  body: string | null
+  reaction: GalleryReaction | null
+  created_at: string
+  mention_comment_id: string | null
+  activity_id: string | null
+}
+
+type ActivityRow = {
+  id: string
+  kind: "reply" | "reaction"
+  image_id: string
+  comment_id: string | null
+  reaction: string | null
+  body: string | null
+  created_at: string
+  gallery_images: { id: string; name: string } | null
+  user_profiles: { name: string | null } | null
+}
+
+const ACTIVITY_SELECT = `
+  id,
+  kind,
+  image_id,
+  comment_id,
+  reaction,
+  body,
+  created_at,
+  gallery_images!inner(id, name),
+  user_profiles!gallery_activity_notifications_actor_user_id_fkey(name)
+`
+
+function mapMention(n: GalleryMentionNotification): GalleryNotification {
+  return {
+    key: `mention:${n.comment_id}`,
+    kind: "mention",
+    image_id: n.image_id,
+    image_name: n.image_name,
+    comment_id: n.comment_id,
+    actor_name: n.author_name,
+    body: n.body,
+    reaction: null,
+    created_at: n.created_at,
+    mention_comment_id: n.comment_id,
+    activity_id: null,
+  }
+}
+
+function mapActivity(row: ActivityRow): GalleryNotification | null {
+  return {
+    key: `${row.kind}:${row.id}`,
+    kind: row.kind,
+    image_id: row.image_id,
+    image_name: row.gallery_images?.name ?? "Photo",
+    comment_id: row.comment_id,
+    actor_name: row.user_profiles?.name?.trim() || "Someone",
+    body: row.body,
+    reaction: (row.reaction as GalleryReaction | null) ?? null,
+    created_at: row.created_at,
+    mention_comment_id: null,
+    activity_id: row.id,
+  }
+}
+
+export function sortGalleryNotifications(
+  items: GalleryNotification[]
+): GalleryNotification[] {
+  return [...items].sort(
+    (a, b) =>
+      new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+  )
+}
+
+export async function loadUnreadGalleryNotifications(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<GalleryNotification[]> {
+  const [mentions, activityResult] = await Promise.all([
+    loadUnreadGalleryMentions(supabase, userId),
+    supabase
+      .from("gallery_activity_notifications")
+      .select(ACTIVITY_SELECT)
+      .eq("recipient_user_id", userId)
+      .is("read_at", null)
+      .order("created_at", { ascending: false }),
+  ])
+
+  const activityRows: GalleryNotification[] = []
+  if (activityResult.error) {
+    if (!isActivityNotificationsUnavailable(activityResult.error)) {
+      console.error(
+        "[gallery] failed to load activity notifications",
+        activityResult.error
+      )
+    }
+  } else {
+    for (const row of (activityResult.data ?? []) as unknown as ActivityRow[]) {
+      const mapped = mapActivity(row)
+      if (mapped) activityRows.push(mapped)
+    }
+  }
+
+  return sortGalleryNotifications([
+    ...mentions.map(mapMention),
+    ...activityRows,
+  ])
+}
+
+export function isActivityNotificationsUnavailable(
+  error: { code?: string; message?: string } | null
+): boolean {
+  if (!error) return false
+  const message = error.message ?? ""
+  return (
+    error.code === "PGRST205" ||
+    error.code === "42P01" ||
+    /gallery_activity_notifications/i.test(message) ||
+    /schema cache/i.test(message)
+  )
+}
+
+export async function fetchGalleryActivityNotification(
+  supabase: SupabaseClient,
+  activityId: string,
+  userId: string
+): Promise<GalleryNotification | null> {
+  const { data, error } = await supabase
+    .from("gallery_activity_notifications")
+    .select(ACTIVITY_SELECT)
+    .eq("id", activityId)
+    .eq("recipient_user_id", userId)
+    .is("read_at", null)
+    .maybeSingle()
+
+  if (error || !data) return null
+  return mapActivity(data as unknown as ActivityRow)
+}
+
+export { fetchGalleryMentionNotification }

--- a/supabase/migrations/2026-06-30-gallery-activity-notifications.sql
+++ b/supabase/migrations/2026-06-30-gallery-activity-notifications.sql
@@ -1,0 +1,50 @@
+-- In-app notifications for comment replies and photo reactions.
+
+create table if not exists public.gallery_activity_notifications (
+  id uuid primary key default gen_random_uuid(),
+  recipient_user_id uuid not null references public.user_profiles(id) on delete cascade,
+  kind text not null check (kind in ('reply', 'reaction')),
+  image_id uuid not null references public.gallery_images(id) on delete cascade,
+  comment_id uuid references public.gallery_comments(id) on delete cascade,
+  actor_user_id uuid not null references public.user_profiles(id) on delete cascade,
+  reaction text,
+  body text,
+  read_at timestamptz,
+  created_at timestamptz not null default now(),
+  constraint gallery_activity_reply_needs_comment check (
+    kind <> 'reply' or comment_id is not null
+  ),
+  constraint gallery_activity_reaction_check check (
+    kind <> 'reaction'
+    or reaction = any (
+      array['like'::text, 'love'::text, 'haha'::text, 'wow'::text, 'sad'::text, 'angry'::text, 'point'::text, 'cheers'::text]
+    )
+  )
+);
+
+create unique index if not exists gallery_activity_reply_unique
+  on public.gallery_activity_notifications (comment_id, recipient_user_id)
+  where (kind = 'reply');
+
+create unique index if not exists gallery_activity_reaction_unique
+  on public.gallery_activity_notifications (image_id, actor_user_id, recipient_user_id)
+  where (kind = 'reaction');
+
+create index if not exists gallery_activity_notifications_unread
+  on public.gallery_activity_notifications (recipient_user_id, created_at desc)
+  where (read_at is null);
+
+alter table public.gallery_activity_notifications enable row level security;
+
+create policy "gallery_activity_notifications_select"
+on public.gallery_activity_notifications for select
+to authenticated
+using (true);
+
+create policy "gallery_activity_notifications_update_own_read"
+on public.gallery_activity_notifications for update
+to authenticated
+using (recipient_user_id = auth.uid())
+with check (recipient_user_id = auth.uid());
+
+alter publication supabase_realtime add table public.gallery_activity_notifications;


### PR DESCRIPTION
Closes #246

## Summary
- Expand notification bell beyond @mentions to comment replies and photo reactions (new `gallery_activity_notifications` table + Realtime)
- Lightbox: one-click copy share link, arrow keys for sequences
- Home wall filters (uploader / media / date) with pill UI matching pagination style
- Multi-file upload shows batch progress (e.g. 3/10)
- Case-insensitive @mention highlight in comments

## Test plan
- [ ] Apply migration `2026-06-30-gallery-activity-notifications.sql` and enable Realtime on the new table
- [ ] Reply to someone else's comment → recipient sees notification in bell; click opens photo + comment
- [ ] React to someone else's photo → uploader sees reaction notification
- [ ] Copy link from lightbox → paste opens correct photo (and comment when deep-linked)
- [ ] Arrow keys navigate sequence in lightbox; Esc closes
- [ ] Filter pills narrow the wall; pagination preserves filter query params
- [ ] Multi-file upload shows N/M counter
- [ ] `@mention` highlights regardless of case
- [ ] `bun test` and `bun run typecheck` in `apps/gallery`

Made with [Cursor](https://cursor.com)