### PR TITLE
fix(bento): stop cramming order-stats combo breakdown into a Badge

### DIFF
--- a/apps/portal/app/bento/_components/order-stats.tsx
+++ b/apps/portal/app/bento/_components/order-stats.tsx
@@ -119,29 +119,30 @@ export function OrderStats({
         </span>
       </p>
       {menuItemsList.length > 0 && (
-        <div className="flex flex-wrap items-center gap-2">
-          {menuItemsList.map((item, index) => (
-            <Badge
-              key={index}
-              variant="outline"
-              className="px-2 py-0.5 text-xs"
-            >
-              {item.name} <span className="font-medium">{item.totalCount}</span>{" "}
-              份
-              {Array.from(item.combinations.entries())
-                .sort((a, b) => b[1].count - a[1].count)
-                .map(([combinationKey, { count, label }]) =>
-                  label ? (
-                    <span
-                      key={combinationKey}
-                      className="ml-1 text-[11px] text-muted-foreground"
-                    >
-                      （{label} {count} 份）
-                    </span>
-                  ) : null
+        <div className="flex flex-col gap-2">
+          {menuItemsList.map((item, index) => {
+            const combos = Array.from(item.combinations.entries())
+              .filter(([, { label }]) => label)
+              .sort((a, b) => b[1].count - a[1].count)
+
+            return (
+              <div key={index} className="flex flex-col gap-1">
+                <Badge variant="outline" className="w-fit px-2 py-0.5 text-xs">
+                  {item.name}{" "}
+                  <span className="font-medium">{item.totalCount}</span> 份
+                </Badge>
+                {combos.length > 0 && (
+                  <ul className="ml-1 flex flex-col gap-0.5 text-[11px] text-muted-foreground">
+                    {combos.map(([combinationKey, { count, label }]) => (
+                      <li key={combinationKey}>
+                        {label} × {count}
+                      </li>
+                    ))}
+                  </ul>
                 )}
-            </Badge>
-          ))}
+              </div>
+            )
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
Closes #275

## Summary
#274 added a per-combo breakdown (甜度/冰量/加料) inside `OrderStats`, but rendered every combo as a `<span>` stuffed inside the same `<Badge>` as the item name/count. `Badge` is `h-5 overflow-hidden whitespace-nowrap` — built for short pill tags, not a variable-length list. With several drink combos on one item, the content overflowed the fixed-height pill and the layout broke.

Fix: the item name+count stays in the `Badge`, the combo breakdown moves to a plain list underneath it. Container switched from `flex flex-wrap` (row of badges) to `flex flex-col` (stacked rows) since each item's block height now varies with its combo count.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `bunx eslint` clean
- [x] `bun test lib/bento` — 28/28 pass
- [ ] Manual visual check in a logged-in session (no Keycloak login available in this environment) — reasoning about the fix is straightforward (Badge's `h-5`/`overflow-hidden` was the root cause, moving content out of it removes the constraint) but I can't screenshot the real result myself