### PR TITLE
feat(gallery): comment editing, manage tools, and lightbox UX batch

### DIFF
--- a/apps/gallery/app/_components/gallery-card.tsx
+++ b/apps/gallery/app/_components/gallery-card.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import {
+  useCallback,
   useEffect,
   useState,
   useTransition,
@@ -15,6 +16,7 @@ import {
   IconChevronLeft,
   IconChevronRight,
   IconChevronUp,
+  IconDownload,
   IconLink,
   IconX,
 } from "@tabler/icons-react"
@@ -36,6 +38,7 @@ import { toast } from "sonner"
 
 import { ReactionBar } from "@/app/_components/reaction-bar"
 import { GalleryComments } from "@/app/_components/gallery-comments"
+import { UploaderFilterLink } from "@/app/_components/uploader-filter-link"
 import { ReactionGlyph } from "@/app/_components/reaction-glyph"
 import {
   galleryPillClass,
@@ -47,6 +50,7 @@ import { setGalleryReaction } from "@/app/actions"
 import { formatUploadedAt } from "@/lib/gallery/format-uploaded-at"
 import { getPolaroidFrame } from "@/lib/gallery/polaroid-frame"
 import { buildGalleryPhotoHref } from "@/lib/gallery/photo-deep-link"
+import { loadLightboxSocial } from "@/lib/gallery/lightbox-social"
 import { getRotation } from "@/lib/gallery/rotation"
 import {
   GALLERY_REACTIONS,
@@ -62,6 +66,7 @@ import type {
   GallerySequenceItem,
 } from "@/lib/gallery/types"
 import { getGalleryImageUrl, getGalleryThumbUrl } from "@/lib/gallery/url"
+import { createClient } from "@/lib/supabase/client"
 
 function applyReactionOptimistic(
   prev: GalleryReaction | null,
@@ -134,6 +139,9 @@ export function GalleryCard({
   priorityLcp = false,
   initialOpen = false,
   highlightCommentId = null,
+  open,
+  onOpenChange,
+  gridFocused = false,
 }: {
   image: GalleryImage
   isSignedIn: boolean
@@ -143,6 +151,9 @@ export function GalleryCard({
   priorityLcp?: boolean
   initialOpen?: boolean
   highlightCommentId?: string | null
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+  gridFocused?: boolean
 }) {
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -162,7 +173,19 @@ export function GalleryCard({
           },
         ]
   const isSequence = sequenceMedia.length > 1
-  const [isDialogOpen, setIsDialogOpen] = useState(initialOpen)
+  const [internalOpen, setInternalOpen] = useState(initialOpen)
+  const isDialogOpen = open !== undefined ? open : internalOpen
+  const setIsDialogOpen = (next: boolean) => {
+    onOpenChange?.(next)
+    if (open === undefined) setInternalOpen(next)
+    if (next) return
+    if (!searchParams.has("photo")) return
+    const params = new URLSearchParams(searchParams.toString())
+    params.delete("photo")
+    params.delete("comment")
+    const qs = params.toString()
+    router.replace(qs ? `/?${qs}` : "/", { scroll: false })
+  }
   const [mobileDetailsOpen, setMobileDetailsOpen] = useState(false)
   const [activeIndex, setActiveIndex] = useState(0)
   const activeItem = sequenceMedia[activeIndex] ?? sequenceMedia[0]
@@ -186,23 +209,62 @@ export function GalleryCard({
   }, [image.comments])
 
   useEffect(() => {
-    if (initialOpen) {
-      setIsDialogOpen(true)
-      if (highlightCommentId) setMobileDetailsOpen(true)
+    if (open && highlightCommentId) {
+      setMobileDetailsOpen(true)
     }
-  }, [initialOpen, highlightCommentId])
+  }, [open, highlightCommentId])
 
-  const handleDialogOpenChange = (open: boolean) => {
-    setIsDialogOpen(open)
-    if (open) return
-    if (!searchParams.has("photo")) return
-
-    const params = new URLSearchParams(searchParams.toString())
-    params.delete("photo")
-    params.delete("comment")
-    const qs = params.toString()
-    router.replace(qs ? `/?${qs}` : "/", { scroll: false })
+  const handleDialogOpenChange = (next: boolean) => {
+    setIsDialogOpen(next)
   }
+
+  const refreshSocial = useCallback(async () => {
+    const supabase = createClient()
+    const social = await loadLightboxSocial(supabase, image.id, viewerId)
+    setComments(social.comments)
+    setCounts(social.reaction_counts)
+    setNamesByReaction(social.reaction_names)
+    setMyReaction(social.my_reaction)
+  }, [image.id, viewerId])
+
+  useEffect(() => {
+    if (!isDialogOpen) return
+
+    const supabase = createClient()
+    const channelName = `gallery-lightbox:${image.id}:${crypto.randomUUID()}`
+    const channel = supabase.channel(channelName)
+
+    const onChange = () => {
+      void refreshSocial()
+    }
+
+    channel
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "gallery_comments",
+          filter: `image_id=eq.${image.id}`,
+        },
+        onChange
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "gallery_image_votes",
+          filter: `image_id=eq.${image.id}`,
+        },
+        onChange
+      )
+      .subscribe()
+
+    return () => {
+      void supabase.removeChannel(channel)
+    }
+  }, [isDialogOpen, image.id, refreshSocial])
 
   useEffect(() => {
     if (isDialogOpen) return
@@ -278,7 +340,14 @@ export function GalleryCard({
   }
 
   return (
-    <figure className={cn("mx-auto w-full sm:max-w-none", frame.maxWidthClass)}>
+    <figure
+      className={cn(
+        "mx-auto w-full sm:max-w-none",
+        frame.maxWidthClass,
+        gridFocused &&
+          "rounded-sm ring-2 ring-ring ring-offset-2 ring-offset-background"
+      )}
+    >
       <div className="flex justify-center px-3 py-3 sm:px-4 sm:py-4">
         <div
           className={cn(
@@ -294,12 +363,12 @@ export function GalleryCard({
           }
         >
           <Dialog open={isDialogOpen} onOpenChange={handleDialogOpenChange}>
-            <DialogTrigger asChild>
-              <button
-                type="button"
-                className="block w-full rounded-[2px] text-left outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-              >
-                <div className={galleryPolaroidClass()}>
+            <div className={galleryPolaroidClass()}>
+              <DialogTrigger asChild>
+                <button
+                  type="button"
+                  className="block w-full rounded-[2px] text-left outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                >
                   {thumbFailed ? (
                     <div
                       className={cn(
@@ -338,7 +407,7 @@ export function GalleryCard({
                       ) : null}
                     </div>
                   )}
-                  <div className="gallery-polaroid-caption px-3 pt-3 pb-4">
+                  <div className="gallery-polaroid-caption px-3 pt-3 pb-2">
                     <p
                       className={cn(
                         gallerySerif(),
@@ -347,18 +416,27 @@ export function GalleryCard({
                     >
                       {image.name}
                     </p>
-                    <p
-                      className={cn(
-                        gallerySans(),
-                        "mt-1 truncate text-center text-[10px] text-muted-foreground"
-                      )}
-                    >
-                      {image.uploader_name}
-                    </p>
                   </div>
-                </div>
-              </button>
-            </DialogTrigger>
+                </button>
+              </DialogTrigger>
+              <p
+                className={cn(
+                  gallerySans(),
+                  "truncate px-3 pb-4 text-center text-[10px] text-muted-foreground"
+                )}
+              >
+                {image.created_by && isSignedIn ? (
+                  <UploaderFilterLink
+                    uploaderId={image.created_by}
+                    className="text-muted-foreground"
+                  >
+                    {image.uploader_name}
+                  </UploaderFilterLink>
+                ) : (
+                  image.uploader_name
+                )}
+              </p>
+            </div>
             <DialogContent
               showCloseButton={false}
               className={cn(
@@ -391,7 +469,10 @@ export function GalleryCard({
                 onClick={() => void copyShareLink()}
                 aria-label="Copy share link"
                 className={cn(
-                  "absolute top-[max(env(safe-area-inset-top),0.75rem)] right-[calc(max(env(safe-area-inset-right),0.75rem)+3rem)] z-20",
+                  "absolute top-[max(env(safe-area-inset-top),0.75rem)] z-20",
+                  isSignedIn
+                    ? "right-[calc(max(env(safe-area-inset-right),0.75rem)+6rem)]"
+                    : "right-[calc(max(env(safe-area-inset-right),0.75rem)+3rem)]",
                   "inline-flex h-11 w-11 items-center justify-center rounded-full",
                   "bg-white/85 text-foreground shadow-lg backdrop-blur-sm",
                   "transition-colors hover:bg-white",
@@ -400,6 +481,22 @@ export function GalleryCard({
               >
                 <IconLink className="h-5 w-5" />
               </button>
+              {isSignedIn ? (
+                <a
+                  href={mediaUrl}
+                  download
+                  aria-label="Save original"
+                  className={cn(
+                    "absolute top-[max(env(safe-area-inset-top),0.75rem)] right-[calc(max(env(safe-area-inset-right),0.75rem)+3rem)] z-20",
+                    "inline-flex h-11 w-11 items-center justify-center rounded-full",
+                    "bg-white/85 text-foreground shadow-lg backdrop-blur-sm",
+                    "transition-colors hover:bg-white",
+                    "focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none"
+                  )}
+                >
+                  <IconDownload className="h-5 w-5" />
+                </a>
+              ) : null}
               <div className="gallery-lightbox-layout">
                 <div className="gallery-lightbox-media">
                   {lightboxFailed ? (
@@ -534,7 +631,14 @@ export function GalleryCard({
                           "text-xs text-muted-foreground"
                         )}
                       >
-                        by {image.uploader_name}
+                        by{" "}
+                        {image.created_by && isSignedIn ? (
+                          <UploaderFilterLink uploaderId={image.created_by}>
+                            {image.uploader_name}
+                          </UploaderFilterLink>
+                        ) : (
+                          image.uploader_name
+                        )}
                         {uploadedAt ? (
                           <>
                             <span aria-hidden> · </span>

--- a/apps/gallery/app/_components/gallery-comments.tsx
+++ b/apps/gallery/app/_components/gallery-comments.tsx
@@ -3,12 +3,26 @@
 import { useEffect, useMemo, useRef, useState, useTransition } from "react"
 
 import { Avatar, AvatarFallback } from "@workspace/ui/components/avatar"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@workspace/ui/components/alert-dialog"
 import { Button } from "@workspace/ui/components/button"
 import { Textarea } from "@workspace/ui/components/textarea"
 import { cn } from "@workspace/ui/lib/utils"
 import { toast } from "sonner"
 
-import { addGalleryComment, deleteGalleryComment } from "@/app/actions"
+import {
+  addGalleryComment,
+  deleteGalleryComment,
+  updateGalleryComment,
+} from "@/app/actions"
 import { galleryPillClass, gallerySans } from "@/components/gallery-chrome"
 import { FormattedCommentMentions } from "@/lib/gallery/format-comment-mentions"
 import type { GalleryComment, GalleryMember } from "@/lib/gallery/types"
@@ -36,6 +50,9 @@ export function GalleryComments({
 }) {
   const [draft, setDraft] = useState("")
   const [replyTarget, setReplyTarget] = useState<string | null>(null)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editDraft, setEditDraft] = useState("")
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null)
   const [mentionQuery, setMentionQuery] = useState<string | null>(null)
   const [highlightedId, setHighlightedId] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
@@ -123,6 +140,7 @@ export function GalleryComments({
         {
           ...result.data,
           commenter_name: viewerName,
+          updated_at: result.data.updated_at ?? null,
         },
       ])
       setDraft("")
@@ -140,7 +158,50 @@ export function GalleryComments({
         return
       }
       onCommentsChange(removeCommentWithDescendants(comments, commentId))
+      if (editingId === commentId) {
+        setEditingId(null)
+        setEditDraft("")
+      }
       toast.success("Comment deleted.")
+    })
+  }
+
+  const startEdit = (comment: GalleryComment) => {
+    setReplyTarget(null)
+    setEditingId(comment.id)
+    setEditDraft(comment.body)
+    setMentionQuery(null)
+  }
+
+  const cancelEdit = () => {
+    setEditingId(null)
+    setEditDraft("")
+  }
+
+  const saveEdit = (commentId: string) => {
+    const body = editDraft.trim()
+    if (!body) return
+
+    startTransition(async () => {
+      const result = await updateGalleryComment(commentId, body)
+      if (!result.ok) {
+        toast.error(result.error)
+        return
+      }
+      onCommentsChange(
+        comments.map((comment) =>
+          comment.id === commentId
+            ? {
+                ...comment,
+                body: result.data.body,
+                updated_at: result.data.updated_at,
+              }
+            : comment
+        )
+      )
+      setEditingId(null)
+      setEditDraft("")
+      toast.success("Comment updated.")
     })
   }
 
@@ -158,6 +219,8 @@ export function GalleryComments({
           <ul className="space-y-2.5">
             {flattened.map((comment) => {
               const mine = viewerId === comment.created_by
+              const isEditing = editingId === comment.id
+              const edited = isCommentEdited(comment)
               return (
                 <li
                   key={comment.id}
@@ -180,36 +243,86 @@ export function GalleryComments({
                         timeStyle: "short",
                       })}
                     </time>
-                  </div>
-                  <p className="mt-1.5 text-sm leading-relaxed break-words whitespace-pre-wrap text-foreground/90">
-                    <FormattedCommentMentions
-                      content={comment.body}
-                      members={members}
-                    />
-                  </p>
-                  <div className="mt-2 flex items-center gap-2">
-                    {isSignedIn ? (
-                      <button
-                        type="button"
-                        onClick={() => setReplyTarget(comment.id)}
-                        className={galleryPillClass()}
-                      >
-                        Reply
-                      </button>
-                    ) : null}
-                    {mine ? (
-                      <button
-                        type="button"
-                        onClick={() => removeComment(comment.id)}
-                        className={cn(
-                          galleryPillClass(),
-                          "text-destructive/90 hover:text-destructive"
-                        )}
-                      >
-                        Delete
-                      </button>
+                    {edited ? (
+                      <>
+                        <span aria-hidden>·</span>
+                        <span>edited</span>
+                      </>
                     ) : null}
                   </div>
+                  {isEditing ? (
+                    <div className="mt-1.5 space-y-2">
+                      <Textarea
+                        value={editDraft}
+                        onChange={(e) => setEditDraft(e.target.value)}
+                        disabled={isPending}
+                        className="min-h-[3.25rem] resize-none rounded-xl border-border/60 bg-background text-sm"
+                      />
+                      <div className="flex items-center gap-2">
+                        <Button
+                          type="button"
+                          size="sm"
+                          className={cn(
+                            gallerySans(),
+                            "h-8 rounded-full px-3 text-xs"
+                          )}
+                          disabled={isPending || !editDraft.trim()}
+                          onClick={() => saveEdit(comment.id)}
+                        >
+                          Save
+                        </Button>
+                        <button
+                          type="button"
+                          onClick={cancelEdit}
+                          disabled={isPending}
+                          className={galleryPillClass()}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <p className="mt-1.5 text-sm leading-relaxed break-words whitespace-pre-wrap text-foreground/90">
+                      <FormattedCommentMentions
+                        content={comment.body}
+                        members={members}
+                      />
+                    </p>
+                  )}
+                  {!isEditing ? (
+                    <div className="mt-2 flex items-center gap-2">
+                      {isSignedIn ? (
+                        <button
+                          type="button"
+                          onClick={() => setReplyTarget(comment.id)}
+                          className={galleryPillClass()}
+                        >
+                          Reply
+                        </button>
+                      ) : null}
+                      {mine ? (
+                        <>
+                          <button
+                            type="button"
+                            onClick={() => startEdit(comment)}
+                            className={galleryPillClass()}
+                          >
+                            Edit
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setDeleteTargetId(comment.id)}
+                            className={cn(
+                              galleryPillClass(),
+                              "text-destructive/90 hover:text-destructive"
+                            )}
+                          >
+                            Delete
+                          </button>
+                        </>
+                      ) : null}
+                    </div>
+                  ) : null}
                 </li>
               )
             })}
@@ -306,7 +419,43 @@ export function GalleryComments({
           </Button>
         </div>
       </div>
+
+      <AlertDialog
+        open={deleteTargetId !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTargetId(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this comment?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes the comment and any replies. Cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (!deleteTargetId) return
+                removeComment(deleteTargetId)
+                setDeleteTargetId(null)
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
+  )
+}
+
+function isCommentEdited(comment: GalleryComment): boolean {
+  if (!comment.updated_at) return false
+  return (
+    new Date(comment.updated_at).getTime() >
+    new Date(comment.created_at).getTime()
   )
 }
 

--- a/apps/gallery/app/_components/gallery-grid.tsx
+++ b/apps/gallery/app/_components/gallery-grid.tsx
@@ -1,8 +1,21 @@
 "use client"
 
+import { useEffect, useState } from "react"
+
 import { GalleryCard } from "@/app/_components/gallery-card"
 import { GalleryEmptyState } from "@/components/gallery-chrome"
 import type { GalleryImage, GalleryMember } from "@/lib/gallery/types"
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  const tag = target.tagName
+  return (
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT" ||
+    target.isContentEditable
+  )
+}
 
 export function GalleryGrid({
   images,
@@ -21,6 +34,56 @@ export function GalleryGrid({
   openPhotoId?: string | null
   openCommentId?: string | null
 }) {
+  const [focusIndex, setFocusIndex] = useState(() => {
+    if (!openPhotoId) return -1
+    const index = images.findIndex((image) => image.id === openPhotoId)
+    return index >= 0 ? index : -1
+  })
+  const [keyboardNavActive, setKeyboardNavActive] = useState(false)
+  const [openIndex, setOpenIndex] = useState<number | null>(() => {
+    if (!openPhotoId) return null
+    const index = images.findIndex((image) => image.id === openPhotoId)
+    return index >= 0 ? index : null
+  })
+
+  useEffect(() => {
+    if (!openPhotoId) return
+    const index = images.findIndex((image) => image.id === openPhotoId)
+    if (index >= 0) {
+      setFocusIndex(index)
+      setOpenIndex(index)
+    }
+  }, [images, openPhotoId])
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (isTypingTarget(event.target)) return
+      if (openIndex !== null) return
+
+      if (event.key === "j" || event.key === "ArrowRight") {
+        event.preventDefault()
+        setKeyboardNavActive(true)
+        setFocusIndex((index) =>
+          Math.min(images.length - 1, Math.max(0, index + 1))
+        )
+        return
+      }
+      if (event.key === "k" || event.key === "ArrowLeft") {
+        event.preventDefault()
+        setKeyboardNavActive(true)
+        setFocusIndex((index) => Math.max(0, index - 1))
+        return
+      }
+      if (event.key === "Enter" && focusIndex >= 0) {
+        event.preventDefault()
+        setOpenIndex(focusIndex)
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown)
+    return () => window.removeEventListener("keydown", onKeyDown)
+  }, [focusIndex, images.length, openIndex])
+
   if (images.length === 0) {
     return (
       <GalleryEmptyState
@@ -31,7 +94,10 @@ export function GalleryGrid({
   }
 
   return (
-    <div className="grid grid-cols-1 gap-x-5 gap-y-9 sm:grid-cols-2 sm:gap-x-7 sm:gap-y-11 lg:grid-cols-3 lg:gap-x-8 lg:gap-y-12">
+    <div
+      className="grid grid-cols-1 gap-x-5 gap-y-9 sm:grid-cols-2 sm:gap-x-7 sm:gap-y-11 lg:grid-cols-3 lg:gap-x-8 lg:gap-y-12"
+      aria-label="Gallery wall"
+    >
       {images.map((image, index) => (
         <div key={image.id} className="w-full max-w-full">
           <GalleryCard
@@ -41,8 +107,16 @@ export function GalleryGrid({
             viewerName={viewerName}
             members={members}
             priorityLcp={index === 0}
-            initialOpen={openPhotoId === image.id}
+            initialOpen={false}
             highlightCommentId={openPhotoId === image.id ? openCommentId : null}
+            open={openIndex === index}
+            onOpenChange={(open) => {
+              if (open) setOpenIndex(index)
+              else setOpenIndex(null)
+            }}
+            gridFocused={
+              keyboardNavActive && focusIndex === index && openIndex === null
+            }
           />
         </div>
       ))}

--- a/apps/gallery/app/_components/uploader-filter-link.tsx
+++ b/apps/gallery/app/_components/uploader-filter-link.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import type { ReactNode } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
+
+import { cn } from "@workspace/ui/lib/utils"
+
+import { gallerySans } from "@/components/gallery-chrome"
+import { buildGalleryHomeHref } from "@/lib/gallery/home-filters"
+
+export function UploaderFilterLink({
+  uploaderId,
+  className,
+  children,
+}: {
+  uploaderId: string
+  className?: string
+  children: ReactNode
+}) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const applyFilter = () => {
+    const href = buildGalleryHomeHref({
+      filters: {
+        uploaderId,
+        media: "all",
+        uploadedAfter: null,
+      },
+      photoId: searchParams.get("photo"),
+      commentId: searchParams.get("comment"),
+    })
+    router.push(href)
+  }
+
+  return (
+    <span
+      role="link"
+      tabIndex={0}
+      onClick={(event) => {
+        event.stopPropagation()
+        applyFilter()
+      }}
+      onKeyDown={(event) => {
+        if (event.key !== "Enter" && event.key !== " ") return
+        event.preventDefault()
+        event.stopPropagation()
+        applyFilter()
+      }}
+      className={cn(
+        gallerySans(),
+        "cursor-pointer rounded-sm underline-offset-2 transition-colors hover:text-foreground hover:underline",
+        className
+      )}
+    >
+      {children}
+    </span>
+  )
+}

--- a/apps/gallery/app/actions.ts
+++ b/apps/gallery/app/actions.ts
@@ -7,6 +7,7 @@ import {
   isGalleryReaction,
 } from "@/lib/gallery/reactions"
 import { parseMentions, resolveMentionedProfiles } from "@/lib/gallery/mentions"
+import { isGalleryCommentEditUnavailable } from "@/lib/gallery/comment-edit"
 import {
   type GallerySeasonalThemeId,
   isGallerySeasonalThemeId,
@@ -111,6 +112,73 @@ export type CreatedGalleryComment = {
   body: string
   created_by: string
   created_at: string
+  updated_at: string | null
+}
+
+async function syncGalleryCommentMentions(
+  admin: ReturnType<typeof createAdminClient>,
+  commentId: string,
+  body: string,
+  authorId: string
+) {
+  const mentionNames = parseMentions(body)
+  const { data: existingRows } = await admin
+    .from("gallery_comment_mentions")
+    .select("mentioned_user_id")
+    .eq("comment_id", commentId)
+
+  const existingIds = new Set(
+    (existingRows ?? []).map((row) => row.mentioned_user_id)
+  )
+
+  if (mentionNames.length === 0) {
+    if (existingIds.size > 0) {
+      const { error } = await admin
+        .from("gallery_comment_mentions")
+        .delete()
+        .eq("comment_id", commentId)
+      if (error) {
+        console.error("[gallery] failed to clear comment mentions", error)
+      }
+    }
+    return
+  }
+
+  const { data: profiles } = await admin
+    .from("user_profiles")
+    .select("id, name")
+    .not("name", "is", null)
+
+  const matched = resolveMentionedProfiles(mentionNames, profiles ?? [])
+  const others = matched.filter((profile) => profile.id !== authorId)
+  const targetIds = new Set(others.map((profile) => profile.id))
+
+  const toRemove = [...existingIds].filter((id) => !targetIds.has(id))
+  if (toRemove.length > 0) {
+    const { error } = await admin
+      .from("gallery_comment_mentions")
+      .delete()
+      .eq("comment_id", commentId)
+      .in("mentioned_user_id", toRemove)
+    if (error) {
+      console.error("[gallery] failed to remove stale mentions", error)
+    }
+  }
+
+  const toAdd = others.filter((profile) => !existingIds.has(profile.id))
+  if (toAdd.length === 0) return
+
+  const { error: mentionError } = await admin
+    .from("gallery_comment_mentions")
+    .insert(
+      toAdd.map((profile) => ({
+        comment_id: commentId,
+        mentioned_user_id: profile.id,
+      }))
+    )
+  if (mentionError) {
+    console.error("[gallery] failed to save comment mentions", mentionError)
+  }
 }
 
 export async function addGalleryComment(
@@ -187,27 +255,73 @@ export async function addGalleryComment(
 
   const mentionNames = parseMentions(trimmed)
   if (mentionNames.length > 0) {
-    const { data: profiles } = await admin
-      .from("user_profiles")
-      .select("id, name")
-      .not("name", "is", null)
+    await syncGalleryCommentMentions(admin, data.id, trimmed, userId)
+  }
 
-    const matched = resolveMentionedProfiles(mentionNames, profiles ?? [])
-    const others = matched.filter((p) => p.id !== userId)
-    if (others.length > 0) {
-      const { error: mentionError } = await admin
-        .from("gallery_comment_mentions")
-        .insert(
-          others.map((u) => ({
-            comment_id: data.id,
-            mentioned_user_id: u.id,
-          }))
-        )
-      if (mentionError) {
-        console.error("[gallery] failed to save comment mentions", mentionError)
+  revalidatePath("/", "layout")
+  return { ok: true, data: { ...data, updated_at: null } }
+}
+
+export async function updateGalleryComment(
+  commentId: string,
+  body: string
+): Promise<CommentActionResult<CreatedGalleryComment>> {
+  const trimmed = body.trim()
+  if (!commentId) return { ok: false, error: "Missing comment id." }
+  if (!trimmed) return { ok: false, error: "Comment cannot be empty." }
+  if (trimmed.length > 1000) {
+    return { ok: false, error: "Comment is too long (max 1000 chars)." }
+  }
+
+  const supabase = await createClient()
+  const { data: claimsData } = await supabase.auth.getClaims()
+  const userId = claimsData?.claims?.sub
+  if (!userId) return { ok: false, error: "Please sign in first." }
+
+  const updatedAt = new Date().toISOString()
+  let data: CreatedGalleryComment | null = null
+  let error: { code?: string; message?: string } | null = null
+
+  const withUpdatedAt = await supabase
+    .from("gallery_comments")
+    .update({ body: trimmed, updated_at: updatedAt })
+    .eq("id", commentId)
+    .eq("created_by", userId)
+    .select("id, image_id, parent_id, body, created_by, created_at, updated_at")
+    .maybeSingle()
+
+  data = withUpdatedAt.data as CreatedGalleryComment | null
+  error = withUpdatedAt.error
+
+  if (error && isGalleryCommentEditUnavailable(error)) {
+    const fallback = await supabase
+      .from("gallery_comments")
+      .update({ body: trimmed })
+      .eq("id", commentId)
+      .eq("created_by", userId)
+      .select("id, image_id, parent_id, body, created_by, created_at")
+      .maybeSingle()
+
+    if (fallback.error || !fallback.data) {
+      return {
+        ok: false,
+        error: `Update failed: ${fallback.error?.message ?? "Comment edit is not available yet — apply the gallery comments update migration."}`,
       }
     }
+
+    data = { ...fallback.data, updated_at: null }
+    error = null
   }
+
+  if (error || !data) {
+    return {
+      ok: false,
+      error: `Update failed: ${error?.message ?? "Comment not found."}`,
+    }
+  }
+
+  const admin = createAdminClient()
+  await syncGalleryCommentMentions(admin, commentId, trimmed, userId)
 
   revalidatePath("/", "layout")
   return { ok: true, data }

--- a/apps/gallery/app/upload/_components/upload-form.tsx
+++ b/apps/gallery/app/upload/_components/upload-form.tsx
@@ -2,6 +2,7 @@
 
 import type { FormEvent } from "react"
 import { useRef, useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 
 import { Button } from "@workspace/ui/components/button"
@@ -11,6 +12,7 @@ import { cn } from "@workspace/ui/lib/utils"
 
 import { registerGalleryImage } from "@/app/upload/actions"
 import { gallerySans, gallerySerif } from "@/components/gallery-chrome"
+import { buildGalleryPhotoHref } from "@/lib/gallery/photo-deep-link"
 import {
   guessExtension,
   resolveMediaMimeType,
@@ -42,6 +44,7 @@ const PHASE_LABEL: Record<CompressPhase, string> = {
 
 /** Client uploads bytes to Supabase Storage; server action only registers the row (no 413 on Vercel). */
 export function UploadForm() {
+  const router = useRouter()
   const formRef = useRef<HTMLFormElement>(null)
   const [pending, startTransition] = useTransition()
   const [name, setName] = useState("")
@@ -81,6 +84,7 @@ export function UploadForm() {
       let successCount = 0
       const failed: string[] = []
       const sequenceId = files.length > 1 ? crypto.randomUUID() : null
+      let wallPhotoId: string | null = null
 
       const batch =
         files.length > 1 ? { total: files.length, current: 0 } : undefined
@@ -112,8 +116,9 @@ export function UploadForm() {
           files.length === 1 && trimmed ? trimmed : inferArtworkName(file.name)
 
         try {
+          let registeredId: string
           if (resolved.kind === "image") {
-            await uploadImage({
+            registeredId = await uploadImage({
               supabase,
               userId,
               file,
@@ -125,7 +130,7 @@ export function UploadForm() {
               sequenceIndex: sequenceId ? i : null,
             })
           } else {
-            await uploadVideo({
+            registeredId = await uploadVideo({
               supabase,
               userId,
               file,
@@ -135,6 +140,9 @@ export function UploadForm() {
               sequenceId,
               sequenceIndex: sequenceId ? i : null,
             })
+          }
+          if (!wallPhotoId && (sequenceId ? i === 0 : true)) {
+            wallPhotoId = registeredId
           }
           successCount += 1
         } catch (err) {
@@ -147,7 +155,17 @@ export function UploadForm() {
 
       if (successCount > 0) {
         const suffix = successCount > 1 ? "s" : ""
-        toast.success(`Uploaded ${successCount} work${suffix}.`)
+        if (wallPhotoId) {
+          const href = buildGalleryPhotoHref({ photoId: wallPhotoId })
+          toast.success(`Uploaded ${successCount} work${suffix}.`, {
+            action: {
+              label: "View on wall",
+              onClick: () => router.push(href),
+            },
+          })
+        } else {
+          toast.success(`Uploaded ${successCount} work${suffix}.`)
+        }
         form?.reset()
         setName("")
         setFileNames([])
@@ -273,7 +291,7 @@ type UploadCtx = {
 
 async function uploadImage(
   ctx: UploadCtx & { resolved: ResolvedMime }
-): Promise<void> {
+): Promise<string> {
   const {
     supabase,
     userId,
@@ -320,9 +338,10 @@ async function uploadImage(
     await supabase.storage.from("gallery").remove([objectPath])
     throw new Error(result.error)
   }
+  return result.id
 }
 
-async function uploadVideo(ctx: UploadCtx): Promise<void> {
+async function uploadVideo(ctx: UploadCtx): Promise<string> {
   const {
     supabase,
     userId,
@@ -396,4 +415,5 @@ async function uploadVideo(ctx: UploadCtx): Promise<void> {
     await supabase.storage.from("gallery").remove([videoPath, posterPath])
     throw new Error(result.error)
   }
+  return result.id
 }

--- a/apps/gallery/app/upload/_components/upload-manage-list.tsx
+++ b/apps/gallery/app/upload/_components/upload-manage-list.tsx
@@ -1,0 +1,218 @@
+"use client"
+
+import { useMemo, useState, useTransition, type ReactNode } from "react"
+import { toast } from "sonner"
+
+import { cn } from "@workspace/ui/lib/utils"
+
+import { updateGallerySequenceOrder } from "@/app/upload/actions"
+import { DeleteButton } from "@/app/upload/_components/delete-button"
+import { RenameButton } from "@/app/upload/_components/rename-button"
+import { UploadListThumb } from "@/app/upload/_components/upload-list-thumb"
+import { ViewOnWallLink } from "@/app/upload/_components/view-on-wall-link"
+import {
+  galleryPanelClass,
+  galleryPillClass,
+  gallerySans,
+  gallerySectionTitleClass,
+} from "@/components/gallery-chrome"
+import {
+  groupManageUploads,
+  swapSequenceOrder,
+  type ManageUploadRow,
+} from "@/lib/gallery/manage-uploads"
+import { resolveWallPhotoId } from "@/lib/gallery/wall-photo-id"
+import { getGalleryImageUrl } from "@/lib/gallery/url"
+
+function UploadListItem({
+  image,
+  siblings,
+  sequenceControls,
+}: {
+  image: ManageUploadRow
+  siblings: ManageUploadRow[]
+  sequenceControls?: ReactNode
+}) {
+  const isVideo = image.media_type === "video"
+  const thumbPath =
+    isVideo && image.poster_path ? image.poster_path : image.image_path
+  const wallPhotoId = resolveWallPhotoId(image, siblings)
+
+  return (
+    <li
+      className={cn(
+        galleryPanelClass(),
+        "flex items-center gap-4 !p-4 sm:gap-5"
+      )}
+    >
+      <UploadListThumb
+        src={getGalleryImageUrl(thumbPath)}
+        alt={image.name}
+        isVideo={isVideo}
+      />
+      <div className="min-w-0 flex-1 space-y-1">
+        <p
+          className={cn(
+            gallerySectionTitleClass(),
+            "truncate text-lg sm:text-xl"
+          )}
+        >
+          {image.name}
+        </p>
+        <p className={cn(gallerySans(), "text-xs text-muted-foreground")}>
+          {new Date(image.created_at).toLocaleDateString(undefined, {
+            dateStyle: "medium",
+          })}
+          {isVideo && image.duration_seconds
+            ? ` · ${image.duration_seconds}s video`
+            : ""}
+        </p>
+        {sequenceControls ? (
+          <div className="flex flex-wrap items-center gap-2 pt-1">
+            {sequenceControls}
+          </div>
+        ) : null}
+      </div>
+      <div className="flex shrink-0 flex-wrap items-center justify-end gap-1">
+        <ViewOnWallLink photoId={wallPhotoId} />
+        <RenameButton id={image.id} name={image.name} />
+        <DeleteButton
+          id={image.id}
+          imagePath={image.image_path}
+          posterPath={image.poster_path}
+          name={image.name}
+        />
+      </div>
+    </li>
+  )
+}
+
+function UploadSequenceGroup({
+  sequenceId,
+  items: initialItems,
+  allImages,
+}: {
+  sequenceId: string
+  items: ManageUploadRow[]
+  allImages: ManageUploadRow[]
+}) {
+  const [items, setItems] = useState(initialItems)
+  const [isPending, startTransition] = useTransition()
+  const orderedIds = useMemo(() => items.map((item) => item.id), [items])
+
+  const persistOrder = (nextIds: string[], nextItems: ManageUploadRow[]) => {
+    setItems(nextItems)
+    startTransition(async () => {
+      const result = await updateGallerySequenceOrder(sequenceId, nextIds)
+      if (!result.ok) {
+        toast.error(result.error)
+        setItems(initialItems)
+      } else {
+        toast.success("Sequence updated.")
+      }
+    })
+  }
+
+  const move = (fromIndex: number, toIndex: number) => {
+    const nextIds = swapSequenceOrder(orderedIds, fromIndex, toIndex)
+    if (!nextIds) return
+    const nextItems = nextIds
+      .map((id) => items.find((item) => item.id === id))
+      .filter((item): item is ManageUploadRow => Boolean(item))
+    persistOrder(nextIds, nextItems)
+  }
+
+  const setCover = (index: number) => {
+    if (index === 0) return
+    const nextIds = swapSequenceOrder(orderedIds, index, 0)
+    if (!nextIds) return
+    const nextItems = nextIds
+      .map((id) => items.find((item) => item.id === id))
+      .filter((item): item is ManageUploadRow => Boolean(item))
+    persistOrder(nextIds, nextItems)
+  }
+
+  return (
+    <div className="space-y-3">
+      <p
+        className={cn(gallerySans(), "text-xs text-muted-foreground uppercase")}
+      >
+        Sequence · {items.length} shots
+      </p>
+      <ul className="flex flex-col gap-3">
+        {items.map((image, index) => (
+          <UploadListItem
+            key={image.id}
+            image={image}
+            siblings={allImages}
+            sequenceControls={
+              <>
+                {index === 0 ? (
+                  <span
+                    className={cn(galleryPillClass(), "pointer-events-none")}
+                  >
+                    Cover
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    disabled={isPending}
+                    onClick={() => setCover(index)}
+                    className={galleryPillClass()}
+                  >
+                    Set cover
+                  </button>
+                )}
+                <button
+                  type="button"
+                  disabled={isPending || index === 0}
+                  onClick={() => move(index, index - 1)}
+                  className={galleryPillClass()}
+                >
+                  Up
+                </button>
+                <button
+                  type="button"
+                  disabled={isPending || index === items.length - 1}
+                  onClick={() => move(index, index + 1)}
+                  className={galleryPillClass()}
+                >
+                  Down
+                </button>
+              </>
+            }
+          />
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export function UploadManageList({ images }: { images: ManageUploadRow[] }) {
+  const { singles, sequences } = useMemo(
+    () => groupManageUploads(images),
+    [images]
+  )
+
+  if (images.length === 0) return null
+
+  return (
+    <div className="flex flex-col gap-6">
+      {sequences.map((sequence) => (
+        <UploadSequenceGroup
+          key={sequence.sequenceId}
+          sequenceId={sequence.sequenceId}
+          items={sequence.items}
+          allImages={images}
+        />
+      ))}
+      {singles.length > 0 ? (
+        <ul className="flex flex-col gap-3">
+          {singles.map((image) => (
+            <UploadListItem key={image.id} image={image} siblings={images} />
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/gallery/app/upload/_components/view-on-wall-link.tsx
+++ b/apps/gallery/app/upload/_components/view-on-wall-link.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link"
+
+import { cn } from "@workspace/ui/lib/utils"
+
+import { galleryPillClass } from "@/components/gallery-chrome"
+import { buildGalleryPhotoHref } from "@/lib/gallery/photo-deep-link"
+
+export function ViewOnWallLink({
+  photoId,
+  className,
+}: {
+  photoId: string
+  className?: string
+}) {
+  return (
+    <Link
+      href={buildGalleryPhotoHref({ photoId })}
+      className={cn(galleryPillClass(), className)}
+    >
+      On wall
+    </Link>
+  )
+}

--- a/apps/gallery/app/upload/actions.ts
+++ b/apps/gallery/app/upload/actions.ts
@@ -6,6 +6,9 @@ import { isValidClientObjectPath } from "@/lib/gallery/object-path"
 import { createClient } from "@/lib/supabase/server"
 
 export type ActionResult = { ok: true } | { ok: false; error: string }
+export type RegisterResult =
+  | { ok: true; id: string }
+  | { ok: false; error: string }
 
 export type RegisterMediaInput = {
   name: string
@@ -23,7 +26,7 @@ export type RegisterMediaInput = {
  */
 export async function registerGalleryImage(
   input: RegisterMediaInput
-): Promise<ActionResult> {
+): Promise<RegisterResult> {
   const trimmed = input.name.trim()
   if (!trimmed) return { ok: false, error: "Name is required." }
   if (!input.imagePath) return { ok: false, error: "Missing media path." }
@@ -36,7 +39,10 @@ export async function registerGalleryImage(
   if (input.mediaType === "image" && input.posterPath) {
     return { ok: false, error: "Images must not have a poster path." }
   }
-  if ((input.sequenceId && input.sequenceIndex == null) || (!input.sequenceId && input.sequenceIndex != null)) {
+  if (
+    (input.sequenceId && input.sequenceIndex == null) ||
+    (!input.sequenceId && input.sequenceIndex != null)
+  ) {
     return { ok: false, error: "Sequence metadata is incomplete." }
   }
   if (input.sequenceIndex != null && input.sequenceIndex < 0) {
@@ -104,21 +110,23 @@ export async function registerGalleryImage(
     sequence_index: input.sequenceIndex ?? null,
   }
 
-  const { error: insertError } = await supabase
+  const { data: inserted, error: insertError } = await supabase
     .from("gallery_images")
     .insert(insertPayload)
+    .select("id")
+    .single()
 
-  if (insertError) {
+  if (insertError || !inserted) {
     await supabase.storage.from("gallery").remove(expectedPaths)
     return {
       ok: false,
-      error: `Database insert failed: ${insertError.message}`,
+      error: `Database insert failed: ${insertError?.message ?? "Unknown error."}`,
     }
   }
 
   revalidatePath("/")
   revalidatePath("/upload")
-  return { ok: true }
+  return { ok: true, id: inserted.id }
 }
 
 export async function deleteGalleryImage(
@@ -144,6 +152,67 @@ export async function deleteGalleryImage(
     .remove(targets)
   if (storageError) {
     console.error("[gallery] storage delete failed", storageError)
+  }
+
+  revalidatePath("/")
+  revalidatePath("/upload")
+  return { ok: true }
+}
+
+export async function updateGallerySequenceOrder(
+  sequenceId: string,
+  orderedImageIds: string[]
+): Promise<ActionResult> {
+  if (!sequenceId) return { ok: false, error: "Missing sequence id." }
+  if (orderedImageIds.length === 0) {
+    return { ok: false, error: "Sequence is empty." }
+  }
+
+  const supabase = await createClient()
+  const { data: claimsData } = await supabase.auth.getClaims()
+  const userId = claimsData?.claims?.sub
+  if (!userId) return { ok: false, error: "Not signed in." }
+
+  const uniqueIds = Array.from(new Set(orderedImageIds))
+  if (uniqueIds.length !== orderedImageIds.length) {
+    return { ok: false, error: "Duplicate shots in sequence order." }
+  }
+
+  const { data: rows, error: fetchError } = await supabase
+    .from("gallery_images")
+    .select("id")
+    .eq("sequence_id", sequenceId)
+    .eq("created_by", userId)
+
+  if (fetchError) {
+    return { ok: false, error: `Sequence load failed: ${fetchError.message}` }
+  }
+
+  const existingIds = new Set((rows ?? []).map((row) => row.id))
+  if (existingIds.size !== orderedImageIds.length) {
+    return { ok: false, error: "Sequence shots do not match your uploads." }
+  }
+  for (const id of orderedImageIds) {
+    if (!existingIds.has(id)) {
+      return { ok: false, error: "Sequence shots do not match your uploads." }
+    }
+  }
+
+  for (let index = 0; index < orderedImageIds.length; index++) {
+    const imageId = orderedImageIds[index]!
+    const { error } = await supabase
+      .from("gallery_images")
+      .update({ sequence_index: index })
+      .eq("id", imageId)
+      .eq("created_by", userId)
+      .eq("sequence_id", sequenceId)
+
+    if (error) {
+      return {
+        ok: false,
+        error: `Could not reorder sequence: ${error.message}`,
+      }
+    }
   }
 
   revalidatePath("/")

--- a/apps/gallery/app/upload/page.tsx
+++ b/apps/gallery/app/upload/page.tsx
@@ -1,10 +1,8 @@
 import { redirect } from "next/navigation"
 
 import { SeasonalThemePanel } from "@/app/upload/_components/seasonal-theme-panel"
-import { DeleteButton } from "@/app/upload/_components/delete-button"
-import { RenameButton } from "@/app/upload/_components/rename-button"
-import { UploadListThumb } from "@/app/upload/_components/upload-list-thumb"
 import { UploadForm } from "@/app/upload/_components/upload-form"
+import { UploadManageList } from "@/app/upload/_components/upload-manage-list"
 import {
   galleryPanelClass,
   gallerySans,
@@ -12,13 +10,12 @@ import {
   gallerySectionTitleClass,
 } from "@/components/gallery-chrome"
 import { GalleryThemedShell } from "@/components/gallery-shell"
-import { createClient } from "@/lib/supabase/server"
-import type { GalleryImage } from "@/lib/gallery/types"
+import type { ManageUploadRow } from "@/lib/gallery/manage-uploads"
 import {
   getGallerySeasonalThemeId,
   isGallerySettingsReady,
 } from "@/lib/gallery/settings"
-import { getGalleryImageUrl } from "@/lib/gallery/url"
+import { createClient } from "@/lib/supabase/server"
 import { getCurrentUser } from "@/lib/user"
 import { cn } from "@workspace/ui/lib/utils"
 
@@ -33,7 +30,7 @@ export default async function UploadPage() {
     supabase
       .from("gallery_images")
       .select(
-        "id, name, image_path, media_type, poster_path, duration_seconds, created_by, created_at"
+        "id, name, image_path, media_type, poster_path, duration_seconds, created_by, created_at, sequence_id, sequence_index"
       )
       .eq("created_by", user.id)
       .order("created_at", { ascending: false }),
@@ -41,20 +38,7 @@ export default async function UploadPage() {
     isGallerySettingsReady(supabase),
   ])
 
-  const { data } = imagesResult
-
-  const myImages = (data ?? []) as Array<
-    Pick<
-      GalleryImage,
-      | "id"
-      | "name"
-      | "image_path"
-      | "media_type"
-      | "poster_path"
-      | "duration_seconds"
-      | "created_at"
-    >
-  >
+  const myImages = (imagesResult.data ?? []) as ManageUploadRow[]
 
   return (
     <GalleryThemedShell active="manage" signedIn containerClassName="max-w-3xl">
@@ -85,65 +69,7 @@ export default async function UploadPage() {
               You haven&apos;t uploaded anything yet.
             </p>
           ) : (
-            <ul className="flex flex-col gap-3">
-              {myImages.map((image) => {
-                const isVideo = image.media_type === "video"
-                const thumbPath =
-                  isVideo && image.poster_path
-                    ? image.poster_path
-                    : image.image_path
-                return (
-                  <li
-                    key={image.id}
-                    className={cn(
-                      galleryPanelClass(),
-                      "flex items-center gap-4 !p-4 sm:gap-5"
-                    )}
-                  >
-                    <UploadListThumb
-                      src={getGalleryImageUrl(thumbPath)}
-                      alt={image.name}
-                      isVideo={isVideo}
-                    />
-                    <div className="min-w-0 flex-1 space-y-1">
-                      <p
-                        className={cn(
-                          gallerySectionTitleClass(),
-                          "truncate text-lg sm:text-xl"
-                        )}
-                      >
-                        {image.name}
-                      </p>
-                      <p
-                        className={cn(
-                          gallerySans(),
-                          "text-xs text-muted-foreground"
-                        )}
-                      >
-                        {new Date(image.created_at).toLocaleDateString(
-                          undefined,
-                          {
-                            dateStyle: "medium",
-                          }
-                        )}
-                        {isVideo && image.duration_seconds
-                          ? ` · ${image.duration_seconds}s video`
-                          : ""}
-                      </p>
-                    </div>
-                    <div className="flex shrink-0 items-center gap-1">
-                      <RenameButton id={image.id} name={image.name} />
-                      <DeleteButton
-                        id={image.id}
-                        imagePath={image.image_path}
-                        posterPath={image.poster_path}
-                        name={image.name}
-                      />
-                    </div>
-                  </li>
-                )
-              })}
-            </ul>
+            <UploadManageList images={myImages} />
           )}
         </section>
       </div>

--- a/apps/gallery/lib/gallery/comment-edit.test.ts
+++ b/apps/gallery/lib/gallery/comment-edit.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  formatGallerySupabaseError,
+  isGalleryCommentEditUnavailable,
+} from "@/lib/gallery/comment-edit"
+
+describe("isGalleryCommentEditUnavailable", () => {
+  test("detects missing updated_at column", () => {
+    expect(
+      isGalleryCommentEditUnavailable({
+        code: "42703",
+        message: "column gallery_comments.updated_at does not exist",
+      })
+    ).toBe(true)
+  })
+
+  test("returns false for unrelated errors", () => {
+    expect(
+      isGalleryCommentEditUnavailable({
+        code: "42501",
+        message: "permission denied",
+      })
+    ).toBe(false)
+  })
+})
+
+describe("formatGallerySupabaseError", () => {
+  test("includes message and code", () => {
+    expect(
+      formatGallerySupabaseError({
+        code: "42703",
+        message: "column does not exist",
+        hint: "Perhaps you meant created_at",
+      })
+    ).toContain("column does not exist")
+    expect(
+      formatGallerySupabaseError({
+        code: "42703",
+        message: "column does not exist",
+        hint: "Perhaps you meant created_at",
+      })
+    ).toContain("code=42703")
+  })
+})

--- a/apps/gallery/lib/gallery/comment-edit.ts
+++ b/apps/gallery/lib/gallery/comment-edit.ts
@@ -1,0 +1,95 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+const COMMENT_SELECT_BASE =
+  "id, image_id, parent_id, body, created_by, created_at"
+const COMMENT_SELECT_WITH_EDIT = `${COMMENT_SELECT_BASE}, updated_at`
+
+export type GalleryCommentRow = {
+  id: string
+  image_id: string
+  parent_id: string | null
+  body: string
+  created_by: string
+  created_at: string
+  updated_at?: string | null
+}
+
+export function isGalleryCommentEditUnavailable(
+  error: { code?: string; message?: string } | null
+): boolean {
+  if (!error) return false
+  const message = error.message ?? ""
+  const code = error.code ?? ""
+  return (
+    code === "PGRST204" ||
+    code === "42703" ||
+    /updated_at/i.test(message) ||
+    /gallery_comments_update/i.test(message) ||
+    /schema cache/i.test(message)
+  )
+}
+
+export function formatGallerySupabaseError(
+  error: {
+    code?: string
+    message?: string
+    details?: string
+    hint?: string
+  } | null
+): string {
+  if (!error) return "Unknown error"
+  const parts = [
+    error.message,
+    error.code ? `code=${error.code}` : null,
+    error.details ? `details=${error.details}` : null,
+    error.hint ? `hint=${error.hint}` : null,
+  ].filter(Boolean)
+  return parts.join(" | ") || "Unknown error"
+}
+
+export async function loadGalleryCommentRows(
+  supabase: SupabaseClient,
+  imageIds: string[]
+): Promise<
+  { data: GalleryCommentRow[]; error: null } | { data: []; error: string }
+> {
+  if (imageIds.length === 0) return { data: [], error: null }
+
+  const withEdit = await supabase
+    .from("gallery_comments")
+    .select(COMMENT_SELECT_WITH_EDIT)
+    .in("image_id", imageIds)
+    .order("created_at", { ascending: true })
+
+  if (!withEdit.error) {
+    return { data: (withEdit.data ?? []) as GalleryCommentRow[], error: null }
+  }
+
+  if (!isGalleryCommentEditUnavailable(withEdit.error)) {
+    return {
+      data: [],
+      error: formatGallerySupabaseError(withEdit.error),
+    }
+  }
+
+  const fallback = await supabase
+    .from("gallery_comments")
+    .select(COMMENT_SELECT_BASE)
+    .in("image_id", imageIds)
+    .order("created_at", { ascending: true })
+
+  if (fallback.error) {
+    return {
+      data: [],
+      error: formatGallerySupabaseError(fallback.error),
+    }
+  }
+
+  return {
+    data: ((fallback.data ?? []) as GalleryCommentRow[]).map((row) => ({
+      ...row,
+      updated_at: null,
+    })),
+    error: null,
+  }
+}

--- a/apps/gallery/lib/gallery/lightbox-social.ts
+++ b/apps/gallery/lib/gallery/lightbox-social.ts
@@ -1,0 +1,90 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+import { loadGalleryCommentRows } from "@/lib/gallery/comment-edit"
+import {
+  aggregateReactions,
+  isGalleryReaction,
+  EMPTY_REACTION_COUNTS,
+  EMPTY_REACTION_NAMES,
+} from "@/lib/gallery/reactions"
+import type { GalleryComment } from "@/lib/gallery/types"
+import type { GalleryReaction } from "@/lib/gallery/reactions"
+
+export async function loadLightboxSocial(
+  supabase: SupabaseClient,
+  imageId: string,
+  viewerId: string | null
+): Promise<{
+  comments: GalleryComment[]
+  reaction_counts: typeof EMPTY_REACTION_COUNTS
+  reaction_names: typeof EMPTY_REACTION_NAMES
+  my_reaction: GalleryReaction | null
+}> {
+  const [commentResult, voteResult] = await Promise.all([
+    loadGalleryCommentRows(supabase, [imageId]),
+    supabase
+      .from("gallery_image_votes")
+      .select("image_id, user_id, reaction")
+      .eq("image_id", imageId),
+  ])
+
+  const commentRows = commentResult.error ? [] : commentResult.data
+  const voteRows = voteResult.data ?? []
+
+  const profileIds = Array.from(
+    new Set([
+      ...commentRows.map((row) => row.created_by),
+      ...voteRows.map((row) => row.user_id),
+    ])
+  )
+
+  let nameById = new Map<string, string>()
+  if (profileIds.length > 0) {
+    const { data: profiles } = await supabase
+      .from("user_profiles")
+      .select("id, name, email")
+      .in("id", profileIds)
+
+    for (const profile of profiles ?? []) {
+      const fallback =
+        typeof profile.email === "string" ? profile.email.split("@")[0] : null
+      const name =
+        (typeof profile.name === "string" && profile.name.trim()) ||
+        fallback ||
+        "Unknown"
+      nameById.set(profile.id, name)
+    }
+  }
+
+  const comments: GalleryComment[] = commentRows.map((row) => ({
+    id: row.id,
+    image_id: row.image_id,
+    parent_id: row.parent_id ?? null,
+    body: row.body,
+    created_by: row.created_by,
+    created_at: row.created_at,
+    updated_at: row.updated_at ?? null,
+    commenter_name: nameById.get(row.created_by) ?? "Unknown",
+  }))
+
+  const aggregated = aggregateReactions(voteRows, nameById)
+  const counts = aggregated.countsByImage.get(imageId) ?? EMPTY_REACTION_COUNTS
+  const names = aggregated.namesByImage.get(imageId) ?? EMPTY_REACTION_NAMES
+
+  let myReaction: GalleryReaction | null = null
+  if (viewerId) {
+    for (const row of voteRows) {
+      if (row.user_id === viewerId && isGalleryReaction(row.reaction)) {
+        myReaction = row.reaction
+        break
+      }
+    }
+  }
+
+  return {
+    comments,
+    reaction_counts: counts,
+    reaction_names: names,
+    my_reaction: myReaction,
+  }
+}

--- a/apps/gallery/lib/gallery/load-home-page.ts
+++ b/apps/gallery/lib/gallery/load-home-page.ts
@@ -12,6 +12,7 @@ import type {
   GalleryMember,
 } from "@/lib/gallery/types"
 import type { GalleryHomeFilters } from "@/lib/gallery/home-filters"
+import { loadGalleryCommentRows } from "@/lib/gallery/comment-edit"
 
 export const GALLERY_PAGE_SIZE = 36
 
@@ -158,11 +159,7 @@ export async function loadGalleryHomePage(
         .from("gallery_image_votes")
         .select("image_id, user_id, reaction")
         .in("image_id", imageIds),
-      supabase
-        .from("gallery_comments")
-        .select("id, image_id, parent_id, body, created_by, created_at")
-        .in("image_id", imageIds)
-        .order("created_at", { ascending: true }),
+      loadGalleryCommentRows(supabase, imageIds),
     ])
 
     if (voteResult.error) {
@@ -173,7 +170,7 @@ export async function loadGalleryHomePage(
     }
 
     const voteRows = voteResult.data ?? []
-    const commentRows = commentResult.data ?? []
+    const commentRows = commentResult.data
 
     if (!userId) {
       const profileIds = Array.from(
@@ -222,6 +219,7 @@ export async function loadGalleryHomePage(
         body: row.body,
         created_by: row.created_by,
         created_at: row.created_at,
+        updated_at: row.updated_at ?? null,
         commenter_name: nameById.get(row.created_by) ?? "Unknown",
       })
       commentsByImage.set(row.image_id, bucket)

--- a/apps/gallery/lib/gallery/manage-uploads.test.ts
+++ b/apps/gallery/lib/gallery/manage-uploads.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  groupManageUploads,
+  swapSequenceOrder,
+} from "@/lib/gallery/manage-uploads"
+import { resolveWallPhotoId } from "@/lib/gallery/wall-photo-id"
+
+describe("resolveWallPhotoId", () => {
+  test("returns cover id for non-cover sequence shots", () => {
+    const siblings = [
+      { id: "cover", sequence_id: "seq-1", sequence_index: 0 },
+      { id: "shot-2", sequence_id: "seq-1", sequence_index: 1 },
+    ]
+    expect(resolveWallPhotoId(siblings[1]!, siblings)).toBe("cover")
+  })
+})
+
+describe("groupManageUploads", () => {
+  test("groups sequence rows and keeps singles separate", () => {
+    const rows = [
+      {
+        id: "a",
+        name: "A",
+        image_path: "u/a.jpg",
+        media_type: "image" as const,
+        poster_path: null,
+        duration_seconds: null,
+        created_at: "2026-01-02T00:00:00.000Z",
+        sequence_id: "seq",
+        sequence_index: 1,
+      },
+      {
+        id: "b",
+        name: "B",
+        image_path: "u/b.jpg",
+        media_type: "image" as const,
+        poster_path: null,
+        duration_seconds: null,
+        created_at: "2026-01-01T00:00:00.000Z",
+        sequence_id: "seq",
+        sequence_index: 0,
+      },
+      {
+        id: "solo",
+        name: "Solo",
+        image_path: "u/solo.jpg",
+        media_type: "image" as const,
+        poster_path: null,
+        duration_seconds: null,
+        created_at: "2026-01-03T00:00:00.000Z",
+        sequence_id: null,
+        sequence_index: null,
+      },
+    ]
+
+    const grouped = groupManageUploads(rows)
+    expect(grouped.singles).toHaveLength(1)
+    expect(grouped.sequences).toHaveLength(1)
+    expect(grouped.sequences[0]?.items.map((item) => item.id)).toEqual([
+      "b",
+      "a",
+    ])
+  })
+})
+
+describe("swapSequenceOrder", () => {
+  test("moves an item to a new index", () => {
+    expect(swapSequenceOrder(["a", "b", "c"], 2, 0)).toEqual(["c", "a", "b"])
+  })
+})

--- a/apps/gallery/lib/gallery/manage-uploads.ts
+++ b/apps/gallery/lib/gallery/manage-uploads.ts
@@ -1,0 +1,69 @@
+import type { WallPhotoSource } from "@/lib/gallery/wall-photo-id"
+
+export type ManageUploadRow = WallPhotoSource & {
+  name: string
+  image_path: string
+  media_type: "image" | "video"
+  poster_path: string | null
+  duration_seconds: number | null
+  created_at: string
+}
+
+export type ManageUploadSequence = {
+  sequenceId: string
+  items: ManageUploadRow[]
+}
+
+export function groupManageUploads(rows: ManageUploadRow[]): {
+  singles: ManageUploadRow[]
+  sequences: ManageUploadSequence[]
+} {
+  const singles: ManageUploadRow[] = []
+  const bySequence = new Map<string, ManageUploadRow[]>()
+
+  for (const row of rows) {
+    if (!row.sequence_id) {
+      singles.push(row)
+      continue
+    }
+    const bucket = bySequence.get(row.sequence_id) ?? []
+    bucket.push(row)
+    bySequence.set(row.sequence_id, bucket)
+  }
+
+  const sequences = [...bySequence.entries()].map(([sequenceId, items]) => ({
+    sequenceId,
+    items: [...items].sort(
+      (a, b) => (a.sequence_index ?? 0) - (b.sequence_index ?? 0)
+    ),
+  }))
+
+  sequences.sort(
+    (a, b) =>
+      new Date(b.items[0]?.created_at ?? 0).getTime() -
+      new Date(a.items[0]?.created_at ?? 0).getTime()
+  )
+
+  return { singles, sequences }
+}
+
+export function swapSequenceOrder(
+  orderedIds: string[],
+  fromIndex: number,
+  toIndex: number
+): string[] | null {
+  if (
+    fromIndex < 0 ||
+    toIndex < 0 ||
+    fromIndex >= orderedIds.length ||
+    toIndex >= orderedIds.length ||
+    fromIndex === toIndex
+  ) {
+    return null
+  }
+  const next = [...orderedIds]
+  const [moved] = next.splice(fromIndex, 1)
+  if (!moved) return null
+  next.splice(toIndex, 0, moved)
+  return next
+}

--- a/apps/gallery/lib/gallery/types.ts
+++ b/apps/gallery/lib/gallery/types.ts
@@ -45,6 +45,7 @@ export type GalleryComment = {
   body: string
   created_by: string
   created_at: string
+  updated_at: string | null
   commenter_name: string
 }
 

--- a/apps/gallery/lib/gallery/wall-photo-id.ts
+++ b/apps/gallery/lib/gallery/wall-photo-id.ts
@@ -1,0 +1,17 @@
+export type WallPhotoSource = {
+  id: string
+  sequence_id: string | null
+  sequence_index: number | null
+}
+
+/** Wall deep links always use the sequence cover (index 0) when applicable. */
+export function resolveWallPhotoId(
+  image: WallPhotoSource,
+  siblings: WallPhotoSource[]
+): string {
+  if (!image.sequence_id || image.sequence_index === 0) return image.id
+  const cover = siblings.find(
+    (row) => row.sequence_id === image.sequence_id && row.sequence_index === 0
+  )
+  return cover?.id ?? image.id
+}

--- a/supabase/migrations/2026-07-01-gallery-comments-update.sql
+++ b/supabase/migrations/2026-07-01-gallery-comments-update.sql
@@ -1,0 +1,10 @@
+-- Allow comment authors to edit their own comments.
+
+alter table public.gallery_comments
+  add column if not exists updated_at timestamptz;
+
+create policy "gallery_comments_update"
+on public.gallery_comments for update
+to authenticated
+using (created_by = auth.uid())
+with check (created_by = auth.uid());

--- a/supabase/migrations/2026-07-03-gallery-lightbox-realtime.sql
+++ b/supabase/migrations/2026-07-03-gallery-lightbox-realtime.sql
@@ -1,0 +1,4 @@
+-- Realtime updates for lightbox comments and reactions.
+
+alter publication supabase_realtime add table public.gallery_comments;
+alter publication supabase_realtime add table public.gallery_image_votes;


### PR DESCRIPTION
Closes #248

## Summary

- Add gallery comment editing (`updated_at`, author-only UPDATE RLS) with migration-safe loading when the column is not yet applied
- Manage page: View on wall links, sequence reordering, upload success toast with wall link
- Wall UX: click uploader name to filter home feed; fix nested-button hydration by moving uploader link outside the dialog trigger
- Lightbox: realtime comments/reactions refresh, download original for signed-in users
- Grid keyboard navigation (`j`/`k`/`Enter`) with focus ring only after keyboard use
- Delete comment confirmation via AlertDialog

## Migrations

- `2026-07-01-gallery-comments-update.sql`
- `2026-07-03-gallery-lightbox-realtime.sql`

Run `supabase db push` after merge.

## Test plan

- [x] `bun test` in `apps/gallery` (103 pass)
- [x] `bun run typecheck --filter=gallery`
- [ ] Home wall loads without hydration / nested-button console errors
- [ ] Click uploader name filters feed without opening lightbox
- [ ] Edit and delete own comment (confirm dialog on delete)
- [ ] Lightbox updates when another tab adds comment or reaction (after migration)
- [ ] Manage: reorder sequence, View on wall link works
- [ ] Upload success toast links to wall photo
- [ ] `j`/`k`/`Enter` grid navigation; focus ring appears only after keyboard use
