### PR TITLE
fix(bento): 修「幫誰點餐」用戶下拉捲動卡頓（改用 popper）

### DIFF
--- a/apps/portal/app/bento/_components/add-order-item-dialog.tsx
+++ b/apps/portal/app/bento/_components/add-order-item-dialog.tsx
@@ -391,7 +391,10 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
                 <SelectTrigger className="w-full">
                   <SelectValue placeholder="代替哪位用戶點餐（留空為自己）" />
                 </SelectTrigger>
-                <SelectContent>
+                {/* popper (not item-aligned) — the ~48-user list janks on open
+                    in item-aligned mode because Radix measures/positions the
+                    whole list against the selected item. */}
+                <SelectContent position="popper">
                   {(userList ?? []).map((u) => (
                     <SelectItem key={u.id} value={u.id}>
                       {u.name ?? u.id}


### PR DESCRIPTION
Closes #258

## Summary
新增訂餐對話框（admin）「代替哪位用戶點餐」的下拉，在 ~48 位使用者時開啟/捲動卡頓。根因是預設 `position="item-aligned"`：Radix 會把整個清單對齊選中項做量測/定位，項目多就 reflow 卡。改用 `position="popper"`（輕量錨定下拉）。

與品項清單先前的 backdrop-blur 卡頓（#250）是不同病因。純前端一行改動。

## Test plan
- [x] tsc --noEmit 通過
- [x] eslint (pre-commit) 通過
- [ ] 部署後真機：admin 開新增訂餐 → 「代替哪位用戶點餐」下拉開啟/捲動順暢