### PR TITLE
perf(portal): stream home page, dedupe auth checks, lazy-load pdf-lib

### DIFF
--- a/apps/portal/app/_components/bulletin-chat.tsx
+++ b/apps/portal/app/_components/bulletin-chat.tsx
@@ -56,7 +56,8 @@ async function fetchInitial(): Promise<{
       supabase
         .from("user_profiles")
         .select("id, name, email")
-        .order("name", { ascending: true }),
+        .order("name", { ascending: true })
+        .limit(500),
       supabase.rpc("is_portal_admin"),
     ])
 

--- a/apps/portal/app/page.tsx
+++ b/apps/portal/app/page.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link"
+import { Suspense } from "react"
 
 import { Button } from "@workspace/ui/components/button"
+import { Skeleton } from "@workspace/ui/components/skeleton"
 import { Toaster } from "@workspace/ui/components/sonner"
 
 import { BulletinBoard } from "@/app/_components/bulletin-board"
@@ -22,6 +24,25 @@ const externalServices = [
   { href: "https://gitlab.winlab.tw", label: "GitLab", note: "Gitlab" },
   { href: "https://wiki.winlab.tw", label: "Wiki", note: "Wiki" },
 ]
+
+function BulletinBoardSkeleton() {
+  return (
+    <div className="flex flex-col gap-3">
+      <Skeleton className="h-5 w-32" />
+      <Skeleton className="h-24 w-full" />
+    </div>
+  )
+}
+
+function BulletinChatSkeleton() {
+  return (
+    <div className="flex flex-col gap-3">
+      <Skeleton className="h-5 w-24" />
+      <Skeleton className="h-40 w-full" />
+      <Skeleton className="h-9 w-full" />
+    </div>
+  )
+}
 
 const baseApps = [
   { href: "/approve", label: "Approve", note: "文件簽核" },
@@ -64,8 +85,12 @@ export default async function Page() {
           email={currentUser.email}
           avatarUrl={currentUser.avatarUrl}
         />
-        <BulletinBoard />
-        <BulletinChat />
+        <Suspense fallback={<BulletinBoardSkeleton />}>
+          <BulletinBoard />
+        </Suspense>
+        <Suspense fallback={<BulletinChatSkeleton />}>
+          <BulletinChat />
+        </Suspense>
         <nav className="flex flex-col gap-3">
           {apps.map((app) => (
             <Button

--- a/apps/portal/lib/approve/pdf-merge.ts
+++ b/apps/portal/lib/approve/pdf-merge.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { PDFDocument } from "pdf-lib"
+import type { PDFDocument } from "pdf-lib"
 
 import type { ApproveField } from "./types"
 
@@ -18,6 +18,7 @@ export async function buildSignedPdf(
     )
   }
   const pdfBytes = await res.arrayBuffer()
+  const { PDFDocument } = await import("pdf-lib")
   const pdf = await PDFDocument.load(pdfBytes)
   const pages = pdf.getPages()
 

--- a/apps/portal/lib/receipts/file.ts
+++ b/apps/portal/lib/receipts/file.ts
@@ -1,5 +1,3 @@
-import { PDFDocument } from "pdf-lib"
-
 // Receipts get archived as PDF — uniform format whether the user uploaded an
 // image (phone photo of a paper receipt) or a PDF invoice. PDFs go through
 // untouched so vector content survives; images get rasterized to JPEG inside a
@@ -28,6 +26,7 @@ export async function fileToReceiptPdf(file: File): Promise<Blob> {
     throw new Error("只支援圖片或 PDF — 收到的是 " + (file.type || "未知格式"))
   }
   const jpegBytes = await rasterizeToJpeg(file)
+  const { PDFDocument } = await import("pdf-lib")
   const pdf = await PDFDocument.create()
   const image = await pdf.embedJpg(jpegBytes)
   const page = pdf.addPage([image.width, image.height])

--- a/apps/portal/lib/trip/convert.ts
+++ b/apps/portal/lib/trip/convert.ts
@@ -1,7 +1,5 @@
 "use client"
 
-import { PDFDocument } from "pdf-lib"
-
 const MAX_DIM = 2000
 const JPEG_QUALITY = 0.85
 const ACCEPTED_IMAGE_TYPES = new Set([
@@ -57,6 +55,7 @@ async function imageToPdfBlob(file: File): Promise<Blob> {
   })
   const jpegBytes = new Uint8Array(await jpegBlob.arrayBuffer())
 
+  const { PDFDocument } = await import("pdf-lib")
   const pdf = await PDFDocument.create()
   const image = await pdf.embedJpg(jpegBytes)
   const page = pdf.addPage([image.width, image.height])

--- a/apps/portal/lib/trip/sign.ts
+++ b/apps/portal/lib/trip/sign.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { PDFDocument, type PDFImage } from "pdf-lib"
+import type { PDFDocument, PDFImage } from "pdf-lib"
 
 export type SignaturePosition = "tl" | "tr" | "bl" | "br"
 
@@ -26,6 +26,7 @@ export async function stampSignatureOnPdf(
   position: SignaturePosition
 ): Promise<Blob> {
   const pdfBytes = new Uint8Array(await pdfBlob.arrayBuffer())
+  const { PDFDocument } = await import("pdf-lib")
   const pdf = await PDFDocument.load(pdfBytes)
   const image = await embedSignatureImage(pdf, signatureDataUrl)
   if (!image) {

--- a/apps/portal/lib/user.ts
+++ b/apps/portal/lib/user.ts
@@ -1,4 +1,5 @@
 import type { AuthSession, AuthUser } from "@supabase/supabase-js"
+import { cache } from "react"
 
 import { createClient } from "@/lib/supabase/server"
 
@@ -64,9 +65,16 @@ export function normalizeClaims(claims: ClaimsShape): NormalizedUser {
   }
 }
 
-export async function getCurrentUser(): Promise<NormalizedUser | null> {
+// Memoizes the create-client + getClaims work within a single request/render
+// pass, so callers like getCurrentUser() and getInitialAuthUser() don't each
+// re-verify the same JWT with a brand-new Supabase client.
+const getCachedClaims = cache(async () => {
   const supabase = await createClient()
-  const { data, error } = await supabase.auth.getClaims()
+  return supabase.auth.getClaims()
+})
+
+export async function getCurrentUser(): Promise<NormalizedUser | null> {
+  const { data, error } = await getCachedClaims()
   if (error || !data?.claims) return null
   return normalizeClaims(data.claims)
 }
@@ -82,8 +90,7 @@ export async function getCurrentAuthUser(): Promise<AuthUser | null> {
 // seed for the client AuthProvider. Full AuthUser will be filled in via
 // onAuthStateChange once the browser hydrates.
 export async function getInitialAuthUser(): Promise<AuthUser | null> {
-  const supabase = await createClient()
-  const { data, error } = await supabase.auth.getClaims()
+  const { data, error } = await getCachedClaims()
   if (error || !data?.claims) return null
   const claims = data.claims
   return {


### PR DESCRIPTION
Closes #267

## Summary
- `app/page.tsx`: wrap `<BulletinBoard/>` and `<BulletinChat/>` each in a `<Suspense>` boundary with a skeleton fallback (`@workspace/ui/components/skeleton`) — home page HTML no longer blocks on their DB queries
- `bulletin-chat.tsx`: add `.limit(500)` safety cap to the previously-unbounded `user_profiles` query used for the @mention list
- `lib/user.ts`: dedupe the `getClaims()` call that ran independently in both `getInitialAuthUser()` (root layout) and `getCurrentUser()` (page) via React `cache()` — one JWT verification per request instead of two. `getCurrentAuthUser()`/`getProfile()` untouched (different Supabase calls); the middleware's own `getClaims()` call is untouched (runs in a separate phase, can't share this cache)
- `lib/receipts/file.ts`, `lib/approve/pdf-merge.ts`, `lib/trip/sign.ts`, `lib/trip/convert.ts`: move `pdf-lib`'s value import to a dynamic `await import("pdf-lib")` inside the function that actually builds a `PDFDocument`, keeping `import type` where it's only used as a type annotation — pdf-lib no longer ships in the initial `/receipts`/`/trip` route bundle

## Test plan
- [x] `tsc --noEmit` clean
- [x] `bunx eslint` clean on all 7 changed files
- [x] `bun test lib/bento` — 28/28 pass (unaffected, sanity check)
- [x] Manual read-through of every changed file confirming Suspense fallbacks render valid JSX, the cached-claims helper is used by both call sites, and each pdf-lib dynamic import sits before its first value use
- [ ] Manual click-through of home page skeleton/streaming behavior in a logged-in session (no Keycloak login available in this environment)