### PR TITLE
feat(bento): 放大菜單圖 lightbox＋點餐對話框可查看菜單圖

### DIFF
--- a/apps/portal/app/bento/_components/add-order-item-dialog.tsx
+++ b/apps/portal/app/bento/_components/add-order-item-dialog.tsx
@@ -38,6 +38,8 @@ import { useOrder } from "@/hooks/bento/use-orders"
 import { useUsers } from "@/hooks/bento/use-users"
 import { useAuth } from "@/hooks/use-auth"
 
+import { MenuImageButton } from "./menu-image-dialog"
+
 interface MenuItem {
   id: string
   name: string
@@ -119,6 +121,7 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
 
   const restaurantAdditionalOptions: string[] | null =
     order?.restaurants?.additional || null
+  const menuImageUrl = order?.restaurants?.menu_image_url
 
   const groups = optionGroups ?? []
   const isDrinks = groups.length > 0
@@ -355,6 +358,15 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
         </DialogHeader>
         <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
           <div className="min-h-0 flex-1 space-y-4 overflow-y-auto py-4">
+            {menuImageUrl && (
+              <div className="flex justify-end">
+                <MenuImageButton
+                  imageUrl={menuImageUrl}
+                  shopName={order?.restaurants?.name ?? "菜單"}
+                  className="text-sm text-muted-foreground"
+                />
+              </div>
+            )}
             {isAnonymous && (
               <div className="space-y-3">
                 <Input

--- a/apps/portal/app/bento/_components/menu-image-dialog.tsx
+++ b/apps/portal/app/bento/_components/menu-image-dialog.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { Image as ImageIcon } from "lucide-react"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@workspace/ui/components/dialog"
+import { cn } from "@workspace/ui/lib/utils"
+
+// A "查看菜單圖" trigger that opens the shop's uploaded menu image in a large,
+// scrollable lightbox. Menu photos are wide/high-res, so the dialog goes near
+// full-width and links to the original for reading fine print.
+export function MenuImageButton({
+  imageUrl,
+  shopName,
+  className,
+}: {
+  imageUrl: string
+  shopName: string
+  className?: string
+}) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "inline-flex items-center gap-1 text-foreground transition-colors hover:text-muted-foreground",
+            className
+          )}
+        >
+          <ImageIcon className="h-3.5 w-3.5" />
+          查看菜單圖
+        </button>
+      </DialogTrigger>
+      <DialogContent className="max-w-[95vw] gap-3 sm:max-w-[95vw]">
+        <DialogHeader>
+          <DialogTitle>{shopName} 菜單</DialogTitle>
+        </DialogHeader>
+        <div className="max-h-[80vh] overflow-auto rounded-md border">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={imageUrl}
+            alt={`${shopName} 菜單圖片`}
+            className="mx-auto h-auto w-full"
+          />
+        </div>
+        <a
+          href={imageUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+        >
+          在新分頁開啟原圖（看更清楚）
+        </a>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/portal/app/bento/_components/order-detail-header.tsx
+++ b/apps/portal/app/bento/_components/order-detail-header.tsx
@@ -1,18 +1,12 @@
 "use client"
 
-import { ExternalLink, Image as ImageIcon } from "lucide-react"
+import { ExternalLink } from "lucide-react"
 
 import { Badge } from "@workspace/ui/components/badge"
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@workspace/ui/components/dialog"
 
 import { formatOrderDate, orderBatchSuffix } from "@/lib/bento/date"
 
+import { MenuImageButton } from "./menu-image-dialog"
 import { OrderStats } from "./order-stats"
 
 interface OrderItem {
@@ -85,28 +79,10 @@ export function OrderDetailHeader({ order }: { order: Order }) {
             </a>
           </span>
           {order.restaurants.menu_image_url && (
-            <Dialog>
-              <DialogTrigger asChild>
-                <button
-                  type="button"
-                  className="inline-flex items-center gap-1 text-foreground transition-colors hover:text-muted-foreground"
-                >
-                  <ImageIcon className="h-3.5 w-3.5" />
-                  查看菜單圖
-                </button>
-              </DialogTrigger>
-              <DialogContent className="max-w-3xl">
-                <DialogHeader>
-                  <DialogTitle>{order.restaurants.name} 菜單</DialogTitle>
-                </DialogHeader>
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={order.restaurants.menu_image_url}
-                  alt={`${order.restaurants.name} 菜單圖片`}
-                  className="max-h-[80vh] w-full rounded-md object-contain"
-                />
-              </DialogContent>
-            </Dialog>
+            <MenuImageButton
+              imageUrl={order.restaurants.menu_image_url}
+              shopName={order.restaurants.name}
+            />
           )}
         </div>
       </div>


### PR DESCRIPTION
Closes #256

## Summary
- 菜單圖 lightbox 從 `max-w-3xl`(768px) 放大到 `95vw`、可捲動，加「開啟原圖」連結 —— 修正 1920px 寬菜單被壓小、字看不清的問題。
- 抽成共用元件 `MenuImageButton`，訂單詳情頁與新增訂餐對話框共用。
- 新增訂餐對話框加入「查看菜單圖」入口，點餐時可對照菜單。

純前端，無 DB 變更。

## Test plan
- [x] tsc --noEmit 通過
- [x] eslint (pre-commit --max-warnings=0) 通過
- [ ] 部署後：訂單詳情頁 + 新增訂餐對話框都看得到「查看菜單圖」，lightbox 夠大、可捲動、可開原圖