### PR TITLE
perf(bento): 修手機下拉選單捲動卡頓（移除 sticky backdrop-blur）

### DIFF
--- a/apps/portal/app/bento/_components/add-order-item-dialog.tsx
+++ b/apps/portal/app/bento/_components/add-order-item-dialog.tsx
@@ -348,7 +348,7 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
                         result.push(
                           <div
                             key={`header-${type}`}
-                            className="sticky top-0 bg-muted/50 px-3 py-2 text-xs font-medium text-foreground backdrop-blur-sm"
+                            className="sticky top-0 bg-muted px-3 py-2 text-xs font-medium text-foreground"
                           >
                             {type}
                           </div>


### PR DESCRIPTION
Closes #250

## Summary

修手機版「新增訂餐」下拉選單捲動卡頓。

品項分類的 sticky 標題原本用 `bg-muted/50` + `backdrop-blur-sm`。在手機上 `position: sticky` + `backdrop-blur` 會在**每個捲動 frame** 對標題後方不斷變動的清單重算背景模糊，GPU 吃重 → 捲動卡頓。改成不透明的 `bg-muted`（標題仍清楚可讀），移除每 frame 的模糊重算，符合 compositor-friendly 原則。

一行 className 變更：

```diff
- className="sticky top-0 bg-muted/50 ... backdrop-blur-sm"
+ className="sticky top-0 bg-muted ..."
```

## Test plan

- [x] `eslint`（pre-commit `--max-warnings=0`）通過
- [ ] 真手機：開「新增訂餐」→ 展開品項下拉 → 快速上下捲動，確認不再卡頓、分類標題仍清楚固定在頂

> 註：因 portal 需 Keycloak 登入、且 CI 環境無 Playwright 瀏覽器，此項以真機手動驗收為準（真機觸控/GPU 比 headless 模擬更能反映捲動手感）。
