### PR TITLE
docs: drop removed apps/mcp, add bulletin & games to app lists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file briefs Claude Code (claude.ai/code) when working in this repository.
 
 ## Product
 
-**portal.winlab.tw** — WinLab's internal portal. The root domain hosts business apps (`/bento`, `/leave`, `/meetings`, `/approve`, `/trip`, `/debt`, `/reimburse`, `/receipts`, `/profile`, `/admin`), each owned by different people but sharing:
+**portal.winlab.tw** — WinLab's internal portal. The root domain hosts business apps (`/bento`, `/leave`, `/meetings`, `/approve`, `/trip`, `/debt`, `/reimburse`, `/receipts`, `/bulletin`, `/games`, `/profile`, `/admin`), each owned by different people but sharing:
 
 - **Auth** — Supabase Auth, Keycloak as the OIDC provider
 - **Profile / session** — one user state across the portal
@@ -12,7 +12,7 @@ This file briefs Claude Code (claude.ai/code) when working in this repository.
 
 A business app is `apps/portal/app/<name>/` — a route segment, **not** a separate Turborepo workspace. To add one, drop a folder under `apps/portal/app/`. Don't open a new `apps/*` Next.js project.
 
-**Exception**: when an app's design system genuinely diverges from portal (different fonts, different layout metaphor), break it out into a subdomain workspace. Today that's `apps/gallery` (`gallery.winlab.tw`, Instrument Serif, polaroid scatter) and `apps/mcp` (`mcp.winlab.tw`, MCP server). Ask the maintainer before opening a new workspace — don't open one just to dodge the shared shell. That's an owner-mindset issue.
+**Exception**: when an app's design system genuinely diverges from portal (different fonts, different layout metaphor), break it out into a subdomain workspace. Today that's `apps/gallery` (`gallery.winlab.tw`, Instrument Serif, polaroid scatter). Ask the maintainer before opening a new workspace — don't open one just to dodge the shared shell. That's an owner-mindset issue.
 
 ## Stack
 
@@ -99,9 +99,8 @@ Never open a PR without a linked issue. Exceptions: typo fixes, dependency bumps
 
 ### Monorepo topology
 
-- `apps/portal` — the main Next.js app on `portal.winlab.tw` (workspace name `portal`, runs on :3000). Most business routes (`/bento`, `/approve`, `/leave`, `/meetings`, `/trip`, `/debt`, `/reimburse`, `/receipts`, `/profile`, `/admin`) live here.
+- `apps/portal` — the main Next.js app on `portal.winlab.tw` (workspace name `portal`, runs on :3000). Most business routes (`/bento`, `/approve`, `/leave`, `/meetings`, `/trip`, `/debt`, `/reimburse`, `/receipts`, `/bulletin`, `/games`, `/profile`, `/admin`) live here.
 - `apps/gallery` — `gallery.winlab.tw`, an independent subdomain workspace (runs on :3005). Instrument Serif polaroid layout with custom `<GalleryShell>` chrome.
-- `apps/mcp` — `mcp.winlab.tw`, an MCP server exposing portal data over OAuth 2.1.
 - `packages/ui` — the single source of truth for the design system and shadcn primitives. `<PortalShell>` lives here; portal and gallery (via its own shell) import from it.
 - `packages/eslint-config` — flat-config presets: `base` / `next-js` / `react-internal`.
 - `packages/typescript-config` — `base.json` / `nextjs.json` / `react-library.json`.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Bun 1.3 · Turborepo 2 · Next.js 16 (App Router + Turbopack) · React 19 · Tai
 | `/admin`     | Super-admin role management (gated by `user_profiles.is_admin`) |
 | `/approve`   | Document signing with PDF field placement + email outbox        |
 | `/bento`     | Lunch-ordering for the lab — orders, menus, realtime            |
+| `/bulletin`  | Lab announcements / bulletin board                              |
 | `/debt`      | Bill-splitting + monthly settlement cron                        |
+| `/games`     | WinLab mini-games with global leaderboards                      |
 | `/leave`     | Monday-meeting attendance sign-ups                              |
 | `/meetings`  | Lab-meeting weekly schedule + teacher papers                    |
 | `/profile`   | Personal account + bento / leave / approve / trip stats         |
@@ -26,10 +28,9 @@ Bun 1.3 · Turborepo 2 · Next.js 16 (App Router + Turbopack) · React 19 · Tai
 | `/reimburse` | Lab cash-flow bookkeeping (egress + ingress)                    |
 | `/trip`      | Travel-document uploads with admin folder export                |
 
-Two apps live on their own subdomains because their design system diverges from portal:
+One app lives on its own subdomain because its design system diverges from portal:
 
 - [`apps/gallery`](./apps/gallery) — `gallery.winlab.tw`, the lab's art wall (Instrument Serif, polaroid layout)
-- [`apps/mcp`](./apps/mcp) — `mcp.winlab.tw`, an MCP server exposing portal data over OAuth 2.1
 
 ## Get started
 


### PR DESCRIPTION
Closes #297

## Summary
Docs drifted from the tree after `apps/mcp` was removed in #236:

- Remove the three `apps/mcp` / `mcp.winlab.tw` references (Product intro, monorepo topology, subdomain-workspace "Exception" in `CLAUDE.md`; subdomain apps list in `README.md`). "Two apps" → "One app".
- Add the two business apps missing from the app lists: `/bulletin` (announcements board) and `/games` (mini-games with global leaderboards), in both `CLAUDE.md` lists and the `README.md` Apps table.

`CHANGELOG.md` left untouched — it correctly records that `apps/mcp` existed and was removed.

## Test plan
- [x] `grep -i "apps/mcp\|mcp.winlab" CLAUDE.md README.md` returns nothing
- [x] `/bulletin` and `/games` correspond to real route segments under `apps/portal/app/`
- [ ] Docs-only change — no build/runtime impact