### PR TITLE
fix(meetings): schedule API 接受 shared secret（修 Apps Script 401）

### DIFF
--- a/apps/portal/.env.example
+++ b/apps/portal/.env.example
@@ -27,3 +27,9 @@ NEXTCLOUD_APP_PASSWORD=
 # Used by Google Apps Script to fetch unnotified announcements and mark them sent.
 # Generate with: openssl rand -hex 32
 BULLETIN_API_SECRET=
+
+# Shared secret for the meetings schedule API.
+# Used by the Google Apps Script reminder mailer to fetch the schedule without a
+# login cookie. Send as `Authorization: Bearer $MEETINGS_API_SECRET`.
+# Generate with: openssl rand -hex 32
+MEETINGS_API_SECRET=

--- a/apps/portal/app/api/meetings/schedule/route.ts
+++ b/apps/portal/app/api/meetings/schedule/route.ts
@@ -15,6 +15,15 @@ function createServiceClient() {
 const SITE_ORIGIN =
   process.env.NEXT_PUBLIC_SITE_URL ?? "https://portal.winlab.tw"
 
+// Server-to-server callers (the Apps Script reminder mailer) can't carry a
+// Supabase login cookie, so they authenticate with a shared secret instead —
+// same pattern as the bulletin API. Browser sessions still work via cookie.
+function hasValidSecret(request: NextRequest): boolean {
+  const secret = process.env.MEETINGS_API_SECRET
+  if (!secret) return false
+  return (request.headers.get("Authorization") ?? "") === `Bearer ${secret}`
+}
+
 const CORS = {
   "Access-Control-Allow-Origin": SITE_ORIGIN,
   "Access-Control-Allow-Methods": "GET, OPTIONS",
@@ -28,15 +37,19 @@ export async function OPTIONS() {
 }
 
 export async function GET(request: NextRequest) {
-  const authClient = await createClient()
-  const {
-    data: { user },
-  } = await authClient.auth.getUser()
-  if (!user) {
-    return NextResponse.json(
-      { error: "Unauthorized" },
-      { status: 401, headers: CORS }
-    )
+  // Accept either a valid shared secret (server-to-server) or a logged-in
+  // Supabase session (browser). The secret check avoids the cookie round-trip.
+  if (!hasValidSecret(request)) {
+    const authClient = await createClient()
+    const {
+      data: { user },
+    } = await authClient.auth.getUser()
+    if (!user) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401, headers: CORS }
+      )
+    }
   }
 
   const { searchParams } = new URL(request.url)


### PR DESCRIPTION
Closes #260

## Summary
Apps Script 提醒信排程 server-to-server 呼叫 `/api/meetings/schedule` 一律 401（無登入 cookie）。比照 bulletin API，讓此端點接受 `Authorization: Bearer $MEETINGS_API_SECRET` 作為替代授權；帶對 secret 或有登入 cookie 皆放行。

**不公開端點** —— 回傳含 `presenter_email`（PII，屬安全稽核 #182 的類型），且 Apps Script 實際用它寄講者提醒信。

- `route.ts`：加 `hasValidSecret()`，secret 通過則跳過 cookie 檢查。
- `.env.example`：新增 `MEETINGS_API_SECRET`（空模板）。

## ⚠️ 部署 / 另一 repo
- 在 Vercel 設 `MEETINGS_API_SECRET`（`openssl rand -hex 32`）。
- Apps Script（`~/Downloads/google-script/`，另一 repo）已改：`ReminderEmail.gs` `safeGetSchedule` 帶 Authorization header、`Config.gs` 加 `SCHEDULE_API_SECRET`。把同一 secret 值填進 `Config.gs` 並重新部署 clasp。

## Test plan
- [x] tsc --noEmit 通過
- [x] eslint (pre-commit) 通過
- [ ] 設好 secret 後：帶 `Authorization: Bearer <secret>` 呼叫 → 200；不帶 → 401；帶錯 → 401
- [ ] 有登入 cookie 的瀏覽器呼叫仍 200（向後相容）
- [ ] Apps Script 提醒信排程恢復正常