### PR TITLE
feat(bento): show date alongside time on order items

### DIFF
--- a/apps/portal/app/bento/_components/order-items-list.tsx
+++ b/apps/portal/app/bento/_components/order-items-list.tsx
@@ -9,7 +9,7 @@ import { cn } from "@workspace/ui/lib/utils"
 
 import { useDeleteOrderItem } from "@/hooks/bento/use-order-items"
 import {
-  formatItemTime,
+  formatItemDateTime,
   groupByPerson,
   itemPersonName,
   sortByTime,
@@ -91,7 +91,7 @@ export function OrderItemsList({
               className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-xl border border-border bg-card px-4 py-3 text-sm"
             >
               <span className="shrink-0 font-medium text-muted-foreground tabular-nums">
-                {formatItemTime(item.created_at)}
+                {formatItemDateTime(item.created_at)}
               </span>
               <span className="shrink-0 text-muted-foreground">
                 {itemPersonName(item)}
@@ -125,7 +125,7 @@ export function OrderItemsList({
                       className="flex flex-wrap items-center gap-2"
                     >
                       <span className="shrink-0 text-xs text-muted-foreground/70 tabular-nums">
-                        {formatItemTime(item.created_at)}
+                        {formatItemDateTime(item.created_at)}
                       </span>
                       <span>{item.menu_items?.name}</span>
                       <ItemOptionBadges

--- a/apps/portal/lib/bento/order-items-view.test.ts
+++ b/apps/portal/lib/bento/order-items-view.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test"
 
 import {
-  formatItemTime,
+  formatItemDateTime,
   groupByPerson,
   itemPrice,
   sortByTime,
@@ -127,12 +127,17 @@ describe("sortByTime", () => {
   })
 })
 
-describe("formatItemTime", () => {
-  it("formats a UTC timestamp as HH:mm in Taipei time (+8)", () => {
-    expect(formatItemTime("2026-07-06T06:23:00Z")).toBe("14:23")
+describe("formatItemDateTime", () => {
+  it("formats a UTC timestamp as MM/DD HH:mm in Taipei time (+8)", () => {
+    expect(formatItemDateTime("2026-07-06T06:23:00Z")).toBe("07/06 14:23")
+  })
+
+  it("rolls over the date when +8 crosses midnight", () => {
+    // 22:30 UTC on 07/06 is 06:30 on 07/07 in Taipei.
+    expect(formatItemDateTime("2026-07-06T22:30:00Z")).toBe("07/07 06:30")
   })
 
   it("returns an empty string for an invalid date", () => {
-    expect(formatItemTime("not-a-date")).toBe("")
+    expect(formatItemDateTime("not-a-date")).toBe("")
   })
 })

--- a/apps/portal/lib/bento/order-items-view.ts
+++ b/apps/portal/lib/bento/order-items-view.ts
@@ -100,15 +100,17 @@ export function sortByTime(
   return direction === "desc" ? sorted.reverse() : sorted
 }
 
-// Formats an item's timestamp as HH:mm in Taipei time, independent of the
-// runtime's timezone so it stays correct on servers and deterministic in tests.
-export function formatItemTime(iso: string): string {
+// Formats an item's timestamp as "MM/DD HH:mm" in Taipei time. Taiwan is a
+// fixed UTC+8 with no DST, so shifting the epoch by 8h and reading UTC parts is
+// exact — and unlike toLocaleString it's independent of the runtime's timezone
+// and ICU version, so it stays correct on servers and deterministic in tests.
+export function formatItemDateTime(iso: string): string {
   const date = new Date(iso)
   if (Number.isNaN(date.getTime())) return ""
-  return date.toLocaleTimeString("zh-TW", {
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-    timeZone: "Asia/Taipei",
-  })
+  const taipei = new Date(date.getTime() + 8 * 60 * 60 * 1000)
+  const mm = String(taipei.getUTCMonth() + 1).padStart(2, "0")
+  const dd = String(taipei.getUTCDate()).padStart(2, "0")
+  const hh = String(taipei.getUTCHours()).padStart(2, "0")
+  const min = String(taipei.getUTCMinutes()).padStart(2, "0")
+  return `${mm}/${dd} ${hh}:${min}`
 }


### PR DESCRIPTION
Closes #293

## Summary
Order-item timestamps now render as `MM/DD HH:mm` (e.g. `07/06 14:23`) instead of time-only, so orders spanning days are unambiguous. `formatItemTime` → `formatItemDateTime`, computed via a fixed +8 epoch shift (Taiwan has no DST) so the result is exact and independent of runtime timezone / ICU version.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `bun test lib/bento` — 51/51 pass (added a midnight-rollover case)
- [x] `bunx eslint` clean
- [ ] Manual check of the date+time display in a logged-in session (no Keycloak login available in this environment)