### PR TITLE
feat(bento): 八曜和茶飲料店，點餐必選甜度/冰量（正規化選項）

### DIFF
--- a/apps/portal/app/bento/_components/add-order-item-dialog.tsx
+++ b/apps/portal/app/bento/_components/add-order-item-dialog.tsx
@@ -27,9 +27,11 @@ import {
 
 import { useAdmin } from "@/hooks/bento/use-admin"
 import { useMenu } from "@/hooks/bento/use-menus"
+import { useOptionGroups } from "@/hooks/bento/use-option-groups"
 import {
   useAddAnonymousItem,
   useAddOrderItem,
+  useAddOrderItemWithOptions,
   useAdminAddItem,
 } from "@/hooks/bento/use-order-items"
 import { useOrder } from "@/hooks/bento/use-orders"
@@ -51,19 +53,34 @@ interface CartLine {
   menu_item_id: string
   no_sauce: boolean
   additional: number | null
+  optionValueIds: string[]
 }
 
+type ValueLabel = Map<string, { group: string; label: string; sort: number }>
+
 function describeLine(
-  line: Pick<CartLine, "menu_item_id" | "no_sauce" | "additional">,
+  line: Pick<
+    CartLine,
+    "menu_item_id" | "no_sauce" | "additional" | "optionValueIds"
+  >,
   menuItems: MenuItem[],
-  additionalOptions: string[] | null
+  additionalOptions: string[] | null,
+  valueLabel: ValueLabel
 ): string {
   const name = menuItems.find((m) => m.id === line.menu_item_id)?.name ?? ""
   const parts: string[] = []
+
+  line.optionValueIds
+    .map((id) => valueLabel.get(id))
+    .filter((v): v is NonNullable<typeof v> => Boolean(v))
+    .sort((a, b) => a.sort - b.sort)
+    .forEach((v) => parts.push(v.label))
+
   if (line.no_sauce) parts.push("不醬")
   const additionalLabel =
     line.additional !== null ? additionalOptions?.[line.additional] : undefined
   if (additionalLabel) parts.push(additionalLabel)
+
   return parts.length > 0 ? `${name}（${parts.join("、")}）` : name
 }
 
@@ -74,6 +91,9 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
   const [selectedAdditional, setSelectedAdditional] = useState<number | null>(
     null
   )
+  const [selectedOptions, setSelectedOptions] = useState<
+    Record<string, string>
+  >({})
   const [cart, setCart] = useState<CartLine[]>([])
   const [targetUserId, setTargetUserId] = useState<string | null>(null)
   const [anonymousName, setAnonymousName] = useState("")
@@ -87,14 +107,33 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
   const { data: order } = useOrder(open ? orderId : undefined)
   const restaurantId = order?.restaurants?.id
   const { data: menuData } = useMenu(open ? restaurantId : undefined)
+  const { data: optionGroups } = useOptionGroups(
+    open ? restaurantId : undefined
+  )
   const { data: userList } = useUsers()
 
   const addItem = useAddOrderItem()
   const adminAddItem = useAdminAddItem()
   const addAnonymousItem = useAddAnonymousItem()
+  const addWithOptions = useAddOrderItemWithOptions()
 
   const restaurantAdditionalOptions: string[] | null =
     order?.restaurants?.additional || null
+
+  const groups = optionGroups ?? []
+  const isDrinks = groups.length > 0
+  const requiredGroups = groups.filter((g) => g.required)
+
+  const valueLabel: ValueLabel = new Map()
+  groups.forEach((g) =>
+    g.values.forEach((v) =>
+      valueLabel.set(v.id, {
+        group: g.name,
+        label: v.label,
+        sort: g.sort_order,
+      })
+    )
+  )
 
   const defaultAdditional =
     restaurantAdditionalOptions && restaurantAdditionalOptions.length > 0
@@ -136,6 +175,7 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
     setSelectedItem("")
     setNoSauce(false)
     setSelectedAdditional(defaultAdditional)
+    setSelectedOptions({})
   }
 
   const resetAll = () => {
@@ -151,22 +191,13 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
     setOpen(value)
     if (value) {
       setSelectedAdditional(defaultAdditional)
+      setSelectedOptions({})
     } else {
       resetAll()
     }
   }
 
-  // Lines to submit = cart plus a still-pending selection the user hasn't
-  // explicitly added yet. This keeps the single-item flow a one-tap submit.
-  const pendingLine: CartLine | null = selectedItem
-    ? {
-        key: "pending",
-        menu_item_id: selectedItem,
-        no_sauce: noSauce,
-        additional: selectedAdditional,
-      }
-    : null
-  const effectiveLines: CartLine[] = pendingLine ? [...cart, pendingLine] : cart
+  const pendingOptionsMet = requiredGroups.every((g) => selectedOptions[g.id])
 
   // Monotonic counter so cart keys stay unique across add/remove sequences
   // even when crypto.randomUUID is unavailable (e.g. plain-http contexts).
@@ -181,13 +212,15 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
 
   const handleAddToCart = () => {
     if (!selectedItem) return
+    if (isDrinks && !pendingOptionsMet) return
     setCart((prev) => [
       ...prev,
       {
         key: makeKey(),
         menu_item_id: selectedItem,
-        no_sauce: noSauce,
-        additional: selectedAdditional,
+        no_sauce: isDrinks ? false : noSauce,
+        additional: isDrinks ? null : selectedAdditional,
+        optionValueIds: isDrinks ? Object.values(selectedOptions) : [],
       },
     ])
     resetSelection()
@@ -196,6 +229,21 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
   const handleRemoveFromCart = (key: string) => {
     setCart((prev) => prev.filter((line) => line.key !== key))
   }
+
+  // For meal shops a still-pending selection is auto-included on submit, so the
+  // single-item flow stays one tap. Drink shops require 加入清單 first (each drink
+  // has mandatory ice/sugar), so only the cart is submitted.
+  const pendingLine: CartLine | null =
+    !isDrinks && selectedItem
+      ? {
+          key: "pending",
+          menu_item_id: selectedItem,
+          no_sauce: noSauce,
+          additional: selectedAdditional,
+          optionValueIds: [],
+        }
+      : null
+  const effectiveLines: CartLine[] = pendingLine ? [...cart, pendingLine] : cart
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -217,7 +265,16 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
     let added = 0
     try {
       for (const line of effectiveLines) {
-        if (isAnonymous) {
+        if (isDrinks) {
+          await addWithOptions.mutateAsync({
+            order_id: orderId,
+            menu_item_id: line.menu_item_id,
+            option_value_ids: line.optionValueIds,
+            user_id: isAdminUser && targetUserId ? targetUserId : null,
+            anonymous_name: isAnonymous ? anonymousName.trim() : null,
+            anonymous_contact: isAnonymous ? anonymousContact.trim() : null,
+          })
+        } else if (isAnonymous) {
           await addAnonymousItem.mutateAsync({
             order_id: orderId,
             menu_item_id: line.menu_item_id,
@@ -272,12 +329,15 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
     submitting ||
     addItem.isPending ||
     adminAddItem.isPending ||
-    addAnonymousItem.isPending
+    addAnonymousItem.isPending ||
+    addWithOptions.isPending
 
   const submitDisabled =
     isPending ||
     effectiveLines.length === 0 ||
     (isAnonymous && (!anonymousName.trim() || !anonymousContact.trim()))
+
+  const addDisabled = !selectedItem || (isDrinks && !pendingOptionsMet)
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -288,7 +348,9 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
         <DialogHeader>
           <DialogTitle>新增訂餐</DialogTitle>
           <DialogDescription>
-            選擇品項與選項，可加入多筆後一次送出
+            {isDrinks
+              ? "選擇品項與甜度、冰量，加入清單後一次送出"
+              : "選擇品項與選項，可加入多筆後一次送出"}
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
@@ -372,54 +434,92 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
                 </SelectContent>
               </Select>
 
-              <div className="flex flex-wrap items-center gap-4">
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id="noSauce"
-                    checked={noSauce}
-                    onCheckedChange={(checked) => setNoSauce(checked === true)}
-                  />
-                  <Label
-                    htmlFor="noSauce"
-                    className="cursor-pointer whitespace-nowrap"
-                  >
-                    不醬
-                  </Label>
-                </div>
-                {restaurantAdditionalOptions &&
-                  restaurantAdditionalOptions.length > 0 && (
+              {/* Drink shops: mandatory option groups (甜度 / 冰量). */}
+              {isDrinks &&
+                groups.map((group) => (
+                  <div key={group.id} className="flex items-center gap-3">
+                    <Label className="w-12 shrink-0 text-sm">
+                      {group.name}
+                      {group.required && (
+                        <span className="text-destructive"> *</span>
+                      )}
+                    </Label>
                     <Select
-                      value={
-                        selectedAdditional !== null
-                          ? selectedAdditional.toString()
-                          : undefined
-                      }
-                      onValueChange={(value) =>
-                        setSelectedAdditional(parseInt(value))
+                      value={selectedOptions[group.id] ?? ""}
+                      onValueChange={(v) =>
+                        setSelectedOptions((prev) => ({
+                          ...prev,
+                          [group.id]: v,
+                        }))
                       }
                     >
-                      <SelectTrigger className="w-32">
-                        <SelectValue placeholder="選項" />
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder={`選擇${group.name}`} />
                       </SelectTrigger>
                       <SelectContent>
-                        {restaurantAdditionalOptions.map(
-                          (option: string, index: number) => (
-                            <SelectItem key={index} value={index.toString()}>
-                              {option}
-                            </SelectItem>
-                          )
-                        )}
+                        {group.values.map((v) => (
+                          <SelectItem key={v.id} value={v.id}>
+                            {v.label}
+                          </SelectItem>
+                        ))}
                       </SelectContent>
                     </Select>
-                  )}
-              </div>
+                  </div>
+                ))}
+
+              {/* Meal shops: 不醬 + restaurant additional option. */}
+              {!isDrinks && (
+                <div className="flex flex-wrap items-center gap-4">
+                  <div className="flex items-center gap-2">
+                    <Checkbox
+                      id="noSauce"
+                      checked={noSauce}
+                      onCheckedChange={(checked) =>
+                        setNoSauce(checked === true)
+                      }
+                    />
+                    <Label
+                      htmlFor="noSauce"
+                      className="cursor-pointer whitespace-nowrap"
+                    >
+                      不醬
+                    </Label>
+                  </div>
+                  {restaurantAdditionalOptions &&
+                    restaurantAdditionalOptions.length > 0 && (
+                      <Select
+                        value={
+                          selectedAdditional !== null
+                            ? selectedAdditional.toString()
+                            : undefined
+                        }
+                        onValueChange={(value) =>
+                          setSelectedAdditional(parseInt(value))
+                        }
+                      >
+                        <SelectTrigger className="w-32">
+                          <SelectValue placeholder="選項" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {restaurantAdditionalOptions.map(
+                            (option: string, index: number) => (
+                              <SelectItem key={index} value={index.toString()}>
+                                {option}
+                              </SelectItem>
+                            )
+                          )}
+                        </SelectContent>
+                      </Select>
+                    )}
+                </div>
+              )}
 
               <Button
                 type="button"
                 variant="secondary"
                 className="w-full"
                 onClick={handleAddToCart}
-                disabled={!selectedItem}
+                disabled={addDisabled}
               >
                 加入清單
               </Button>
@@ -440,7 +540,8 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
                       {describeLine(
                         line,
                         menuItems,
-                        restaurantAdditionalOptions
+                        restaurantAdditionalOptions,
+                        valueLabel
                       )}
                     </span>
                     <Button
@@ -482,7 +583,8 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
                           {describeLine(
                             line,
                             menuItems,
-                            restaurantAdditionalOptions
+                            restaurantAdditionalOptions,
+                            valueLabel
                           )}
                         </li>
                       ))}

--- a/apps/portal/app/bento/_components/order-items-list.tsx
+++ b/apps/portal/app/bento/_components/order-items-list.tsx
@@ -25,6 +25,7 @@ interface OrderItem {
     name: string | null
     email?: string
   } | null
+  selected_options?: { group_name: string; label: string }[]
 }
 
 interface GroupedOrderItem {
@@ -118,6 +119,15 @@ export function OrderItemsList({
                   className="flex flex-wrap items-center gap-2"
                 >
                   <span>{item.menu_items?.name}</span>
+                  {item.selected_options?.map((opt, i) => (
+                    <Badge
+                      key={`${opt.group_name}-${i}`}
+                      variant="secondary"
+                      className="px-2 py-0.5 text-[11px]"
+                    >
+                      {opt.label}
+                    </Badge>
+                  ))}
                   {item.no_sauce && (
                     <Badge
                       variant="secondary"

--- a/apps/portal/hooks/bento/query-keys.ts
+++ b/apps/portal/hooks/bento/query-keys.ts
@@ -9,6 +9,10 @@ export const queryKeys = {
     detail: (id: string) => [...queryKeys.menus.all, id] as const,
     stats: (id: string) => [...queryKeys.menus.all, id, "stats"] as const,
   },
+  optionGroups: {
+    all: ["bento", "option-groups"] as const,
+    byRestaurant: (id: string) => [...queryKeys.optionGroups.all, id] as const,
+  },
   users: {
     all: ["bento", "users"] as const,
   },

--- a/apps/portal/hooks/bento/use-option-groups.ts
+++ b/apps/portal/hooks/bento/use-option-groups.ts
@@ -1,0 +1,51 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+
+import { createClient } from "@/lib/supabase/client"
+import type { OptionGroup, OptionValue } from "@/lib/bento/types"
+
+import { queryKeys } from "./query-keys"
+
+// Fetches a restaurant's option groups (e.g. 甜度, 冰量) with their values.
+// Flat two-step query (groups, then values) so typing does not depend on
+// relationship-based nested selects.
+export function useOptionGroups(restaurantId: string | undefined) {
+  const supabase = createClient()
+
+  return useQuery({
+    queryKey: queryKeys.optionGroups.byRestaurant(restaurantId ?? ""),
+    queryFn: async (): Promise<OptionGroup[]> => {
+      const { data: groups, error: groupsError } = await supabase
+        .from("bento_option_groups")
+        .select("id, restaurant_id, name, required, single_select, sort_order")
+        .eq("restaurant_id", restaurantId!)
+        .order("sort_order")
+
+      if (groupsError) throw groupsError
+      if (!groups || groups.length === 0) return []
+
+      const groupIds = groups.map((g) => g.id)
+      const { data: values, error: valuesError } = await supabase
+        .from("bento_option_values")
+        .select("id, group_id, label, price_delta, sort_order")
+        .in("group_id", groupIds)
+        .order("sort_order")
+
+      if (valuesError) throw valuesError
+
+      const valuesByGroup = new Map<string, OptionValue[]>()
+      for (const value of (values ?? []) as OptionValue[]) {
+        const list = valuesByGroup.get(value.group_id) ?? []
+        list.push(value)
+        valuesByGroup.set(value.group_id, list)
+      }
+
+      return groups.map((group) => ({
+        ...group,
+        values: valuesByGroup.get(group.id) ?? [],
+      }))
+    },
+    enabled: !!restaurantId,
+  })
+}

--- a/apps/portal/hooks/bento/use-order-items.ts
+++ b/apps/portal/hooks/bento/use-order-items.ts
@@ -106,6 +106,44 @@ export function useAddAnonymousItem() {
   })
 }
 
+interface AddWithOptionsParams {
+  order_id: string
+  menu_item_id: string
+  option_value_ids: string[]
+  no_sauce?: boolean
+  user_id?: string | null
+  anonymous_name?: string | null
+  anonymous_contact?: string | null
+}
+
+// Adds an order item together with its selected options (e.g. 甜度/冰量) in one
+// atomic RPC. The RPC enforces that every required option group is satisfied, so
+// mandatory ice/sugar cannot be bypassed. Used for drink shops.
+export function useAddOrderItemWithOptions() {
+  const supabase = createClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (params: AddWithOptionsParams) => {
+      const { data, error } = await supabase.rpc("add_bento_order_item", {
+        p_order_id: params.order_id,
+        p_menu_item_id: params.menu_item_id,
+        p_option_value_ids: params.option_value_ids,
+        p_no_sauce: params.no_sauce ?? false,
+        p_user_id: params.user_id ?? undefined,
+        p_anonymous_name: params.anonymous_name ?? undefined,
+        p_anonymous_contact: params.anonymous_contact ?? undefined,
+      })
+
+      if (error) throw error
+      return data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.orders.all })
+    },
+  })
+}
+
 export function useDeleteOrderItem() {
   const supabase = createClient()
   const queryClient = useQueryClient()

--- a/apps/portal/hooks/bento/use-orders.ts
+++ b/apps/portal/hooks/bento/use-orders.ts
@@ -79,6 +79,57 @@ export function useOrder(id: string | undefined) {
         }
       }
 
+      // Attach selected options (e.g. 甜度/冰量) to each item, flat-queried so
+      // typing does not depend on relationship-based nested selects.
+      if (order?.order_items && order.order_items.length > 0) {
+        const enriched = order.order_items
+        const itemIds = enriched.map((item) => item.id)
+        const { data: picks } = await supabase
+          .from("bento_order_item_options")
+          .select("order_item_id, option_value_id")
+          .in("order_item_id", itemIds)
+
+        if (picks && picks.length > 0) {
+          const valueIds = [...new Set(picks.map((p) => p.option_value_id))]
+          const { data: values } = await supabase
+            .from("bento_option_values")
+            .select("id, label, group_id, sort_order")
+            .in("id", valueIds)
+          const groupIds = [...new Set((values ?? []).map((v) => v.group_id))]
+          const { data: groups } = await supabase
+            .from("bento_option_groups")
+            .select("id, name, sort_order")
+            .in("id", groupIds)
+
+          const valueMap = new Map((values ?? []).map((v) => [v.id, v]))
+          const groupMap = new Map((groups ?? []).map((g) => [g.id, g]))
+
+          const byItem = new Map<
+            string,
+            Array<{ group_name: string; label: string; group_sort: number }>
+          >()
+          for (const pick of picks) {
+            const value = valueMap.get(pick.option_value_id)
+            if (!value) continue
+            const group = groupMap.get(value.group_id)
+            const list = byItem.get(pick.order_item_id) ?? []
+            list.push({
+              group_name: group?.name ?? "",
+              label: value.label,
+              group_sort: group?.sort_order ?? 0,
+            })
+            byItem.set(pick.order_item_id, list)
+          }
+
+          order.order_items = enriched.map((item) => ({
+            ...item,
+            selected_options: (byItem.get(item.id) ?? [])
+              .sort((a, b) => a.group_sort - b.group_sort)
+              .map(({ group_name, label }) => ({ group_name, label })),
+          }))
+        }
+      }
+
       return order
     },
     enabled: !!id,

--- a/apps/portal/lib/bento/types.ts
+++ b/apps/portal/lib/bento/types.ts
@@ -13,7 +13,32 @@ export interface Restaurant {
   phone: string
   google_map_link?: string | null
   additional?: string[] | null
+  kind?: "meal" | "drinks"
   created_at: string
+}
+
+export interface OptionValue {
+  id: string
+  group_id: string
+  label: string
+  price_delta: number
+  sort_order: number
+}
+
+export interface OptionGroup {
+  id: string
+  restaurant_id: string
+  name: string
+  required: boolean
+  single_select: boolean
+  sort_order: number
+  values: OptionValue[]
+}
+
+// A selected option shown on an order item (group name + chosen label).
+export interface SelectedOption {
+  group_name: string
+  label: string
 }
 
 export interface OrderItem {
@@ -36,6 +61,7 @@ export interface OrderItemWithUser extends OrderItem {
     name: string | null
     email?: string
   } | null
+  selected_options?: SelectedOption[]
 }
 
 export interface Order {

--- a/apps/portal/lib/supabase/database.types.ts
+++ b/apps/portal/lib/supabase/database.types.ts
@@ -397,6 +397,7 @@ export type Database = {
           google_map_link: string | null
           id: string
           is_active: boolean
+          kind: string
           name: string
           phone: string
           updated_at: string | null
@@ -407,6 +408,7 @@ export type Database = {
           google_map_link?: string | null
           id?: string
           is_active?: boolean
+          kind?: string
           name: string
           phone: string
           updated_at?: string | null
@@ -417,11 +419,112 @@ export type Database = {
           google_map_link?: string | null
           id?: string
           is_active?: boolean
+          kind?: string
           name?: string
           phone?: string
           updated_at?: string | null
         }
         Relationships: []
+      }
+      bento_option_groups: {
+        Row: {
+          created_at: string
+          id: string
+          name: string
+          required: boolean
+          restaurant_id: string
+          single_select: boolean
+          sort_order: number
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          name: string
+          required?: boolean
+          restaurant_id: string
+          single_select?: boolean
+          sort_order?: number
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          name?: string
+          required?: boolean
+          restaurant_id?: string
+          single_select?: boolean
+          sort_order?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "bento_option_groups_restaurant_id_fkey"
+            columns: ["restaurant_id"]
+            isOneToOne: false
+            referencedRelation: "bento_menus"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      bento_option_values: {
+        Row: {
+          group_id: string
+          id: string
+          label: string
+          price_delta: number
+          sort_order: number
+        }
+        Insert: {
+          group_id: string
+          id?: string
+          label: string
+          price_delta?: number
+          sort_order?: number
+        }
+        Update: {
+          group_id?: string
+          id?: string
+          label?: string
+          price_delta?: number
+          sort_order?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "bento_option_values_group_id_fkey"
+            columns: ["group_id"]
+            isOneToOne: false
+            referencedRelation: "bento_option_groups"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      bento_order_item_options: {
+        Row: {
+          option_value_id: string
+          order_item_id: string
+        }
+        Insert: {
+          option_value_id: string
+          order_item_id: string
+        }
+        Update: {
+          option_value_id?: string
+          order_item_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "bento_order_item_options_option_value_id_fkey"
+            columns: ["option_value_id"]
+            isOneToOne: false
+            referencedRelation: "bento_option_values"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "bento_order_item_options_order_item_id_fkey"
+            columns: ["order_item_id"]
+            isOneToOne: false
+            referencedRelation: "bento_order_items"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       bento_order_items: {
         Row: {
@@ -2083,6 +2186,34 @@ export type Database = {
       }
     }
     Functions: {
+      add_bento_order_item: {
+        Args: {
+          p_anonymous_contact?: string
+          p_anonymous_name?: string
+          p_menu_item_id: string
+          p_no_sauce?: boolean
+          p_option_value_ids?: string[]
+          p_order_id: string
+          p_user_id?: string
+        }
+        Returns: {
+          additional: number | null
+          anonymous_contact: string | null
+          anonymous_name: string | null
+          created_at: string | null
+          id: string
+          menu_item_id: string
+          no_sauce: boolean | null
+          order_id: string
+          user_id: string | null
+        }
+        SetofOptions: {
+          from: "*"
+          to: "bento_order_items"
+          isOneToOne: true
+          isSetofReturn: false
+        }
+      }
       approve_doc_status: { Args: { doc_id: string }; Returns: string }
       approve_is_creator: {
         Args: { doc_id: string; uid: string }

--- a/supabase/migrations/2026-07-03-bento-drinks-option-groups.sql
+++ b/supabase/migrations/2026-07-03-bento-drinks-option-groups.sql
@@ -1,0 +1,284 @@
+-- Drink-shop support for bento, with a NORMALIZED per-restaurant option model.
+--
+-- Motivation: the existing customization is denormalized — bento_menus.additional
+-- is a jsonb string array (one implicit single-select group) chosen per item via
+-- bento_order_items.additional (int index), plus a hardcoded no_sauce boolean.
+-- Drink shops need mandatory 甜度/冰量, which shouldn't be stuffed into more jsonb.
+--
+-- Model:
+--   * bento_menus.kind ('meal' | 'drinks') marks a restaurant as a drink shop.
+--   * bento_option_groups: named option groups per restaurant (e.g. 甜度, 冰量),
+--     each required? and single_select?
+--   * bento_option_values: the choices in a group (無糖, 1分糖, 去冰, ...).
+--   * bento_order_item_options: which values an order item selected (M:N).
+-- Mandatory groups are enforced in add_bento_order_item() (DB-level), not just UI.
+--
+-- RLS mirrors the existing bento tables: option groups/values are world-readable
+-- and admin-writable; selections are world-readable but only writable through the
+-- SECURITY DEFINER RPC (no direct INSERT policy), which is what enforces "required".
+
+-- 1. Restaurant kind ------------------------------------------------------------
+alter table public.bento_menus
+  add column if not exists kind text not null default 'meal'
+  check (kind in ('meal', 'drinks'));
+
+-- 2. Normalized option tables ---------------------------------------------------
+create table if not exists public.bento_option_groups (
+  id            uuid primary key default gen_random_uuid(),
+  restaurant_id uuid not null references public.bento_menus(id) on delete cascade,
+  name          text not null,
+  required      boolean not null default false,
+  single_select boolean not null default true,
+  sort_order    int not null default 0,
+  created_at    timestamptz not null default now()
+);
+
+create table if not exists public.bento_option_values (
+  id         uuid primary key default gen_random_uuid(),
+  group_id   uuid not null references public.bento_option_groups(id) on delete cascade,
+  label      text not null,
+  price_delta numeric not null default 0,
+  sort_order int not null default 0
+);
+
+create table if not exists public.bento_order_item_options (
+  order_item_id   uuid not null references public.bento_order_items(id) on delete cascade,
+  option_value_id uuid not null references public.bento_option_values(id) on delete cascade,
+  primary key (order_item_id, option_value_id)
+);
+
+create index if not exists bento_option_groups_restaurant_idx
+  on public.bento_option_groups (restaurant_id);
+create index if not exists bento_option_values_group_idx
+  on public.bento_option_values (group_id);
+create index if not exists bento_order_item_options_value_idx
+  on public.bento_order_item_options (option_value_id);
+
+-- 3. RLS ------------------------------------------------------------------------
+alter table public.bento_option_groups enable row level security;
+alter table public.bento_option_values enable row level security;
+alter table public.bento_order_item_options enable row level security;
+
+-- Option groups: world-readable, admin-writable (mirror bento_menu_items).
+create policy "Anyone can view option groups"
+  on public.bento_option_groups for select using (true);
+create policy "Admins can manage option groups"
+  on public.bento_option_groups for all
+  using (has_role(auth.uid(), 'bento', 'admin'))
+  with check (has_role(auth.uid(), 'bento', 'admin'));
+
+create policy "Anyone can view option values"
+  on public.bento_option_values for select using (true);
+create policy "Admins can manage option values"
+  on public.bento_option_values for all
+  using (has_role(auth.uid(), 'bento', 'admin'))
+  with check (has_role(auth.uid(), 'bento', 'admin'));
+
+-- Selections: world-readable; NO direct write policy on purpose — only the
+-- SECURITY DEFINER RPC below (and service_role) may insert, so "required groups
+-- must be selected" cannot be bypassed by a direct client insert. Deletes happen
+-- via ON DELETE CASCADE when the parent order item is removed.
+create policy "Anyone can view order item options"
+  on public.bento_order_item_options for select using (true);
+
+-- 4. Atomic add-with-options RPC ------------------------------------------------
+-- Replaces the three direct-insert paths for drink orders: inserts the order item
+-- and its option selections in one transaction, and validates that every required
+-- option group for the item's restaurant is satisfied. Re-implements the identity
+-- checks that the bento_order_items INSERT policies enforce (self / anon / admin).
+create or replace function public.add_bento_order_item(
+  p_order_id          text,
+  p_menu_item_id      uuid,
+  p_option_value_ids  uuid[] default '{}',
+  p_no_sauce          boolean default false,
+  p_user_id           uuid default null,
+  p_anonymous_name    text default null,
+  p_anonymous_contact text default null
+)
+returns bento_order_items
+language plpgsql
+security definer
+set search_path to 'public'
+as $function$
+declare
+  v_uid     uuid := auth.uid();
+  v_rid     uuid;
+  v_missing text;
+  v_item    public.bento_order_items;
+begin
+  -- Order must exist and be open.
+  select restaurant_id into v_rid
+  from public.bento_orders where id = p_order_id and status = 'active';
+  if v_rid is null then
+    raise exception '訂單不存在或已關閉' using errcode = 'P0001';
+  end if;
+
+  -- Menu item must belong to this order's restaurant.
+  if not exists (
+    select 1 from public.bento_menu_items
+    where id = p_menu_item_id and restaurant_id = v_rid
+  ) then
+    raise exception '品項不屬於此訂單的店家' using errcode = 'P0001';
+  end if;
+
+  -- Every provided option value must belong to a group of this restaurant.
+  if exists (
+    select 1 from unnest(p_option_value_ids) as sel(vid)
+    left join public.bento_option_values ov on ov.id = sel.vid
+    left join public.bento_option_groups og on og.id = ov.group_id
+    where ov.id is null or og.restaurant_id is distinct from v_rid
+  ) then
+    raise exception '選項不合法' using errcode = 'P0001';
+  end if;
+
+  -- Every required group must have at least one selected value.
+  select string_agg(og.name, '、' order by og.sort_order) into v_missing
+  from public.bento_option_groups og
+  where og.restaurant_id = v_rid
+    and og.required
+    and not exists (
+      select 1 from unnest(p_option_value_ids) as sel(vid)
+      join public.bento_option_values ov on ov.id = sel.vid
+      where ov.group_id = og.id
+    );
+  if v_missing is not null then
+    raise exception '請選擇：%', v_missing using errcode = 'P0001';
+  end if;
+
+  -- Identity: mirror the bento_order_items INSERT policies.
+  if v_uid is null then
+    if p_anonymous_name is null or btrim(p_anonymous_name) = ''
+       or p_anonymous_contact is null or btrim(p_anonymous_contact) = '' then
+      raise exception '匿名點餐需填姓名與聯絡方式' using errcode = 'P0001';
+    end if;
+    insert into public.bento_order_items
+      (order_id, menu_item_id, user_id, no_sauce, anonymous_name, anonymous_contact)
+    values
+      (p_order_id, p_menu_item_id, null, coalesce(p_no_sauce, false),
+       btrim(p_anonymous_name), btrim(p_anonymous_contact))
+    returning * into v_item;
+  elsif p_user_id is not null and p_user_id <> v_uid then
+    if not has_role(v_uid, 'bento', 'admin') then
+      raise exception 'Forbidden: 僅管理員可代點' using errcode = 'P0001';
+    end if;
+    insert into public.bento_order_items (order_id, menu_item_id, user_id, no_sauce)
+    values (p_order_id, p_menu_item_id, p_user_id, coalesce(p_no_sauce, false))
+    returning * into v_item;
+  else
+    insert into public.bento_order_items (order_id, menu_item_id, user_id, no_sauce)
+    values (p_order_id, p_menu_item_id, v_uid, coalesce(p_no_sauce, false))
+    returning * into v_item;
+  end if;
+
+  -- Record the selections.
+  insert into public.bento_order_item_options (order_item_id, option_value_id)
+  select v_item.id, sel.vid from unnest(p_option_value_ids) as sel(vid);
+
+  return v_item;
+end;
+$function$;
+
+grant execute on function public.add_bento_order_item(text, uuid, uuid[], boolean, uuid, text, text)
+  to anon, authenticated, service_role;
+
+-- 5. Seed the 八曜和茶 drink shop ------------------------------------------------
+do $$
+declare
+  v_rid   uuid;
+  v_sugar uuid;
+  v_ice   uuid;
+begin
+  -- Seeded inactive on purpose: the shop stays hidden from the order-creation
+  -- picker (and create_bento_order rejects inactive restaurants) until the
+  -- drink-ordering frontend is deployed. Flip is_active = true to launch.
+  select id into v_rid from public.bento_menus where name = '八曜和茶' and kind = 'drinks';
+  if v_rid is null then
+    insert into public.bento_menus (name, phone, kind, is_active)
+    values ('八曜和茶', '', 'drinks', false)
+    returning id into v_rid;
+  end if;
+
+  -- Menu items (only seed once).
+  if not exists (select 1 from public.bento_menu_items where restaurant_id = v_rid) then
+    insert into public.bento_menu_items (restaurant_id, name, price, type) values
+      (v_rid, '八曜和茶', 35, '和風茶'),
+      (v_rid, '和風308', 50, '和風茶'),
+      (v_rid, '83蜂凝露', 55, '和風茶'),
+      (v_rid, '和風307', 50, '和風日式複方茶'),
+      (v_rid, '究極308', 42, '和風日式複方茶'),
+      (v_rid, '朝日覺醒紅茶', 40, '和風日式複方茶'),
+      (v_rid, '83蜂見茶', 60, '和風日式複方茶'),
+      (v_rid, '極上307', 37, '自然茶'),
+      (v_rid, '舞伎406紅茶', 46, '自然茶'),
+      (v_rid, '大地覺醒紅茶', 35, '自然茶'),
+      (v_rid, '明日清爽茶', 35, '自然茶'),
+      (v_rid, '焙煎黑烏龍', 35, '自然茶'),
+      (v_rid, '茉妃505', 40, '自然茶'),
+      (v_rid, '柚香覺醒307', 67, '纖果爽'),
+      (v_rid, '柚香覺醒紅茶', 65, '纖果爽'),
+      (v_rid, '八曜雙C纖檸露', 50, '纖果爽'),
+      (v_rid, '寧夏307', 60, '纖果爽'),
+      (v_rid, '明日清爽檸檬茶', 55, '纖果爽'),
+      (v_rid, '京楓檸檬紅茶', 50, '纖果爽'),
+      (v_rid, '八曜黑檸檬茶', 55, '纖果爽'),
+      (v_rid, '83蜂檸爽爽', 65, '纖果爽'),
+      (v_rid, '覺醒奶茶', 55, '厚奶茶'),
+      (v_rid, '匠心奶茶', 60, '厚奶茶'),
+      (v_rid, '深煎黑龍奶茶', 55, '厚奶茶'),
+      (v_rid, '京彩舞伎奶茶', 66, '厚奶茶'),
+      (v_rid, '冬戀奶茶', 66, '厚奶茶'),
+      (v_rid, '308炙燒濃乳', 66, '厚奶茶'),
+      (v_rid, '83蜂潮奶茶', 69, '厚奶茶'),
+      (v_rid, '雪匠奶茶', 69, '厚奶茶'),
+      (v_rid, '茉妃雪奶', 60, '厚奶茶'),
+      (v_rid, '八曜和風（茶乳）', 55, '鮮乳定製'),
+      (v_rid, '八曜和風（乳茶）', 65, '鮮乳定製'),
+      (v_rid, '牧場覺醒（茶乳）', 55, '鮮乳定製'),
+      (v_rid, '牧場覺醒（乳茶）', 65, '鮮乳定製'),
+      (v_rid, '牧場黑烏龍（茶乳）', 60, '鮮乳定製'),
+      (v_rid, '牧場黑烏龍（乳茶）', 70, '鮮乳定製'),
+      (v_rid, '牧場307（茶乳）', 65, '鮮乳定製'),
+      (v_rid, '牧場307（乳茶）', 75, '鮮乳定製'),
+      (v_rid, '牧場308（茶乳）', 65, '鮮乳定製'),
+      (v_rid, '牧場308（乳茶）', 75, '鮮乳定製'),
+      (v_rid, '贅澤香焙歐蕾', 66, '鮮乳定製'),
+      (v_rid, '茉妃牧場505（茶乳）', 65, '鮮乳定製'),
+      (v_rid, '茉妃牧場505（乳茶）', 75, '鮮乳定製'),
+      (v_rid, '8YO極韻白奶茶', 79, '極韻白奶茶'),
+      (v_rid, '308極韻白奶茶', 79, '極韻白奶茶'),
+      (v_rid, '307極韻白奶茶', 89, '極韻白奶茶'),
+      (v_rid, '406極韻白奶茶', 89, '極韻白奶茶'),
+      (v_rid, '茉心極韻白奶茶', 89, '極韻白奶茶'),
+      (v_rid, '樂多307', 70, '乳酸樂多'),
+      (v_rid, '樂多308', 70, '乳酸樂多'),
+      (v_rid, '八曜樂多', 60, '乳酸樂多'),
+      (v_rid, '明日樂多', 60, '乳酸樂多'),
+      (v_rid, '茉語樂多', 70, '乳酸樂多');
+  end if;
+
+  -- 甜度 (required, single-select).
+  if not exists (select 1 from public.bento_option_groups where restaurant_id = v_rid and name = '甜度') then
+    insert into public.bento_option_groups (restaurant_id, name, required, single_select, sort_order)
+    values (v_rid, '甜度', true, true, 1)
+    returning id into v_sugar;
+    insert into public.bento_option_values (group_id, label, sort_order) values
+      (v_sugar, '無糖', 1),
+      (v_sugar, '1分糖', 2),
+      (v_sugar, '3分糖', 3),
+      (v_sugar, '5分糖', 4),
+      (v_sugar, '8分糖（全糖）', 5);
+  end if;
+
+  -- 冰量 (required, single-select).
+  if not exists (select 1 from public.bento_option_groups where restaurant_id = v_rid and name = '冰量') then
+    insert into public.bento_option_groups (restaurant_id, name, required, single_select, sort_order)
+    values (v_rid, '冰量', true, true, 2)
+    returning id into v_ice;
+    insert into public.bento_option_values (group_id, label, sort_order) values
+      (v_ice, '熱', 1),
+      (v_ice, '溫', 2),
+      (v_ice, '完全去冰', 3),
+      (v_ice, '去冰五顆冰', 4),
+      (v_ice, '35%冰', 5);
+  end if;
+end $$;


### PR DESCRIPTION
Closes #252

## Summary

新增 bento **飲料店**支援，採**正規化的每店家選項模型**，讓飲料店可要求每杯必填甜度/冰量，而不是把更多選項塞進反正規化的 `bento_menus.additional` jsonb。

### Schema（migration `2026-07-03-bento-drinks-option-groups`）
- `bento_menus.kind`（`meal` | `drinks`）標記飲料店
- `bento_option_groups` / `bento_option_values`（每店家、`required`、`single_select`）+ `bento_order_item_options`（多對多選擇）
- `add_bento_order_item()` RPC：原子新增品項＋選項，並在 **DB 層**強制每個 required group 都要選（SECURITY DEFINER、`search_path` 已 pin）；選擇表**無直接 INSERT policy**，只能經 RPC 寫，避免繞過必填
- 匯入八曜和茶（53 品項）+ 必選甜度/冰量；**新店家 `is_active = false`**，前端上線前不會出現在點單選單

### 前端
- `useOptionGroups`、`useAddOrderItemWithOptions` hooks；`useOrder` 附上每個品項的已選選項供顯示
- `AddOrderItemDialog`：飲料店顯示甜度/冰量必選，未選不能「加入清單」，透過 RPC 送出；一般（meal）店家維持既有 不醬/加料 流程不變
- 訂單品項以 badge 顯示已選選項

## ⚠️ 部署狀態
- **migration 已透過 MCP 套用到線上**（version `20260702063343`… 實際 `2026-07-03-…`），並記入 `schema_migrations`，與本 PR 檔名一致。合併後**不需**再 apply。
- 已用 `get_advisors` 驗證：無 ERROR、3 張新表 RLS 皆啟用、RPC 的 `search_path` 已 pin。
- 八曜和茶目前 `is_active = false`；**前端部署後**由管理員在 `/bento/menus` 開啟即上線。

## Test plan
- [x] `tsc --noEmit`（portal）通過
- [x] `eslint`（pre-commit `--max-warnings=0`）通過
- [x] `bun test lib/bento`（28 pass）
- [x] 線上驗證：`order_date`/schema、53 品項、甜度+冰量各 5 值、RLS、search_path
- [ ] 部署後真機：開啟八曜和茶 → 建立訂單 → 新增訂餐需選甜度+冰量才能加入清單 → 送出 → 品項顯示甜度/冰量 badge
- [ ] 一般便當店流程未受影響（不醬/加料/複選/送出）
- [ ] 品名/價格 spot-check（依菜單圖轉錄）
