### PR TITLE
feat: redirect bento.winlab.tw to portal.winlab.tw/bento

### DIFF
--- a/apps/portal/next.config.mjs
+++ b/apps/portal/next.config.mjs
@@ -1,6 +1,17 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   transpilePackages: ["@workspace/ui"],
+  async redirects() {
+    return [
+      // bento.winlab.tw is retired — the app lives at /bento now
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "bento.winlab.tw" }],
+        destination: "https://portal.winlab.tw/bento",
+        permanent: true,
+      },
+    ]
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
Closes #262

## Summary
Adds a host-based permanent redirect in `apps/portal/next.config.mjs`: requests arriving with `Host: bento.winlab.tw` are 308-redirected to `https://portal.winlab.tw/bento`. Once merged and deployed, the `bento.winlab.tw` domain moves to the `portal-winlab-tw` Vercel project, the standalone Vercel project gets deleted, and the old repo is archived.

## Test plan
- [x] CI (lint / typecheck / build / tests)
- [ ] After domain move: `curl -I https://bento.winlab.tw` → 308 → `https://portal.winlab.tw/bento`
- [ ] `portal.winlab.tw` itself unaffected (host rule doesn't match)