### PR TITLE
fix(bento): default order items to person view, self on top

### DIFF
--- a/apps/portal/app/bento/_components/order-items-list.tsx
+++ b/apps/portal/app/bento/_components/order-items-list.tsx
@@ -36,7 +36,7 @@ export function OrderItemsList({
   restaurantAdditional,
 }: OrderItemsListProps) {
   const deleteItem = useDeleteOrderItem()
-  const [sortMode, setSortMode] = useState<SortMode>("time")
+  const [sortMode, setSortMode] = useState<SortMode>("person")
 
   const handleDelete = async (id: string) => {
     try {
@@ -157,8 +157,8 @@ function SortToggle({
   onChange: (mode: SortMode) => void
 }) {
   const options: { mode: SortMode; label: string }[] = [
-    { mode: "time", label: "依時間" },
     { mode: "person", label: "依人" },
+    { mode: "time", label: "依時間" },
   ]
   return (
     <div className="flex self-end rounded-lg border border-border p-0.5">


### PR DESCRIPTION
Closes #295

## Summary
- OrderItemsList now defaults to 依人 (person) view instead of the time feed — it's what people reach for most (splitting the bill, finding their own order).
- The current user's group already pins to the top via `groupByPerson(items, currentUserId)`.
- Toggle button order flipped to 依人 | 依時間 to match the new default.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `bun test lib/bento` — 51/51 pass
- [x] `bunx eslint` clean