### PR TITLE
fix(bento): stable tie-break sort for order-stats lists

### DIFF
--- a/apps/portal/app/bento/_components/order-stats.tsx
+++ b/apps/portal/app/bento/_components/order-stats.tsx
@@ -99,7 +99,7 @@ export function OrderStats({
   }, 0)
 
   const menuItemsList = Array.from(menuItemCounts.values()).sort(
-    (a, b) => b.totalCount - a.totalCount
+    (a, b) => b.totalCount - a.totalCount || a.name.localeCompare(b.name)
   )
 
   return (
@@ -123,7 +123,11 @@ export function OrderStats({
           {menuItemsList.map((item, index) => {
             const combos = Array.from(item.combinations.entries())
               .filter(([, { label }]) => label)
-              .sort((a, b) => b[1].count - a[1].count)
+              .sort(
+                (a, b) =>
+                  b[1].count - a[1].count ||
+                  a[1].label.localeCompare(b[1].label)
+              )
 
             return (
               <div key={index} className="flex flex-col gap-1">


### PR DESCRIPTION
Closes #277

## Summary
- Menu-item list: sort by `totalCount` desc, then item name (`localeCompare`) asc for ties
- Combo breakdown within each item: sort by `count` desc, then label (`localeCompare`) asc for ties

Previously ties fell back to Map insertion order (first-seen-in-order in the raw order_items array), which reads as unsorted/random when several combos share the same count.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `bunx eslint` clean
- [x] `bun test lib/bento` — 28/28 pass