### PR TITLE
feat(bento): 每家店可上傳真實圖片菜單

### DIFF
--- a/apps/portal/app/bento/_components/edit-restaurant-dialog.tsx
+++ b/apps/portal/app/bento/_components/edit-restaurant-dialog.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Pencil } from "lucide-react"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@workspace/ui/components/button"
@@ -17,7 +17,11 @@ import {
 import { Input } from "@workspace/ui/components/input"
 import { Label } from "@workspace/ui/components/label"
 
-import { useUpdateMenu } from "@/hooks/bento/use-menus"
+import {
+  useRemoveMenuImage,
+  useUpdateMenu,
+  useUploadMenuImage,
+} from "@/hooks/bento/use-menus"
 
 import { MenuItemsEditor, type MenuItemDraft } from "./menu-items-editor"
 
@@ -27,6 +31,7 @@ interface Restaurant {
   phone: string
   google_map_link?: string | null
   additional?: string[] | null
+  menu_image_url?: string | null
 }
 
 interface MenuItemRow {
@@ -65,7 +70,13 @@ export function EditRestaurantDialog({
     restaurant.additional || []
   )
   const [newAdditionalOption, setNewAdditionalOption] = useState("")
+  const [menuImageUrl, setMenuImageUrl] = useState<string | null>(
+    restaurant.menu_image_url ?? null
+  )
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const updateMenu = useUpdateMenu(restaurant.id)
+  const uploadImage = useUploadMenuImage(restaurant.id)
+  const removeImage = useRemoveMenuImage(restaurant.id)
 
   useEffect(() => {
     if (open) {
@@ -74,8 +85,35 @@ export function EditRestaurantDialog({
       setGoogleMapLink(restaurant.google_map_link ?? "")
       setMenuItems(toDraft(existingMenuItems))
       setAdditionalOptions(restaurant.additional || [])
+      setMenuImageUrl(restaurant.menu_image_url ?? null)
     }
   }, [open, restaurant, existingMenuItems])
+
+  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    try {
+      const url = await uploadImage.mutateAsync(file)
+      setMenuImageUrl(url)
+      toast.success("菜單圖已上傳")
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error("上傳失敗")
+      toast.error(`上傳失敗：${err.message}`)
+    } finally {
+      if (fileInputRef.current) fileInputRef.current.value = ""
+    }
+  }
+
+  const handleImageRemove = async () => {
+    try {
+      await removeImage.mutateAsync()
+      setMenuImageUrl(null)
+      toast.success("菜單圖已移除")
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error("移除失敗")
+      toast.error(`移除失敗：${err.message}`)
+    }
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -153,6 +191,56 @@ export function EditRestaurantDialog({
                 value={phone}
                 onChange={(e) => setPhone(e.target.value)}
                 required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>菜單圖片（選填）</Label>
+              {menuImageUrl ? (
+                <div className="space-y-2">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={menuImageUrl}
+                    alt="菜單圖片"
+                    className="max-h-48 w-full rounded-md border object-contain"
+                  />
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => fileInputRef.current?.click()}
+                      disabled={uploadImage.isPending}
+                    >
+                      {uploadImage.isPending ? "上傳中..." : "更換"}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleImageRemove}
+                      disabled={removeImage.isPending}
+                    >
+                      移除
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={uploadImage.isPending}
+                >
+                  {uploadImage.isPending ? "上傳中..." : "上傳菜單圖"}
+                </Button>
+              )}
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={handleImageChange}
               />
             </div>
             <div className="space-y-2">

--- a/apps/portal/app/bento/_components/order-detail-header.tsx
+++ b/apps/portal/app/bento/_components/order-detail-header.tsx
@@ -1,8 +1,15 @@
 "use client"
 
-import { ExternalLink } from "lucide-react"
+import { ExternalLink, Image as ImageIcon } from "lucide-react"
 
 import { Badge } from "@workspace/ui/components/badge"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@workspace/ui/components/dialog"
 
 import { formatOrderDate, orderBatchSuffix } from "@/lib/bento/date"
 
@@ -32,6 +39,7 @@ interface Order {
     phone: string
     google_map_link?: string | null
     additional?: string[] | null
+    menu_image_url?: string | null
   }
   order_items?: OrderItem[]
 }
@@ -76,6 +84,30 @@ export function OrderDetailHeader({ order }: { order: Order }) {
               {order.restaurants.phone}
             </a>
           </span>
+          {order.restaurants.menu_image_url && (
+            <Dialog>
+              <DialogTrigger asChild>
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-1 text-foreground transition-colors hover:text-muted-foreground"
+                >
+                  <ImageIcon className="h-3.5 w-3.5" />
+                  查看菜單圖
+                </button>
+              </DialogTrigger>
+              <DialogContent className="max-w-3xl">
+                <DialogHeader>
+                  <DialogTitle>{order.restaurants.name} 菜單</DialogTitle>
+                </DialogHeader>
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={order.restaurants.menu_image_url}
+                  alt={`${order.restaurants.name} 菜單圖片`}
+                  className="max-h-[80vh] w-full rounded-md object-contain"
+                />
+              </DialogContent>
+            </Dialog>
+          )}
         </div>
       </div>
       <OrderStats

--- a/apps/portal/hooks/bento/use-menus.ts
+++ b/apps/portal/hooks/bento/use-menus.ts
@@ -337,3 +337,83 @@ export function useDeleteMenu(id: string) {
     },
   })
 }
+
+const MENU_IMAGE_BUCKET = "bento-menus"
+
+async function clearMenuImageFolder(
+  supabase: ReturnType<typeof createClient>,
+  restaurantId: string
+) {
+  const { data: existing } = await supabase.storage
+    .from(MENU_IMAGE_BUCKET)
+    .list(restaurantId)
+  if (existing && existing.length > 0) {
+    await supabase.storage
+      .from(MENU_IMAGE_BUCKET)
+      .remove(existing.map((f) => `${restaurantId}/${f.name}`))
+  }
+}
+
+// Uploads a restaurant's image menu to the public bento-menus bucket (one file
+// per restaurant, replacing any previous one) and stores its URL on the row.
+export function useUploadMenuImage(restaurantId: string) {
+  const supabase = createClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (file: File) => {
+      await clearMenuImageFolder(supabase, restaurantId)
+
+      const ext = file.name.split(".").pop()?.toLowerCase() || "jpg"
+      const path = `${restaurantId}/menu.${ext}`
+      const { error: uploadError } = await supabase.storage
+        .from(MENU_IMAGE_BUCKET)
+        .upload(path, file, { upsert: true, contentType: file.type })
+      if (uploadError) throw uploadError
+
+      const {
+        data: { publicUrl },
+      } = supabase.storage.from(MENU_IMAGE_BUCKET).getPublicUrl(path)
+      // Cache-bust so the <img> refreshes when the menu is replaced.
+      const url = `${publicUrl}?v=${Date.now()}`
+
+      const { error: updateError } = await supabase
+        .from("bento_menus")
+        .update({ menu_image_url: url, updated_at: new Date().toISOString() })
+        .eq("id", restaurantId)
+      if (updateError) throw updateError
+
+      return url
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.menus.all })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.menus.detail(restaurantId),
+      })
+      queryClient.invalidateQueries({ queryKey: queryKeys.orders.all })
+    },
+  })
+}
+
+export function useRemoveMenuImage(restaurantId: string) {
+  const supabase = createClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async () => {
+      await clearMenuImageFolder(supabase, restaurantId)
+      const { error } = await supabase
+        .from("bento_menus")
+        .update({ menu_image_url: null, updated_at: new Date().toISOString() })
+        .eq("id", restaurantId)
+      if (error) throw error
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.menus.all })
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.menus.detail(restaurantId),
+      })
+      queryClient.invalidateQueries({ queryKey: queryKeys.orders.all })
+    },
+  })
+}

--- a/apps/portal/lib/bento/types.ts
+++ b/apps/portal/lib/bento/types.ts
@@ -14,6 +14,7 @@ export interface Restaurant {
   google_map_link?: string | null
   additional?: string[] | null
   kind?: "meal" | "drinks"
+  menu_image_url?: string | null
   created_at: string
 }
 

--- a/apps/portal/lib/supabase/database.types.ts
+++ b/apps/portal/lib/supabase/database.types.ts
@@ -398,6 +398,7 @@ export type Database = {
           id: string
           is_active: boolean
           kind: string
+          menu_image_url: string | null
           name: string
           phone: string
           updated_at: string | null
@@ -409,6 +410,7 @@ export type Database = {
           id?: string
           is_active?: boolean
           kind?: string
+          menu_image_url?: string | null
           name: string
           phone: string
           updated_at?: string | null
@@ -420,6 +422,7 @@ export type Database = {
           id?: string
           is_active?: boolean
           kind?: string
+          menu_image_url?: string | null
           name?: string
           phone?: string
           updated_at?: string | null

--- a/supabase/migrations/2026-07-03-bento-menu-image.sql
+++ b/supabase/migrations/2026-07-03-bento-menu-image.sql
@@ -1,0 +1,40 @@
+-- Per-restaurant uploaded image menu (a real photo/scan of the shop's menu).
+--
+-- Stores the public URL on bento_menus and keeps the file in a public
+-- 'bento-menus' storage bucket. Uploads/replacements are gated to bento admins
+-- (shared, admin-managed content), while anyone can view — mirroring how the
+-- rest of bento is world-readable + admin-writable.
+
+alter table public.bento_menus
+  add column if not exists menu_image_url text;
+
+-- Public bucket for menu images.
+insert into storage.buckets (id, name, public)
+values ('bento-menus', 'bento-menus', true)
+on conflict (id) do nothing;
+
+-- Anyone can read; only bento admins can write.
+create policy "bento_menus_storage_select"
+  on storage.objects for select
+  using (bucket_id = 'bento-menus');
+
+create policy "bento_menus_storage_insert"
+  on storage.objects for insert
+  with check (
+    bucket_id = 'bento-menus' and has_role(auth.uid(), 'bento', 'admin')
+  );
+
+create policy "bento_menus_storage_update"
+  on storage.objects for update
+  using (
+    bucket_id = 'bento-menus' and has_role(auth.uid(), 'bento', 'admin')
+  )
+  with check (
+    bucket_id = 'bento-menus' and has_role(auth.uid(), 'bento', 'admin')
+  );
+
+create policy "bento_menus_storage_delete"
+  on storage.objects for delete
+  using (
+    bucket_id = 'bento-menus' and has_role(auth.uid(), 'bento', 'admin')
+  );


### PR DESCRIPTION
Closes #254

## Summary

每家店可上傳一張真實的圖片菜單（菜單照片／掃描圖），點餐的人能直接看原始菜單。

- **Migration `2026-07-03-bento-menu-image`**：`bento_menus.menu_image_url` + public storage bucket `bento-menus`；storage 寫入限 bento admin、讀取全開（比照 bento 其餘表的「全讀、admin 寫」）。
- **Hooks**：`useUploadMenuImage` / `useRemoveMenuImage` —— 一家一張，上傳前先清掉舊檔避免孤兒檔，存公開 URL（加 `?v=` cache-bust）。
- **編輯店家對話框**：admin 上傳／更換／移除，含預覽。
- **訂單詳情頁**：`查看菜單圖` 按鈕開 lightbox 看大圖。
- `<img>` 沿用 repo 既有的 `eslint-disable @next/next/no-img-element` 慣例。

## ⚠️ 部署狀態
- **migration 已透過 MCP 套用到線上**並記入 `schema_migrations`（含 `bento-menus` bucket 與 storage policies），與本 PR 檔名一致；合併後不需再 apply。

## Test plan
- [x] `tsc --noEmit`（portal）通過
- [x] `eslint`（pre-commit `--max-warnings=0`）通過
- [x] `bun test lib/bento`（28 pass）
- [ ] 部署後：admin 在「編輯店家」上傳圖片 → 預覽出現；訂單詳情頁出現「查看菜單圖」→ lightbox 顯示
- [ ] 非 admin 無法上傳（storage policy 擋）；一般使用者看得到圖
- [ ] 更換圖片後舊檔被清除、新圖即時刷新（cache-bust）
