### PR TITLE
feat(bento): support priced add-ons for drink orders

### DIFF
--- a/apps/portal/app/bento/_components/add-order-item-dialog.tsx
+++ b/apps/portal/app/bento/_components/add-order-item-dialog.tsx
@@ -94,7 +94,7 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
     null
   )
   const [selectedOptions, setSelectedOptions] = useState<
-    Record<string, string>
+    Record<string, string[]>
   >({})
   const [cart, setCart] = useState<CartLine[]>([])
   const [targetUserId, setTargetUserId] = useState<string | null>(null)
@@ -200,7 +200,9 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
     }
   }
 
-  const pendingOptionsMet = requiredGroups.every((g) => selectedOptions[g.id])
+  const pendingOptionsMet = requiredGroups.every(
+    (g) => (selectedOptions[g.id]?.length ?? 0) > 0
+  )
 
   // Monotonic counter so cart keys stay unique across add/remove sequences
   // even when crypto.randomUUID is unavailable (e.g. plain-http contexts).
@@ -223,7 +225,7 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
         menu_item_id: selectedItem,
         no_sauce: isDrinks ? false : noSauce,
         additional: isDrinks ? null : selectedAdditional,
-        optionValueIds: isDrinks ? Object.values(selectedOptions) : [],
+        optionValueIds: isDrinks ? Object.values(selectedOptions).flat() : [],
       },
     ])
     resetSelection()
@@ -449,38 +451,78 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
                 </SelectContent>
               </Select>
 
-              {/* Drink shops: mandatory option groups (甜度 / 冰量). */}
+              {/* Drink shops: mandatory single-select groups (甜度 / 冰量)
+                  plus optional multi-select add-ons (加料). */}
               {isDrinks &&
-                groups.map((group) => (
-                  <div key={group.id} className="flex items-center gap-3">
-                    <Label className="w-12 shrink-0 text-sm">
-                      {group.name}
-                      {group.required && (
-                        <span className="text-destructive"> *</span>
-                      )}
-                    </Label>
-                    <Select
-                      value={selectedOptions[group.id] ?? ""}
-                      onValueChange={(v) =>
-                        setSelectedOptions((prev) => ({
-                          ...prev,
-                          [group.id]: v,
-                        }))
-                      }
-                    >
-                      <SelectTrigger className="w-full">
-                        <SelectValue placeholder={`選擇${group.name}`} />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {group.values.map((v) => (
-                          <SelectItem key={v.id} value={v.id}>
-                            {v.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                ))}
+                groups.map((group) =>
+                  group.single_select ? (
+                    <div key={group.id} className="flex items-center gap-3">
+                      <Label className="w-12 shrink-0 text-sm">
+                        {group.name}
+                        {group.required && (
+                          <span className="text-destructive"> *</span>
+                        )}
+                      </Label>
+                      <Select
+                        value={selectedOptions[group.id]?.[0] ?? ""}
+                        onValueChange={(v) =>
+                          setSelectedOptions((prev) => ({
+                            ...prev,
+                            [group.id]: v ? [v] : [],
+                          }))
+                        }
+                      >
+                        <SelectTrigger className="w-full">
+                          <SelectValue placeholder={`選擇${group.name}`} />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {group.values.map((v) => (
+                            <SelectItem key={v.id} value={v.id}>
+                              {v.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  ) : (
+                    <div key={group.id} className="space-y-2">
+                      <Label className="text-sm">{group.name}</Label>
+                      <div className="flex flex-wrap gap-x-4 gap-y-2">
+                        {group.values.map((v) => {
+                          const checked =
+                            selectedOptions[group.id]?.includes(v.id) ?? false
+                          return (
+                            <div key={v.id} className="flex items-center gap-2">
+                              <Checkbox
+                                id={`opt-${v.id}`}
+                                checked={checked}
+                                onCheckedChange={(next) =>
+                                  setSelectedOptions((prev) => {
+                                    const current = prev[group.id] ?? []
+                                    return {
+                                      ...prev,
+                                      [group.id]:
+                                        next === true
+                                          ? [...current, v.id]
+                                          : current.filter((id) => id !== v.id),
+                                    }
+                                  })
+                                }
+                              />
+                              <Label
+                                htmlFor={`opt-${v.id}`}
+                                className="cursor-pointer font-normal whitespace-nowrap"
+                              >
+                                {v.label}
+                                {v.price_delta > 0 && ` +$${v.price_delta}`}
+                              </Label>
+                            </div>
+                          )
+                        })}
+                      </div>
+                    </div>
+                  )
+                )}
 
               {/* Meal shops: 不醬 + restaurant additional option. */}
               {!isDrinks && (

--- a/apps/portal/app/bento/_components/add-order-item-dialog.tsx
+++ b/apps/portal/app/bento/_components/add-order-item-dialog.tsx
@@ -58,7 +58,10 @@ interface CartLine {
   optionValueIds: string[]
 }
 
-type ValueLabel = Map<string, { group: string; label: string; sort: number }>
+type ValueLabel = Map<
+  string,
+  { group: string; label: string; price_delta: number; sort: number }
+>
 
 function describeLine(
   line: Pick<
@@ -76,7 +79,9 @@ function describeLine(
     .map((id) => valueLabel.get(id))
     .filter((v): v is NonNullable<typeof v> => Boolean(v))
     .sort((a, b) => a.sort - b.sort)
-    .forEach((v) => parts.push(v.label))
+    .forEach((v) =>
+      parts.push(v.price_delta > 0 ? `${v.label} +$${v.price_delta}` : v.label)
+    )
 
   if (line.no_sauce) parts.push("不醬")
   const additionalLabel =
@@ -133,6 +138,7 @@ export function AddOrderItemDialog({ orderId }: { orderId: string }) {
       valueLabel.set(v.id, {
         group: g.name,
         label: v.label,
+        price_delta: v.price_delta,
         sort: g.sort_order,
       })
     )

--- a/apps/portal/app/bento/_components/order-items-list.tsx
+++ b/apps/portal/app/bento/_components/order-items-list.tsx
@@ -25,7 +25,11 @@ interface OrderItem {
     name: string | null
     email?: string
   } | null
-  selected_options?: { group_name: string; label: string }[]
+  selected_options?: {
+    group_name: string
+    label: string
+    price_delta: number
+  }[]
 }
 
 interface GroupedOrderItem {
@@ -73,8 +77,12 @@ export function OrderItemsList({
           total: 0,
         }
       }
+      const optionsTotal = (item.selected_options ?? []).reduce(
+        (sum, opt) => sum + opt.price_delta,
+        0
+      )
       acc[groupKey].items.push(item)
-      acc[groupKey].total += item.menu_items?.price || 0
+      acc[groupKey].total += (item.menu_items?.price || 0) + optionsTotal
       return acc
     },
     {} as Record<string, GroupedOrderItem>
@@ -126,6 +134,7 @@ export function OrderItemsList({
                       className="px-2 py-0.5 text-[11px]"
                     >
                       {opt.label}
+                      {opt.price_delta > 0 && ` +$${opt.price_delta}`}
                     </Badge>
                   ))}
                   {item.no_sauce && (

--- a/apps/portal/hooks/bento/use-orders.ts
+++ b/apps/portal/hooks/bento/use-orders.ts
@@ -93,7 +93,7 @@ export function useOrder(id: string | undefined) {
           const valueIds = [...new Set(picks.map((p) => p.option_value_id))]
           const { data: values } = await supabase
             .from("bento_option_values")
-            .select("id, label, group_id, sort_order")
+            .select("id, label, price_delta, group_id, sort_order")
             .in("id", valueIds)
           const groupIds = [...new Set((values ?? []).map((v) => v.group_id))]
           const { data: groups } = await supabase
@@ -106,7 +106,12 @@ export function useOrder(id: string | undefined) {
 
           const byItem = new Map<
             string,
-            Array<{ group_name: string; label: string; group_sort: number }>
+            Array<{
+              group_name: string
+              label: string
+              price_delta: number
+              group_sort: number
+            }>
           >()
           for (const pick of picks) {
             const value = valueMap.get(pick.option_value_id)
@@ -116,6 +121,7 @@ export function useOrder(id: string | undefined) {
             list.push({
               group_name: group?.name ?? "",
               label: value.label,
+              price_delta: value.price_delta,
               group_sort: group?.sort_order ?? 0,
             })
             byItem.set(pick.order_item_id, list)
@@ -125,7 +131,11 @@ export function useOrder(id: string | undefined) {
             ...item,
             selected_options: (byItem.get(item.id) ?? [])
               .sort((a, b) => a.group_sort - b.group_sort)
-              .map(({ group_name, label }) => ({ group_name, label })),
+              .map(({ group_name, label, price_delta }) => ({
+                group_name,
+                label,
+                price_delta,
+              })),
           }))
         }
       }

--- a/apps/portal/lib/bento/fetch.ts
+++ b/apps/portal/lib/bento/fetch.ts
@@ -5,6 +5,9 @@ import type { OrderWithStats } from "@/lib/bento/types"
 interface OrderItemRaw {
   user_id: string | null
   menu_items?: { name: string; price: number } | null
+  bento_order_item_options?: Array<{
+    bento_option_values: { price_delta: number } | null
+  }> | null
 }
 
 function computeOrderStats(orderItems: OrderItemRaw[]) {
@@ -18,7 +21,11 @@ function computeOrderStats(orderItems: OrderItemRaw[]) {
   for (const item of orderItems) {
     const name = item.menu_items?.name
     const price = parseFloat(String(item.menu_items?.price || 0))
-    totalPrice += price
+    const optionsPrice = (item.bento_order_item_options ?? []).reduce(
+      (sum, opt) => sum + (opt.bento_option_values?.price_delta ?? 0),
+      0
+    )
+    totalPrice += price + optionsPrice
 
     if (name) {
       const existing = menuItemCounts.get(name)
@@ -47,7 +54,7 @@ export async function fetchOrders(
   const { data, error } = await supabase
     .from("bento_orders")
     .select(
-      "*, restaurants:bento_menus(name, additional), order_items:bento_order_items(*, menu_items:bento_menu_items(name, price))"
+      "*, restaurants:bento_menus(name, additional), order_items:bento_order_items(*, menu_items:bento_menu_items(name, price), bento_order_item_options(bento_option_values(price_delta)))"
     )
     .order("created_at", { ascending: false })
 

--- a/apps/portal/lib/bento/types.ts
+++ b/apps/portal/lib/bento/types.ts
@@ -40,6 +40,7 @@ export interface OptionGroup {
 export interface SelectedOption {
   group_name: string
   label: string
+  price_delta: number
 }
 
 export interface OrderItem {

--- a/supabase/migrations/2026-07-04-bento-drinks-addons.sql
+++ b/supabase/migrations/2026-07-04-bento-drinks-addons.sql
@@ -20,7 +20,6 @@ begin
     values (v_rid, '加料', false, false, 3)
     returning id into v_addon;
     insert into public.bento_option_values (group_id, label, price_delta, sort_order) values
-      (v_addon, '蜜漬白玉丸', 10, 1),
-      (v_addon, '儿儿益生菌', 25, 2);
+      (v_addon, '蜜漬白玉丸', 10, 1);
   end if;
 end $$;

--- a/supabase/migrations/2026-07-04-bento-drinks-addons.sql
+++ b/supabase/migrations/2026-07-04-bento-drinks-addons.sql
@@ -1,0 +1,26 @@
+-- Seed a 加料 (add-on) option group for the 八曜和茶 drink shop.
+--
+-- Unlike 甜度/冰量, this group is optional (required=false) and multi-select
+-- (single_select=false) — customers can pick any number of add-ons, each
+-- carrying a price_delta that add-order-item-dialog.tsx surfaces as "+$N"
+-- and the order/list totals fold into the item price.
+--
+-- Matched by id, not name: the shop has since been renamed to
+-- "八曜和茶 新竹東區清大門市" (was "八曜和茶" when it was first seeded).
+
+do $$
+declare
+  v_rid uuid := 'a6867ebb-4f02-44b1-9ae3-1832eeb9cfb8';
+  v_addon uuid;
+begin
+  if exists (select 1 from public.bento_menus where id = v_rid and kind = 'drinks')
+    and not exists (select 1 from public.bento_option_groups where restaurant_id = v_rid and name = '加料')
+  then
+    insert into public.bento_option_groups (restaurant_id, name, required, single_select, sort_order)
+    values (v_rid, '加料', false, false, 3)
+    returning id into v_addon;
+    insert into public.bento_option_values (group_id, label, price_delta, sort_order) values
+      (v_addon, '蜜漬白玉丸', 10, 1),
+      (v_addon, '儿儿益生菌', 25, 2);
+  end if;
+end $$;


### PR DESCRIPTION
Closes #265

## Summary
- Optional option groups (e.g. 加料) now render as checkboxes so customers can pick any number of add-ons, while mandatory groups (甜度/冰量) stay single-select
- Each selected add-on's `price_delta` folds into the order-item total (order detail) and the restaurant list stats
- Seeded 八曜和茶 with a 加料 group: 蜜漬白玉丸 (+10), 儿儿益生菌 (+25) — migration matches by restaurant id since the shop was renamed to "八曜和茶 新竹東區清大門市" after the original seed

No schema/RPC changes — `bento_option_values.price_delta` and `bento_option_groups.single_select` already supported this.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `bun test lib/bento` — 28/28 pass
- [x] eslint clean on changed files
- [x] Verified seed data via SQL against the live restaurant id
- [ ] Manual click-through of the 加料 checkboxes in a logged-in session (couldn't do this myself — no Keycloak login available in this environment)