### PR TITLE
feat(gallery): add PWA manifest, icons, and mobile install prompt

### DIFF
--- a/apps/gallery/app/_components/gallery-install-prompt.tsx
+++ b/apps/gallery/app/_components/gallery-install-prompt.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+import { IconDownload, IconShare2, IconX } from "@tabler/icons-react"
+
+import { Button } from "@workspace/ui/components/button"
+import { cn } from "@workspace/ui/lib/utils"
+
+import { gallerySans } from "@/components/gallery-chrome"
+import {
+  GALLERY_PWA_INSTALL_DISMISS_KEY,
+  isIosDevice,
+  isStandaloneDisplayMode,
+} from "@/lib/gallery/pwa"
+
+type BeforeInstallPromptEvent = Event & {
+  prompt: () => Promise<void>
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>
+}
+
+export function GalleryInstallPrompt() {
+  const [visible, setVisible] = useState(false)
+  const [iosHint, setIosHint] = useState(false)
+  const [deferredPrompt, setDeferredPrompt] =
+    useState<BeforeInstallPromptEvent | null>(null)
+
+  useEffect(() => {
+    if (window.localStorage.getItem(GALLERY_PWA_INSTALL_DISMISS_KEY) === "1") {
+      return
+    }
+
+    const standalone = isStandaloneDisplayMode(
+      window.matchMedia("(display-mode: standalone)").matches,
+      (
+        navigator as Navigator & {
+          standalone?: boolean
+        }
+      ).standalone === true
+    )
+    if (standalone) return
+
+    const mobile = window.matchMedia("(max-width: 767px)").matches
+    if (!mobile) return
+
+    if (isIosDevice(navigator.userAgent)) {
+      setIosHint(true)
+      setVisible(true)
+      return
+    }
+
+    const onBeforeInstallPrompt = (event: Event) => {
+      event.preventDefault()
+      setDeferredPrompt(event as BeforeInstallPromptEvent)
+      setVisible(true)
+    }
+
+    window.addEventListener("beforeinstallprompt", onBeforeInstallPrompt)
+    return () => {
+      window.removeEventListener("beforeinstallprompt", onBeforeInstallPrompt)
+    }
+  }, [])
+
+  const dismiss = () => {
+    window.localStorage.setItem(GALLERY_PWA_INSTALL_DISMISS_KEY, "1")
+    setVisible(false)
+    setDeferredPrompt(null)
+  }
+
+  const install = async () => {
+    if (!deferredPrompt) return
+    await deferredPrompt.prompt()
+    await deferredPrompt.userChoice
+    dismiss()
+  }
+
+  if (!visible) return null
+
+  return (
+    <div
+      className={cn(
+        gallerySans(),
+        "fixed inset-x-0 bottom-0 z-[90] px-4 pb-[max(env(safe-area-inset-bottom),1rem)]"
+      )}
+    >
+      <div className="mx-auto flex max-w-lg items-start gap-3 rounded-xl border border-border/80 bg-background/95 p-4 shadow-lg backdrop-blur-sm">
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-foreground">Install Gallery</p>
+          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+            {iosHint ? (
+              <>
+                Tap{" "}
+                <IconShare2 className="inline h-3.5 w-3.5 align-text-bottom" />{" "}
+                Share, then &ldquo;Add to Home Screen&rdquo; for a full-screen
+                app experience.
+              </>
+            ) : (
+              "Add Gallery to your home screen for quick access and a cleaner full-screen view."
+            )}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          {!iosHint ? (
+            <Button type="button" size="sm" onClick={() => void install()}>
+              <IconDownload className="h-4 w-4" />
+              Install
+            </Button>
+          ) : null}
+          <Button
+            type="button"
+            size="icon-sm"
+            variant="ghost"
+            aria-label="Dismiss install prompt"
+            onClick={dismiss}
+          >
+            <IconX className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/gallery/app/apple-icon.tsx
+++ b/apps/gallery/app/apple-icon.tsx
@@ -1,0 +1,12 @@
+import { ImageResponse } from "next/og"
+
+import { GalleryPwaIcon } from "@/lib/gallery/pwa-icon"
+
+export const size = { width: 180, height: 180 }
+export const contentType = "image/png"
+
+export default function AppleIcon() {
+  return new ImageResponse(<GalleryPwaIcon size={180} />, {
+    ...size,
+  })
+}

--- a/apps/gallery/app/icon.tsx
+++ b/apps/gallery/app/icon.tsx
@@ -1,0 +1,12 @@
+import { ImageResponse } from "next/og"
+
+import { GalleryPwaIcon } from "@/lib/gallery/pwa-icon"
+
+export const size = { width: 32, height: 32 }
+export const contentType = "image/png"
+
+export default function Icon() {
+  return new ImageResponse(<GalleryPwaIcon size={32} />, {
+    ...size,
+  })
+}

--- a/apps/gallery/app/layout.tsx
+++ b/apps/gallery/app/layout.tsx
@@ -1,5 +1,5 @@
 import { trace } from "@opentelemetry/api"
-import type { Metadata } from "next"
+import type { Metadata, Viewport } from "next"
 import { Geist, Instrument_Serif } from "next/font/google"
 import { headers } from "next/headers"
 
@@ -9,6 +9,7 @@ import "./gallery.css"
 import { Toaster } from "@workspace/ui/components/sonner"
 import { cn } from "@workspace/ui/lib/utils"
 
+import { GalleryInstallPrompt } from "@/app/_components/gallery-install-prompt"
 import { KonamiWinlabLogo } from "@/app/_components/konami-winlab-logo"
 import { ThemeProvider } from "@/components/theme-provider"
 import { getGallerySeasonalThemeId } from "@/lib/gallery/settings"
@@ -31,6 +32,22 @@ const geistSans = Geist({
 export const metadata: Metadata = {
   title: "Gallery — WinLab",
   description: "Art from NYCU WinLab.",
+  applicationName: "Gallery",
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: "default",
+    title: "Gallery",
+  },
+  formatDetection: {
+    telephone: false,
+  },
+}
+
+export const viewport: Viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#fafafa" },
+    { media: "(prefers-color-scheme: dark)", color: "#0a0a0a" },
+  ],
 }
 
 export default async function RootLayout({
@@ -71,6 +88,7 @@ export default async function RootLayout({
       >
         <ThemeProvider>
           {children}
+          <GalleryInstallPrompt />
           <KonamiWinlabLogo />
           <Toaster />
         </ThemeProvider>

--- a/apps/gallery/app/manifest.ts
+++ b/apps/gallery/app/manifest.ts
@@ -1,0 +1,46 @@
+import type { MetadataRoute } from "next"
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "Gallery — WinLab",
+    short_name: "Gallery",
+    description: "Art from NYCU WinLab.",
+    start_url: "/",
+    scope: "/",
+    display: "standalone",
+    orientation: "portrait",
+    background_color: "#fafafa",
+    theme_color: "#fafafa",
+    icons: [
+      {
+        src: "/icon",
+        sizes: "32x32",
+        type: "image/png",
+      },
+      {
+        src: "/apple-icon",
+        sizes: "180x180",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
+        src: "/pwa-icon?size=192",
+        sizes: "192x192",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
+        src: "/pwa-icon?size=512",
+        sizes: "512x512",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
+        src: "/pwa-icon?size=512",
+        sizes: "512x512",
+        type: "image/png",
+        purpose: "maskable",
+      },
+    ],
+  }
+}

--- a/apps/gallery/app/pwa-icon/route.tsx
+++ b/apps/gallery/app/pwa-icon/route.tsx
@@ -1,0 +1,18 @@
+import { ImageResponse } from "next/og"
+
+import { GalleryPwaIcon } from "@/lib/gallery/pwa-icon"
+
+export const runtime = "edge"
+
+const ALLOWED_SIZES = new Set([192, 512])
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const parsed = Number.parseInt(searchParams.get("size") ?? "512", 10)
+  const size = ALLOWED_SIZES.has(parsed) ? parsed : 512
+
+  return new ImageResponse(<GalleryPwaIcon size={size} />, {
+    width: size,
+    height: size,
+  })
+}

--- a/apps/gallery/lib/gallery/pwa-icon.tsx
+++ b/apps/gallery/lib/gallery/pwa-icon.tsx
@@ -1,0 +1,49 @@
+type PwaIconProps = {
+  size: number
+}
+
+/** Polaroid-style mark for manifest / favicon ImageResponse routes. */
+export function GalleryPwaIcon({ size }: PwaIconProps) {
+  const fontSize = Math.round(size * 0.38)
+  const border = Math.max(2, Math.round(size * 0.035))
+  const frameWidth = Math.round(size * 0.72)
+  const frameHeight = Math.round(size * 0.84)
+
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "#f5f0e8",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: frameWidth,
+          height: frameHeight,
+          background: "white",
+          boxShadow: `0 ${border}px ${border * 3}px rgba(0,0,0,0.14)`,
+          transform: "rotate(-3deg)",
+        }}
+      >
+        <span
+          style={{
+            fontFamily: "Georgia, 'Times New Roman', serif",
+            fontSize,
+            fontStyle: "italic",
+            color: "#1c1917",
+            lineHeight: 1,
+          }}
+        >
+          G
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/apps/gallery/lib/gallery/pwa.test.ts
+++ b/apps/gallery/lib/gallery/pwa.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test"
+
+import { isIosDevice, isStandaloneDisplayMode } from "@/lib/gallery/pwa"
+
+describe("isIosDevice", () => {
+  test("detects iPhone user agent", () => {
+    expect(
+      isIosDevice(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15"
+      )
+    ).toBe(true)
+  })
+
+  test("returns false for Android", () => {
+    expect(
+      isIosDevice(
+        "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/120.0.0.0 Mobile"
+      )
+    ).toBe(false)
+  })
+})
+
+describe("isStandaloneDisplayMode", () => {
+  test("detects standalone via display-mode", () => {
+    expect(isStandaloneDisplayMode(true, false)).toBe(true)
+  })
+
+  test("detects iOS standalone flag", () => {
+    expect(isStandaloneDisplayMode(false, true)).toBe(true)
+  })
+
+  test("returns false in browser tab", () => {
+    expect(isStandaloneDisplayMode(false, false)).toBe(false)
+  })
+})

--- a/apps/gallery/lib/gallery/pwa.ts
+++ b/apps/gallery/lib/gallery/pwa.ts
@@ -1,0 +1,12 @@
+export const GALLERY_PWA_INSTALL_DISMISS_KEY = "gallery-pwa-install-dismissed"
+
+export function isIosDevice(userAgent: string): boolean {
+  return /iPad|iPhone|iPod/.test(userAgent)
+}
+
+export function isStandaloneDisplayMode(
+  displayModeMatches: boolean,
+  iosStandalone: boolean
+): boolean {
+  return displayModeMatches || iosStandalone
+}


### PR DESCRIPTION
Closes #279

## Summary
- Add web app manifest with standalone display and 192/512 PNG icons
- Generate polaroid-style favicon, Apple touch icon, and PWA icon route
- Mobile install banner: Chrome \eforeinstallprompt\ on Android, Share → Add to Home Screen hint on iOS
- Apple web app metadata and light/dark \	hemeColor\

## Test plan
- [ ] Open gallery on mobile Chrome → bottom install banner appears
- [ ] Install app → opens standalone without browser chrome
- [ ] iOS Safari → banner shows Share / Add to Home Screen instructions
- [ ] Dismiss banner → does not reappear (localStorage)
- [ ] \un test\ and \un run build\ in apps/gallery pass

Made with [Cursor](https://cursor.com)