### PR TITLE
feat(bento): redesign order stats with tiles and compact card variant

### DIFF
--- a/apps/portal/app/bento/_components/order-card.tsx
+++ b/apps/portal/app/bento/_components/order-card.tsx
@@ -36,6 +36,7 @@ export function OrderCard({ order }: { order: OrderWithStats }) {
       <OrderStats
         orderItems={orderItems}
         restaurantAdditional={order.restaurants?.additional || null}
+        variant="compact"
       />
     </Link>
   )

--- a/apps/portal/app/bento/_components/order-stats.tsx
+++ b/apps/portal/app/bento/_components/order-stats.tsx
@@ -1,154 +1,108 @@
 "use client"
 
-import { Badge } from "@workspace/ui/components/badge"
 import { cn } from "@workspace/ui/lib/utils"
 
-interface OrderItemForStats {
-  menu_item_id: string
-  no_sauce?: boolean
-  additional?: number | null
-  selected_options?: {
-    group_name: string
-    label: string
-    price_delta: number
-  }[]
-  menu_items: {
-    name: string
-    price: number
-  }
-  user_id: string | null
-  anonymous_name?: string | null
-}
-
-function optionLabel(opt: { label: string; price_delta: number }): string {
-  return opt.price_delta > 0 ? `${opt.label} +$${opt.price_delta}` : opt.label
-}
+import { computeOrderStats, type StatsOrderItem } from "@/lib/bento/order-stats"
 
 interface OrderStatsProps {
-  orderItems: OrderItemForStats[]
+  orderItems: StatsOrderItem[]
   restaurantAdditional?: string[] | null
+  variant?: "full" | "compact"
   className?: string
 }
 
 export function OrderStats({
   orderItems,
   restaurantAdditional,
+  variant = "full",
   className,
 }: OrderStatsProps) {
-  const items = orderItems || []
-
-  const uniqueUsers = new Set(
-    items.map(
-      (item) => item.user_id ?? `anon:${item.anonymous_name ?? "unknown"}`
-    )
-  )
-  const userCount = uniqueUsers.size
-
-  const menuItemCounts = new Map<
-    string,
-    {
-      name: string
-      price: number
-      totalCount: number
-      combinations: Map<string, { count: number; label: string }>
-    }
-  >()
-
-  items.forEach((item) => {
-    const menuItemId = item.menu_item_id
-    const menuItemName = item.menu_items?.name || "未知品項"
-    const menuItemPrice = item.menu_items?.price || 0
-
-    const parts = (item.selected_options ?? []).map(optionLabel)
-    if (item.no_sauce) parts.push("不醬")
-    const additionalLabel =
-      item.additional !== null && item.additional !== undefined
-        ? restaurantAdditional?.[item.additional]
-        : undefined
-    if (additionalLabel) parts.push(additionalLabel)
-
-    const combinationKey = JSON.stringify(parts)
-    const combinationLabel = parts.join(" ")
-
-    if (menuItemCounts.has(menuItemId)) {
-      const existing = menuItemCounts.get(menuItemId)!
-      existing.totalCount += 1
-      const currentCount = existing.combinations.get(combinationKey)?.count ?? 0
-      existing.combinations.set(combinationKey, {
-        count: currentCount + 1,
-        label: combinationLabel,
-      })
-    } else {
-      const combinations = new Map<string, { count: number; label: string }>()
-      combinations.set(combinationKey, { count: 1, label: combinationLabel })
-      menuItemCounts.set(menuItemId, {
-        name: menuItemName,
-        price: menuItemPrice,
-        totalCount: 1,
-        combinations,
-      })
-    }
-  })
-
-  const totalPrice = items.reduce((sum, item) => {
-    const optionsPrice = (item.selected_options ?? []).reduce(
-      (s, opt) => s + opt.price_delta,
-      0
-    )
-    return sum + (item.menu_items?.price || 0) + optionsPrice
-  }, 0)
-
-  const menuItemsList = Array.from(menuItemCounts.values()).sort(
-    (a, b) => b.totalCount - a.totalCount || a.name.localeCompare(b.name)
+  const { userCount, itemCount, totalPrice, menuItems } = computeOrderStats(
+    orderItems,
+    restaurantAdditional
   )
 
-  return (
-    <div
-      className={cn(
-        "flex flex-col gap-3 text-sm text-muted-foreground",
-        className
-      )}
-    >
-      <p>
-        已有 <span className="font-medium text-foreground">{userCount}</span>{" "}
-        人訂餐，
-        <span className="font-medium text-foreground">{items.length}</span>{" "}
-        項餐點，共 NT${" "}
-        <span className="font-medium text-foreground">
-          {totalPrice.toLocaleString()}
+  if (variant === "compact") {
+    return (
+      <p className={cn("text-sm text-muted-foreground", className)}>
+        <span className="font-medium text-foreground">{userCount}</span> 人
+        {" · "}
+        <span className="font-medium text-foreground">{itemCount}</span> 項
+        {" · "}
+        <span className="font-medium text-foreground tabular-nums">
+          NT$ {totalPrice.toLocaleString()}
         </span>
       </p>
-      {menuItemsList.length > 0 && (
-        <div className="flex flex-col gap-2">
-          {menuItemsList.map((item, index) => {
-            const combos = Array.from(item.combinations.entries())
-              .filter(([, { label }]) => label)
-              .sort(
-                (a, b) =>
-                  b[1].count - a[1].count ||
-                  a[1].label.localeCompare(b[1].label)
-              )
+    )
+  }
 
-            return (
-              <div key={index} className="flex flex-col gap-1">
-                <Badge variant="outline" className="w-fit px-2 py-0.5 text-xs">
-                  {item.name}{" "}
-                  <span className="font-medium">{item.totalCount}</span> 份
-                </Badge>
-                {combos.length > 0 && (
-                  <ul className="ml-1 flex flex-col gap-0.5 text-[11px] text-muted-foreground">
-                    {combos.map(([combinationKey, { count, label }]) => (
-                      <li key={combinationKey}>
-                        {label} × {count}
-                      </li>
-                    ))}
-                  </ul>
-                )}
+  return (
+    <div className={cn("flex flex-col gap-4", className)}>
+      <div className="grid grid-cols-3 gap-2">
+        <StatTile value={userCount.toLocaleString()} label="人訂餐" />
+        <StatTile value={itemCount.toLocaleString()} label="項餐點" />
+        <StatTile
+          value={totalPrice.toLocaleString()}
+          prefix="NT$"
+          label="總計"
+        />
+      </div>
+
+      {menuItems.length > 0 && (
+        <ul className="flex flex-col gap-3">
+          {menuItems.map((item) => (
+            <li key={item.menu_item_id} className="flex flex-col gap-1.5">
+              <div className="flex items-baseline justify-between gap-3">
+                <span className="text-sm font-medium text-foreground">
+                  {item.name}
+                </span>
+                <span className="shrink-0 text-sm font-medium text-muted-foreground tabular-nums">
+                  ×{item.totalCount}
+                </span>
               </div>
-            )
-          })}
-        </div>
+              {item.combinations.length > 0 && (
+                <ul className="flex flex-col gap-1 border-l border-border pl-3">
+                  {item.combinations.map((combo) => (
+                    <li
+                      key={combo.key}
+                      className="flex items-baseline justify-between gap-3 text-xs text-muted-foreground"
+                    >
+                      <span>{combo.label}</span>
+                      <span className="shrink-0 tabular-nums">
+                        ×{combo.count}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          ))}
+        </ul>
       )}
+    </div>
+  )
+}
+
+function StatTile({
+  value,
+  prefix,
+  label,
+}: {
+  value: string
+  prefix?: string
+  label: string
+}) {
+  return (
+    <div className="flex flex-col gap-0.5 rounded-xl border border-border bg-card px-3 py-3">
+      <span className="text-xl font-semibold text-foreground tabular-nums sm:text-2xl">
+        {prefix && (
+          <span className="mr-0.5 text-sm font-normal text-muted-foreground">
+            {prefix}
+          </span>
+        )}
+        {value}
+      </span>
+      <span className="text-xs text-muted-foreground">{label}</span>
     </div>
   )
 }

--- a/apps/portal/lib/bento/order-stats.test.ts
+++ b/apps/portal/lib/bento/order-stats.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "bun:test"
+
+import { computeOrderStats, type StatsOrderItem } from "./order-stats"
+
+function item(overrides: Partial<StatsOrderItem>): StatsOrderItem {
+  return {
+    menu_item_id: "m1",
+    user_id: "u1",
+    menu_items: { name: "紅茶", price: 30 },
+    ...overrides,
+  }
+}
+
+describe("computeOrderStats", () => {
+  it("returns zeroed result for empty input", () => {
+    const result = computeOrderStats([])
+    expect(result.userCount).toBe(0)
+    expect(result.itemCount).toBe(0)
+    expect(result.totalPrice).toBe(0)
+    expect(result.menuItems).toEqual([])
+  })
+
+  it("tolerates null/undefined order items", () => {
+    expect(computeOrderStats(null).itemCount).toBe(0)
+    expect(computeOrderStats(undefined).itemCount).toBe(0)
+  })
+
+  it("counts unique users, distinguishing anonymous names", () => {
+    const result = computeOrderStats([
+      item({ user_id: "u1" }),
+      item({ user_id: "u1" }),
+      item({ user_id: null, anonymous_name: "路人甲" }),
+      item({ user_id: null, anonymous_name: "路人乙" }),
+    ])
+    expect(result.userCount).toBe(3)
+    expect(result.itemCount).toBe(4)
+  })
+
+  it("folds option price_delta into the total", () => {
+    const result = computeOrderStats([
+      item({
+        menu_items: { name: "奶茶", price: 55 },
+        selected_options: [
+          { group_name: "甜度", label: "無糖", price_delta: 0 },
+          { group_name: "加料", label: "蜜漬白玉丸", price_delta: 10 },
+        ],
+      }),
+    ])
+    expect(result.totalPrice).toBe(65)
+  })
+
+  it("labels a combination with ' · ' and shows +$N for priced add-ons", () => {
+    const result = computeOrderStats([
+      item({
+        selected_options: [
+          { group_name: "甜度", label: "無糖", price_delta: 0 },
+          { group_name: "冰量", label: "去冰", price_delta: 0 },
+          { group_name: "加料", label: "珍珠", price_delta: 10 },
+        ],
+      }),
+    ])
+    expect(result.menuItems[0]!.combinations[0]!.label).toBe(
+      "無糖 · 去冰 · 珍珠 +$10"
+    )
+  })
+
+  it("appends 不醬 and the restaurant additional option to the label", () => {
+    const result = computeOrderStats(
+      [item({ no_sauce: true, additional: 1 })],
+      ["普通", "微辣"]
+    )
+    expect(result.menuItems[0]!.combinations[0]!.label).toBe("不醬 · 微辣")
+  })
+
+  it("groups identical combinations and counts them", () => {
+    const result = computeOrderStats([
+      item({
+        selected_options: [
+          { group_name: "甜度", label: "無糖", price_delta: 0 },
+        ],
+      }),
+      item({
+        selected_options: [
+          { group_name: "甜度", label: "無糖", price_delta: 0 },
+        ],
+      }),
+      item({
+        selected_options: [
+          { group_name: "甜度", label: "全糖", price_delta: 0 },
+        ],
+      }),
+    ])
+    const combos = result.menuItems[0]!.combinations
+    expect(combos).toHaveLength(2)
+    expect(combos[0]).toMatchObject({ label: "無糖", count: 2 })
+    expect(combos[1]).toMatchObject({ label: "全糖", count: 1 })
+  })
+
+  it("sorts menu items by count desc, then name asc for ties", () => {
+    const result = computeOrderStats([
+      item({ menu_item_id: "b", menu_items: { name: "烏龍", price: 30 } }),
+      item({ menu_item_id: "a", menu_items: { name: "綠茶", price: 30 } }),
+      item({ menu_item_id: "c", menu_items: { name: "多多", price: 40 } }),
+      item({ menu_item_id: "c", menu_items: { name: "多多", price: 40 } }),
+    ])
+    expect(result.menuItems.map((m) => m.name)).toEqual([
+      "多多",
+      "烏龍",
+      "綠茶",
+    ])
+  })
+
+  it("sorts combinations by count desc, then label asc for ties", () => {
+    const mk = (label: string) =>
+      item({
+        selected_options: [{ group_name: "甜度", label, price_delta: 0 }],
+      })
+    const result = computeOrderStats([
+      mk("全糖"),
+      mk("半糖"),
+      mk("無糖"),
+      mk("無糖"),
+    ])
+    const combos = result.menuItems[0]!.combinations
+    expect(combos.map((c) => c.label)).toEqual(["無糖", "全糖", "半糖"])
+  })
+
+  it("drops empty-label combinations (no options at all)", () => {
+    const result = computeOrderStats([item({}), item({})])
+    expect(result.menuItems[0]!.totalCount).toBe(2)
+    expect(result.menuItems[0]!.combinations).toEqual([])
+  })
+
+  it("falls back to 未知品項 when menu_items is null", () => {
+    const result = computeOrderStats([item({ menu_items: null })])
+    expect(result.menuItems[0]!.name).toBe("未知品項")
+    expect(result.totalPrice).toBe(0)
+  })
+})

--- a/apps/portal/lib/bento/order-stats.ts
+++ b/apps/portal/lib/bento/order-stats.ts
@@ -1,0 +1,129 @@
+// Pure aggregation for the OrderStats component. Kept React-free and
+// I/O-free so it can be unit-tested directly (see order-stats.test.ts).
+
+export interface StatsOrderItem {
+  menu_item_id: string
+  no_sauce?: boolean
+  additional?: number | null
+  selected_options?: {
+    group_name: string
+    label: string
+    price_delta: number
+  }[]
+  menu_items: {
+    name: string
+    price: number
+  } | null
+  user_id: string | null
+  anonymous_name?: string | null
+}
+
+export interface OrderCombination {
+  key: string
+  label: string
+  count: number
+}
+
+export interface MenuItemStat {
+  menu_item_id: string
+  name: string
+  totalCount: number
+  combinations: OrderCombination[]
+}
+
+export interface OrderStatsResult {
+  userCount: number
+  itemCount: number
+  totalPrice: number
+  menuItems: MenuItemStat[]
+}
+
+function optionLabel(opt: { label: string; price_delta: number }): string {
+  return opt.price_delta > 0 ? `${opt.label} +$${opt.price_delta}` : opt.label
+}
+
+// Builds the ordered label parts for one item's option combination:
+// drink options first (already group-sorted upstream), then 不醬, then the
+// restaurant's additional option.
+function combinationParts(
+  item: StatsOrderItem,
+  restaurantAdditional?: string[] | null
+): string[] {
+  const parts = (item.selected_options ?? []).map(optionLabel)
+  if (item.no_sauce) parts.push("不醬")
+  const additionalLabel =
+    item.additional !== null && item.additional !== undefined
+      ? restaurantAdditional?.[item.additional]
+      : undefined
+  if (additionalLabel) parts.push(additionalLabel)
+  return parts
+}
+
+export function computeOrderStats(
+  orderItems: StatsOrderItem[] | null | undefined,
+  restaurantAdditional?: string[] | null
+): OrderStatsResult {
+  const items = orderItems ?? []
+
+  const uniqueUsers = new Set(
+    items.map(
+      (item) => item.user_id ?? `anon:${item.anonymous_name ?? "unknown"}`
+    )
+  )
+
+  const counts = new Map<
+    string,
+    {
+      name: string
+      totalCount: number
+      combinations: Map<string, { count: number; label: string }>
+    }
+  >()
+
+  let totalPrice = 0
+
+  for (const item of items) {
+    const menuItemId = item.menu_item_id
+    const name = item.menu_items?.name || "未知品項"
+    const price = item.menu_items?.price || 0
+    const optionsPrice = (item.selected_options ?? []).reduce(
+      (sum, opt) => sum + opt.price_delta,
+      0
+    )
+    totalPrice += price + optionsPrice
+
+    const parts = combinationParts(item, restaurantAdditional)
+    const key = JSON.stringify(parts)
+    const label = parts.join(" · ")
+
+    const existing = counts.get(menuItemId)
+    if (existing) {
+      existing.totalCount += 1
+      const current = existing.combinations.get(key)?.count ?? 0
+      existing.combinations.set(key, { count: current + 1, label })
+    } else {
+      const combinations = new Map<string, { count: number; label: string }>()
+      combinations.set(key, { count: 1, label })
+      counts.set(menuItemId, { name, totalCount: 1, combinations })
+    }
+  }
+
+  const menuItems: MenuItemStat[] = Array.from(counts.entries())
+    .map(([menu_item_id, value]) => ({
+      menu_item_id,
+      name: value.name,
+      totalCount: value.totalCount,
+      combinations: Array.from(value.combinations.entries())
+        .map(([key, { count, label }]) => ({ key, label, count }))
+        .filter((combo) => combo.label)
+        .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label)),
+    }))
+    .sort((a, b) => b.totalCount - a.totalCount || a.name.localeCompare(b.name))
+
+  return {
+    userCount: uniqueUsers.size,
+    itemCount: items.length,
+    totalPrice,
+    menuItems,
+  }
+}


### PR DESCRIPTION
Closes #281

## Summary
- **Detail page**: leads with three stat tiles (人訂餐 / 項餐點 / NT$ 總計) for scale-contrast hierarchy, then lists each menu item as `name —— ×count` (right-aligned, `tabular-nums`) with its option-combo breakdown grouped under a left border rail. Combo labels now join with ` · ` so 甜度/冰量/加料 read clearly, priced add-ons show `+$N`.
- **Order card (list page)**: `OrderStats` gains a `variant="compact"` prop rendering a single line `N 人 · M 項 · NT$ X` — no per-item list, so cards stay clean and uniform-height.
- **Refactor**: the aggregation (unique users, total incl. add-on price_delta, per-item combo counts, tie-break sorting) moves to a pure `lib/bento/order-stats.ts` helper; the component only renders. 11 new unit tests cover it.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `bun test lib/bento` — 39/39 pass (11 new)
- [x] `bunx eslint` clean on all 4 changed/new files
- [ ] Manual visual check of tiles + breakdown on the detail page and the compact card in a logged-in session (no Keycloak login available in this environment)