### PR TITLE
feat(bento): sort order items by time or person, show order time

### DIFF
--- a/apps/portal/app/bento/_components/order-items-list.tsx
+++ b/apps/portal/app/bento/_components/order-items-list.tsx
@@ -1,42 +1,31 @@
 "use client"
 
+import { useState } from "react"
 import { toast } from "sonner"
 
 import { Badge } from "@workspace/ui/components/badge"
 import { Button } from "@workspace/ui/components/button"
+import { cn } from "@workspace/ui/lib/utils"
 
 import { useDeleteOrderItem } from "@/hooks/bento/use-order-items"
+import {
+  formatItemTime,
+  groupByPerson,
+  itemPersonName,
+  sortByTime,
+  type ViewOrderItem,
+} from "@/lib/bento/order-items-view"
 
 import { ConfirmDialog } from "./confirm-dialog"
 
-interface OrderItem {
-  id: string
-  menu_item_id: string
-  no_sauce: boolean
-  additional: number | null
-  user_id: string | null
-  anonymous_name?: string | null
-  anonymous_contact?: string | null
-  menu_items: {
-    name: string
-    price: number
-  }
-  user: {
-    name: string | null
-    email?: string
-  } | null
-  selected_options?: {
-    group_name: string
-    label: string
-    price_delta: number
-  }[]
-}
+type SortMode = "time" | "person"
 
-interface GroupedOrderItem {
-  user_id: string
-  user_name: string | null
-  items: OrderItem[]
-  total: number
+interface OrderItemsListProps {
+  items: ViewOrderItem[]
+  isActive: boolean
+  currentUserId?: string
+  isAdmin?: boolean
+  restaurantAdditional?: string[] | null
 }
 
 export function OrderItemsList({
@@ -45,14 +34,9 @@ export function OrderItemsList({
   currentUserId,
   isAdmin,
   restaurantAdditional,
-}: {
-  items: OrderItem[]
-  isActive: boolean
-  currentUserId?: string
-  isAdmin?: boolean
-  restaurantAdditional?: string[] | null
-}) {
+}: OrderItemsListProps) {
   const deleteItem = useDeleteOrderItem()
+  const [sortMode, setSortMode] = useState<SortMode>("time")
 
   const handleDelete = async (id: string) => {
     try {
@@ -65,36 +49,28 @@ export function OrderItemsList({
     }
   }
 
-  const groupedItems = items.reduce(
-    (acc, item) => {
-      const groupKey =
-        item.user_id ?? `anon:${item.anonymous_name ?? "unknown"}`
-      if (!acc[groupKey]) {
-        acc[groupKey] = {
-          user_id: groupKey,
-          user_name: item.user?.name || item.anonymous_name || null,
-          items: [],
-          total: 0,
-        }
-      }
-      const optionsTotal = (item.selected_options ?? []).reduce(
-        (sum, opt) => sum + opt.price_delta,
-        0
-      )
-      acc[groupKey].items.push(item)
-      acc[groupKey].total += (item.menu_items?.price || 0) + optionsTotal
-      return acc
-    },
-    {} as Record<string, GroupedOrderItem>
-  )
+  const canDelete = (item: ViewOrderItem) =>
+    isActive && (currentUserId === item.user_id || Boolean(isAdmin))
 
-  const groupedItemsArray = Object.values(groupedItems).sort((a, b) => {
-    if (currentUserId) {
-      if (a.user_id === currentUserId) return -1
-      if (b.user_id === currentUserId) return 1
-    }
-    return b.total - a.total
-  })
+  const deleteButton = (item: ViewOrderItem) =>
+    canDelete(item) ? (
+      <ConfirmDialog
+        trigger={
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2 py-0 text-xs text-muted-foreground hover:text-destructive"
+          >
+            刪除
+          </Button>
+        }
+        title="刪除此訂餐項目？"
+        description="此操作無法復原。"
+        confirmText="刪除"
+        variant="destructive"
+        onConfirm={() => handleDelete(item.id)}
+      />
+    ) : null
 
   if (items.length === 0) {
     return (
@@ -106,86 +82,142 @@ export function OrderItemsList({
 
   return (
     <div className="flex flex-col gap-3">
-      {groupedItemsArray.map((group) => (
-        <div
-          key={group.user_id}
-          className="flex flex-wrap items-start justify-between gap-4 rounded-xl border border-border bg-card p-4"
-        >
-          <div className="flex min-w-0 flex-1 flex-col gap-2">
-            <div className="text-sm font-medium">
-              {group.user_name || "未知"}
-              {group.items[0]?.anonymous_contact && (
-                <span className="ml-2 text-xs font-normal text-muted-foreground">
-                  ({group.items[0].anonymous_contact})
-                </span>
-              )}
+      <SortToggle value={sortMode} onChange={setSortMode} />
+
+      {sortMode === "time"
+        ? sortByTime(items).map((item) => (
+            <div
+              key={item.id}
+              className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-xl border border-border bg-card px-4 py-3 text-sm"
+            >
+              <span className="shrink-0 font-medium text-muted-foreground tabular-nums">
+                {formatItemTime(item.created_at)}
+              </span>
+              <span className="shrink-0 text-muted-foreground">
+                {itemPersonName(item)}
+              </span>
+              <span className="font-medium">{item.menu_items?.name}</span>
+              <ItemOptionBadges
+                item={item}
+                restaurantAdditional={restaurantAdditional}
+              />
+              {deleteButton(item)}
             </div>
-            <div className="flex flex-col gap-1 text-sm text-muted-foreground">
-              {group.items.map((item) => (
-                <div
-                  key={item.id}
-                  className="flex flex-wrap items-center gap-2"
-                >
-                  <span>{item.menu_items?.name}</span>
-                  {item.selected_options?.map((opt, i) => (
-                    <Badge
-                      key={`${opt.group_name}-${i}`}
-                      variant="secondary"
-                      className="px-2 py-0.5 text-[11px]"
-                    >
-                      {opt.label}
-                      {opt.price_delta > 0 && ` +$${opt.price_delta}`}
-                    </Badge>
-                  ))}
-                  {item.no_sauce && (
-                    <Badge
-                      variant="secondary"
-                      className="px-2 py-0.5 text-[11px]"
-                    >
-                      不醬
-                    </Badge>
-                  )}
-                  {item.additional !== null &&
-                    item.additional !== undefined &&
-                    restaurantAdditional &&
-                    restaurantAdditional[item.additional] && (
-                      <Badge
-                        variant="secondary"
-                        className="px-2 py-0.5 text-[11px]"
-                      >
-                        {restaurantAdditional[item.additional]}
-                      </Badge>
-                    )}
-                  {isActive && (currentUserId === item.user_id || isAdmin) && (
-                    <ConfirmDialog
-                      trigger={
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="h-6 px-2 py-0 text-xs text-muted-foreground hover:text-destructive"
-                        >
-                          刪除
-                        </Button>
-                      }
-                      title="刪除此訂餐項目？"
-                      description="此操作無法復原。"
-                      confirmText="刪除"
-                      variant="destructive"
-                      onConfirm={() => handleDelete(item.id)}
-                    />
+          ))
+        : groupByPerson(items, currentUserId).map((group) => (
+            <div
+              key={group.key}
+              className="flex flex-wrap items-start justify-between gap-4 rounded-xl border border-border bg-card p-4"
+            >
+              <div className="flex min-w-0 flex-1 flex-col gap-2">
+                <div className="text-sm font-medium">
+                  {group.userName || "未知"}
+                  {group.contact && (
+                    <span className="ml-2 text-xs font-normal text-muted-foreground">
+                      ({group.contact})
+                    </span>
                   )}
                 </div>
-              ))}
+                <div className="flex flex-col gap-1 text-sm text-muted-foreground">
+                  {group.items.map((item) => (
+                    <div
+                      key={item.id}
+                      className="flex flex-wrap items-center gap-2"
+                    >
+                      <span className="shrink-0 text-xs text-muted-foreground/70 tabular-nums">
+                        {formatItemTime(item.created_at)}
+                      </span>
+                      <span>{item.menu_items?.name}</span>
+                      <ItemOptionBadges
+                        item={item}
+                        restaurantAdditional={restaurantAdditional}
+                      />
+                      {deleteButton(item)}
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <div className="shrink-0 text-right">
+                <div className="text-xs text-muted-foreground">總計</div>
+                <div className="text-sm font-medium">
+                  NT$ {group.total.toLocaleString()}
+                </div>
+              </div>
             </div>
-          </div>
-          <div className="shrink-0 text-right">
-            <div className="text-xs text-muted-foreground">總計</div>
-            <div className="text-sm font-medium">
-              NT$ {group.total.toLocaleString()}
-            </div>
-          </div>
-        </div>
+          ))}
+    </div>
+  )
+}
+
+function SortToggle({
+  value,
+  onChange,
+}: {
+  value: SortMode
+  onChange: (mode: SortMode) => void
+}) {
+  const options: { mode: SortMode; label: string }[] = [
+    { mode: "time", label: "依時間" },
+    { mode: "person", label: "依人" },
+  ]
+  return (
+    <div className="flex self-end rounded-lg border border-border p-0.5">
+      {options.map((option) => (
+        <button
+          key={option.mode}
+          type="button"
+          onClick={() => onChange(option.mode)}
+          aria-pressed={value === option.mode}
+          className={cn(
+            "rounded-md px-3 py-1 text-xs font-medium transition-colors",
+            value === option.mode
+              ? "bg-muted text-foreground"
+              : "text-muted-foreground hover:text-foreground"
+          )}
+        >
+          {option.label}
+        </button>
       ))}
     </div>
+  )
+}
+
+function ItemOptionBadges({
+  item,
+  restaurantAdditional,
+}: {
+  item: ViewOrderItem
+  restaurantAdditional?: string[] | null
+}) {
+  const additionalLabel =
+    item.additional !== null &&
+    item.additional !== undefined &&
+    restaurantAdditional
+      ? restaurantAdditional[item.additional]
+      : undefined
+
+  return (
+    <>
+      {item.selected_options?.map((opt, i) => (
+        <Badge
+          key={`${opt.group_name}-${i}`}
+          variant="secondary"
+          className="px-2 py-0.5 text-[11px]"
+        >
+          {opt.label}
+          {opt.price_delta > 0 && ` +$${opt.price_delta}`}
+        </Badge>
+      ))}
+      {item.no_sauce && (
+        <Badge variant="secondary" className="px-2 py-0.5 text-[11px]">
+          不醬
+        </Badge>
+      )}
+      {additionalLabel && (
+        <Badge variant="secondary" className="px-2 py-0.5 text-[11px]">
+          {additionalLabel}
+        </Badge>
+      )}
+    </>
   )
 }

--- a/apps/portal/lib/bento/order-items-view.test.ts
+++ b/apps/portal/lib/bento/order-items-view.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "bun:test"
+
+import {
+  formatItemTime,
+  groupByPerson,
+  itemPrice,
+  sortByTime,
+  type ViewOrderItem,
+} from "./order-items-view"
+
+function item(overrides: Partial<ViewOrderItem>): ViewOrderItem {
+  return {
+    id: "i1",
+    created_at: "2026-07-06T06:00:00Z",
+    menu_item_id: "m1",
+    no_sauce: false,
+    additional: null,
+    user_id: "u1",
+    menu_items: { name: "紅茶", price: 30 },
+    user: { name: "王小明" },
+    ...overrides,
+  }
+}
+
+describe("itemPrice", () => {
+  it("adds option price_delta to the menu price", () => {
+    expect(
+      itemPrice(
+        item({
+          menu_items: { name: "奶茶", price: 55 },
+          selected_options: [
+            { group_name: "加料", label: "珍珠", price_delta: 10 },
+          ],
+        })
+      )
+    ).toBe(65)
+  })
+
+  it("treats a null menu_items as 0", () => {
+    expect(itemPrice(item({ menu_items: null }))).toBe(0)
+  })
+})
+
+describe("groupByPerson", () => {
+  it("groups items by user and sums each person's spend", () => {
+    const groups = groupByPerson([
+      item({ id: "a", user_id: "u1", menu_items: { name: "紅茶", price: 30 } }),
+      item({ id: "b", user_id: "u1", menu_items: { name: "奶茶", price: 50 } }),
+      item({ id: "c", user_id: "u2", menu_items: { name: "綠茶", price: 40 } }),
+    ])
+    expect(groups).toHaveLength(2)
+    const u1 = groups.find((g) => g.key === "u1")!
+    expect(u1.items).toHaveLength(2)
+    expect(u1.total).toBe(80)
+  })
+
+  it("keys anonymous items by name and reads their contact", () => {
+    const groups = groupByPerson([
+      item({
+        user_id: null,
+        user: null,
+        anonymous_name: "路人",
+        anonymous_contact: "0912",
+      }),
+    ])
+    expect(groups[0]!.key).toBe("anon:路人")
+    expect(groups[0]!.userName).toBe("路人")
+    expect(groups[0]!.contact).toBe("0912")
+  })
+
+  it("pins the current user first, then orders by spend desc", () => {
+    const groups = groupByPerson(
+      [
+        item({
+          id: "a",
+          user_id: "u1",
+          menu_items: { name: "紅茶", price: 30 },
+        }),
+        item({
+          id: "b",
+          user_id: "u2",
+          menu_items: { name: "奶茶", price: 90 },
+        }),
+        item({
+          id: "c",
+          user_id: "u3",
+          menu_items: { name: "綠茶", price: 60 },
+        }),
+      ],
+      "u1"
+    )
+    expect(groups.map((g) => g.key)).toEqual(["u1", "u2", "u3"])
+  })
+
+  it("orders items within a group chronologically", () => {
+    const groups = groupByPerson([
+      item({ id: "late", created_at: "2026-07-06T08:00:00Z" }),
+      item({ id: "early", created_at: "2026-07-06T06:00:00Z" }),
+    ])
+    expect(groups[0]!.items.map((i) => i.id)).toEqual(["early", "late"])
+  })
+})
+
+describe("sortByTime", () => {
+  const items = [
+    item({ id: "mid", created_at: "2026-07-06T07:00:00Z" }),
+    item({ id: "early", created_at: "2026-07-06T06:00:00Z" }),
+    item({ id: "late", created_at: "2026-07-06T08:00:00Z" }),
+  ]
+
+  it("sorts ascending by default", () => {
+    expect(sortByTime(items).map((i) => i.id)).toEqual(["early", "mid", "late"])
+  })
+
+  it("sorts descending when asked", () => {
+    expect(sortByTime(items, "desc").map((i) => i.id)).toEqual([
+      "late",
+      "mid",
+      "early",
+    ])
+  })
+
+  it("does not mutate the input array", () => {
+    const original = items.map((i) => i.id)
+    sortByTime(items)
+    expect(items.map((i) => i.id)).toEqual(original)
+  })
+})
+
+describe("formatItemTime", () => {
+  it("formats a UTC timestamp as HH:mm in Taipei time (+8)", () => {
+    expect(formatItemTime("2026-07-06T06:23:00Z")).toBe("14:23")
+  })
+
+  it("returns an empty string for an invalid date", () => {
+    expect(formatItemTime("not-a-date")).toBe("")
+  })
+})

--- a/apps/portal/lib/bento/order-items-view.ts
+++ b/apps/portal/lib/bento/order-items-view.ts
@@ -1,0 +1,114 @@
+// Pure view helpers for the order-items list. React-free / I/O-free so the
+// grouping, ordering, and time formatting can be unit-tested directly
+// (see order-items-view.test.ts).
+
+export interface ViewOrderItem {
+  id: string
+  created_at: string
+  menu_item_id: string
+  no_sauce: boolean
+  additional: number | null
+  user_id: string | null
+  anonymous_name?: string | null
+  anonymous_contact?: string | null
+  menu_items: {
+    name: string
+    price: number
+  } | null
+  user: {
+    name: string | null
+    email?: string
+  } | null
+  selected_options?: {
+    group_name: string
+    label: string
+    price_delta: number
+  }[]
+}
+
+export interface PersonGroup {
+  key: string
+  userId: string | null
+  userName: string | null
+  contact: string | null
+  items: ViewOrderItem[]
+  total: number
+}
+
+export function itemPrice(item: ViewOrderItem): number {
+  const options = (item.selected_options ?? []).reduce(
+    (sum, opt) => sum + opt.price_delta,
+    0
+  )
+  return (item.menu_items?.price ?? 0) + options
+}
+
+export function itemPersonName(item: ViewOrderItem): string {
+  return item.user?.name || item.anonymous_name || "未知"
+}
+
+function byTimeAsc(a: ViewOrderItem, b: ViewOrderItem): number {
+  return new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+}
+
+// Groups items by person (logged-in user id, or an anon:<name> key), with the
+// current user pinned first and remaining groups by descending spend — matching
+// the existing list behaviour. Items inside each group are time-ordered.
+export function groupByPerson(
+  items: ViewOrderItem[],
+  currentUserId?: string
+): PersonGroup[] {
+  const groups = new Map<string, PersonGroup>()
+
+  for (const item of items) {
+    const key = item.user_id ?? `anon:${item.anonymous_name ?? "unknown"}`
+    let group = groups.get(key)
+    if (!group) {
+      group = {
+        key,
+        userId: item.user_id,
+        userName: item.user?.name || item.anonymous_name || null,
+        contact: item.anonymous_contact ?? null,
+        items: [],
+        total: 0,
+      }
+      groups.set(key, group)
+    }
+    group.items.push(item)
+    group.total += itemPrice(item)
+  }
+
+  for (const group of groups.values()) {
+    group.items.sort(byTimeAsc)
+  }
+
+  return Array.from(groups.values()).sort((a, b) => {
+    if (currentUserId) {
+      if (a.key === currentUserId) return -1
+      if (b.key === currentUserId) return 1
+    }
+    return b.total - a.total
+  })
+}
+
+// Flattens all items into a single chronological list.
+export function sortByTime(
+  items: ViewOrderItem[],
+  direction: "asc" | "desc" = "asc"
+): ViewOrderItem[] {
+  const sorted = [...items].sort(byTimeAsc)
+  return direction === "desc" ? sorted.reverse() : sorted
+}
+
+// Formats an item's timestamp as HH:mm in Taipei time, independent of the
+// runtime's timezone so it stays correct on servers and deterministic in tests.
+export function formatItemTime(iso: string): string {
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return ""
+  return date.toLocaleTimeString("zh-TW", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: "Asia/Taipei",
+  })
+}

--- a/apps/portal/lib/bento/types.ts
+++ b/apps/portal/lib/bento/types.ts
@@ -50,6 +50,7 @@ export interface OrderItem {
   user_id: string | null
   no_sauce: boolean
   additional: number | null
+  created_at: string
   anonymous_name?: string | null
   anonymous_contact?: string | null
   menu_items: {


### PR DESCRIPTION
Closes #291

## Summary
- The order-items list gains a **依時間 / 依人** toggle (segmented control, top-right).
- **依時間 (default)**: flattens every item into one chronological feed (earliest → latest), each row `time · person · item · options`.
- **依人**: keeps the existing per-person grouping and per-person totals, and now shows each item's order time too.
- No schema change — `bento_order_items.created_at` already exists and already flows through `useOrder`; only added to the TS type.
- Grouping / time-sort / time-formatting extracted to a pure `lib/bento/order-items-view.ts` helper (component renders only). Time is formatted in `Asia/Taipei` so it's correct regardless of runtime TZ and deterministic in tests.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `bun test lib/bento` — 50/50 pass (11 new for the view helper)
- [x] `bunx eslint` clean on all changed/new files
- [ ] Manual toggle + time display check in a logged-in session (no Keycloak login available in this environment)