### PR TITLE
feat: evict departed members from upcoming questioner rosters

### DIFF
--- a/apps/portal/hooks/meetings/use-question-pool.ts
+++ b/apps/portal/hooks/meetings/use-question-pool.ts
@@ -61,14 +61,18 @@ export function useRemovePoolMember() {
 
   return useMutation({
     mutationFn: async (userId: string) => {
-      const { error } = await supabase
-        .from(TABLE)
-        .delete()
-        .eq("user_id", userId)
+      // RPC, not a direct delete: it also evicts the member from FUTURE
+      // meetings' questioner rosters and backfills those slots from the pool,
+      // all in one transaction. Past meetings are left as history.
+      const { error } = await supabase.rpc("meetings_remove_from_pool", {
+        p_user: userId,
+      })
       if (error) throw new Error(error.message || "移出成員池失敗")
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: queryKeys.questionPool.all })
+      // Upcoming rosters may have changed — refresh questioners too.
+      qc.invalidateQueries({ queryKey: ["meetings", "questioners"] })
       toast.success("已移出成員池")
     },
     onError: (e: Error) => toast.error(e.message),

--- a/apps/portal/lib/supabase/database.types.ts
+++ b/apps/portal/lib/supabase/database.types.ts
@@ -2004,6 +2004,10 @@ export type Database = {
       is_trip_admin: { Args: never; Returns: boolean }
       leave_profile_stats: { Args: { p_user_id: string }; Returns: Json }
       meetings_claim: { Args: { p_meeting_id: string }; Returns: undefined }
+      meetings_remove_from_pool: {
+        Args: { p_user: string }
+        Returns: undefined
+      }
       meetings_replace_questioner: {
         Args: {
           p_meeting_id: string

--- a/supabase/migrations/20260707000000_meeting-pool-removal-cleanup.sql
+++ b/supabase/migrations/20260707000000_meeting-pool-removal-cleanup.sql
@@ -1,0 +1,114 @@
+-- Follow-up to 20260706000000_meeting-question-pool: when a member is removed
+-- from the question pool, they should stop appearing as a questioner on FUTURE
+-- meetings (past meetings are history and must stay intact — meeting_questioners
+-- FKs user_profiles, not the pool, precisely so leaving the pool never erases a
+-- past assignment).
+--
+-- Two parts:
+--   1. meetings_sync_questioners now also evicts questioners who are no longer
+--      in the pool, but ONLY for meetings scheduled in the future. This makes
+--      sync the single source of truth for "what a valid upcoming roster is":
+--      not the presenter, only current pool members, topped up to 3.
+--   2. A new admin-only meetings_remove_from_pool() RPC removes a member and
+--      re-syncs exactly their future meetings in one transaction, so the portal
+--      "remove from pool" action cleans up upcoming rosters immediately instead
+--      of leaving the departed member stranded until each week is next touched.
+
+-- 1. Add the future-only left-pool eviction to the sync reconciler ------------
+create or replace function public.meetings_sync_questioners(p_meeting_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path to 'public'
+as $function$
+declare
+  v_meeting        public.meetings;
+  v_current_count  int;
+  v_missing        int;
+begin
+  select * into v_meeting from public.meetings where id = p_meeting_id;
+  if not found then
+    return;
+  end if;
+
+  if v_meeting.is_holiday or v_meeting.presenter_user_id is null then
+    delete from public.meeting_questioners where meeting_id = p_meeting_id;
+    return;
+  end if;
+
+  -- Evict a questioner row that now equals the presenter (e.g. the presenter
+  -- was changed after questioners were already assigned).
+  delete from public.meeting_questioners
+  where meeting_id = p_meeting_id and user_id = v_meeting.presenter_user_id;
+
+  -- Future meetings only: a questioner who has since left the pool is no longer
+  -- a valid pick — evict them so the backfill below refills the slot from the
+  -- current pool. Past meetings are left untouched (their roster is history).
+  if v_meeting.scheduled_date > current_date then
+    delete from public.meeting_questioners mq
+    where mq.meeting_id = p_meeting_id
+      and not exists (
+        select 1 from public.meeting_question_pool p where p.user_id = mq.user_id
+      );
+  end if;
+
+  select count(*) into v_current_count
+  from public.meeting_questioners
+  where meeting_id = p_meeting_id;
+
+  v_missing := 3 - v_current_count;
+  if v_missing > 0 then
+    insert into public.meeting_questioners (meeting_id, user_id, source)
+    select p_meeting_id, r.user_id, 'auto'
+    from public.meeting_question_rotation r
+    where r.user_id <> v_meeting.presenter_user_id
+      and not exists (
+        select 1 from public.meeting_questioners mq
+        where mq.meeting_id = p_meeting_id and mq.user_id = r.user_id
+      )
+    -- Explicit ORDER BY: a view's internal ordering is not guaranteed to
+    -- survive an outer WHERE + LIMIT, and rotation fairness depends on it.
+    order by r.last_asked_date asc nulls first, r.pool_added_at asc, r.user_id asc
+    limit v_missing
+    on conflict (meeting_id, user_id) do nothing;
+  end if;
+end;
+$function$;
+
+-- 2. Admin-only "remove from pool" that also cleans upcoming rosters ----------
+create or replace function public.meetings_remove_from_pool(p_user uuid)
+returns void
+language plpgsql
+security definer
+set search_path to 'public'
+as $function$
+declare
+  v_meeting_id uuid;
+begin
+  if not public.is_meetings_admin() then
+    raise exception 'Forbidden: 僅管理員可管理提問成員池' using errcode = '42501';
+  end if;
+
+  delete from public.meeting_question_pool where user_id = p_user;
+
+  -- Re-sync only the FUTURE meetings where they were still a questioner:
+  -- sync() now sees them as not-in-pool and evicts + backfills from the pool.
+  -- Past meetings are intentionally not visited, so history is preserved.
+  for v_meeting_id in
+    select distinct mq.meeting_id
+    from public.meeting_questioners mq
+    join public.meetings m on m.id = mq.meeting_id
+    where mq.user_id = p_user
+      and m.scheduled_date > current_date
+  loop
+    perform public.meetings_sync_questioners(v_meeting_id);
+  end loop;
+end;
+$function$;
+
+-- Same lockdown as the other RPCs: Supabase default privileges auto-grant anon
+-- EXECUTE on new functions, and revoking from PUBLIC doesn't touch that direct
+-- grant — so revoke anon explicitly. Admin-only in the body; authenticated
+-- grant is what the portal calls with.
+revoke all on function public.meetings_remove_from_pool(uuid) from public, anon;
+grant execute on function public.meetings_remove_from_pool(uuid) to authenticated;

--- a/supabase/tests/questioner-rotation.test.sql
+++ b/supabase/tests/questioner-rotation.test.sql
@@ -16,7 +16,7 @@ create extension if not exists pgtap with schema public;
 -- pgTAP assertion fns must be callable after we drop to the authenticated role.
 grant execute on all functions in schema public to authenticated;
 
-select plan(26);
+select plan(31);
 
 -- ── seed actors (as superuser — bypasses RLS) ───────────────────────────────
 insert into auth.users (id) values
@@ -49,7 +49,11 @@ insert into auth.users (id) values
   ('00000000-0000-0000-0000-000000000053'),
   ('00000000-0000-0000-0000-000000000054'),
   ('00000000-0000-0000-0000-000000000071'), -- s7 pool
-  ('00000000-0000-0000-0000-000000000072');
+  ('00000000-0000-0000-0000-000000000072'),
+  ('00000000-0000-0000-0000-000000000091'), -- s9 pool (removal cleanup)
+  ('00000000-0000-0000-0000-000000000092'),
+  ('00000000-0000-0000-0000-000000000093'),
+  ('00000000-0000-0000-0000-000000000094');
 
 insert into public.user_profiles (id, email, name, roles) values
   ('00000000-0000-0000-0000-000000000001', 'admin@test.local', 'Admin', '{"meetings":["admin"]}'::jsonb),
@@ -81,7 +85,11 @@ insert into public.user_profiles (id, email, name, roles) values
   ('00000000-0000-0000-0000-000000000053', 's6u3@test.local', 'S6 Pool 3', '{}'::jsonb),
   ('00000000-0000-0000-0000-000000000054', 's6u4@test.local', 'S6 Pool 4', '{}'::jsonb),
   ('00000000-0000-0000-0000-000000000071', 's7u1@test.local', 'S7 Pool 1', '{}'::jsonb),
-  ('00000000-0000-0000-0000-000000000072', 's7u2@test.local', 'S7 Pool 2', '{}'::jsonb);
+  ('00000000-0000-0000-0000-000000000072', 's7u2@test.local', 'S7 Pool 2', '{}'::jsonb),
+  ('00000000-0000-0000-0000-000000000091', 's9a@test.local', 'S9 Pool A', '{}'::jsonb),
+  ('00000000-0000-0000-0000-000000000092', 's9b@test.local', 'S9 Pool B', '{}'::jsonb),
+  ('00000000-0000-0000-0000-000000000093', 's9c@test.local', 'S9 Pool C', '{}'::jsonb),
+  ('00000000-0000-0000-0000-000000000094', 's9d@test.local', 'S9 Pool D', '{}'::jsonb);
 
 -- meetings for each scenario, distinct scheduled_date values throughout.
 insert into public.meetings (id, year, scheduled_date, is_holiday, presenter_user_id) values
@@ -424,6 +432,85 @@ select throws_ok(
   'a non-admin cannot directly INSERT into meeting_questioners (must go through the RPCs)'
 );
 reset role;
+
+-- ═══ Scenario 9: removing a pool member cleans FUTURE rosters, keeps PAST ═══
+-- The only scenario that depends on future-vs-past, so meeting dates are
+-- relative to current_date (not fixed literals like the others).
+insert into public.meetings (id, year, scheduled_date, is_holiday, presenter_user_id) values
+  ('10000000-0000-0000-0000-000000000009', 2026, current_date + 30, false, '00000000-0000-0000-0000-000000000002'), -- mFuture
+  ('10000000-0000-0000-0000-00000000000a', 2026, current_date - 30, false, '00000000-0000-0000-0000-000000000003'); -- mPast
+
+insert into public.meeting_question_pool (user_id, created_at) values
+  ('00000000-0000-0000-0000-000000000091', '2020-09-01 00:00:01+00'),
+  ('00000000-0000-0000-0000-000000000092', '2020-09-01 00:00:02+00'),
+  ('00000000-0000-0000-0000-000000000093', '2020-09-01 00:00:03+00'),
+  ('00000000-0000-0000-0000-000000000094', '2020-09-01 00:00:04+00');
+
+-- Assign the future meeting first (A, B, C picked; D spare), while A has no
+-- history so it still qualifies.
+select public.meetings_sync_questioners('10000000-0000-0000-0000-000000000009');
+
+-- A also carries a PAST questioner row — history that must survive removal.
+insert into public.meeting_questioners (meeting_id, user_id, source) values
+  ('10000000-0000-0000-0000-00000000000a', '00000000-0000-0000-0000-000000000091', 'auto');
+
+-- A non-admin cannot remove from the pool.
+set local role authenticated;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"00000000-0000-0000-0000-000000000009","role":"authenticated"}',
+  true
+);
+select throws_ok(
+  $$ select public.meetings_remove_from_pool('00000000-0000-0000-0000-000000000091') $$,
+  '42501',
+  NULL,
+  'a non-admin cannot remove a member from the question pool'
+);
+reset role;
+
+-- An admin removes A.
+set local role authenticated;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"00000000-0000-0000-0000-000000000001","role":"authenticated"}',
+  true
+);
+select lives_ok(
+  $$ select public.meetings_remove_from_pool('00000000-0000-0000-0000-000000000091') $$,
+  'an admin can remove a member from the question pool'
+);
+reset role;
+
+select ok(
+  not exists (
+    select 1 from public.meeting_question_pool
+    where user_id = '00000000-0000-0000-0000-000000000091'
+  ),
+  'the removed member is gone from the pool'
+);
+select is(
+  (select array_agg(user_id order by user_id) from public.meeting_questioners
+   where meeting_id = '10000000-0000-0000-0000-000000000009'),
+  array[
+    '00000000-0000-0000-0000-000000000092', '00000000-0000-0000-0000-000000000093',
+    '00000000-0000-0000-0000-000000000094'
+  ]::uuid[],
+  'future meeting: the removed member is evicted and the slot is backfilled from the pool'
+);
+select ok(
+  exists (
+    select 1 from public.meeting_questioners
+    where meeting_id = '10000000-0000-0000-0000-00000000000a'
+      and user_id = '00000000-0000-0000-0000-000000000091'
+  ),
+  'past meeting: the removed member''s historical questioner row is preserved'
+);
+
+delete from public.meeting_question_pool where user_id in (
+  '00000000-0000-0000-0000-000000000092', '00000000-0000-0000-0000-000000000093',
+  '00000000-0000-0000-0000-000000000094'
+);
 
 select * from finish();
 rollback;


### PR DESCRIPTION
Closes #303

## Summary
Removing a member from the question pool now clears their **upcoming** questioner slots and backfills from the pool, while preserving **past** history.

- `meetings_sync_questioners` evicts left-pool questioners on future meetings (`scheduled_date > current_date`) before topping up to 3; past meetings are untouched (their roster is history — `meeting_questioners` FKs `user_profiles`, not the pool).
- New admin-only `meetings_remove_from_pool(p_user)` RPC: delete from pool + re-sync the member's future meetings, atomically. Locked down (`revoke ... from public, anon`; `grant authenticated`) — same anon-EXECUTE gotcha as the other RPCs.
- `useRemovePoolMember` calls the RPC instead of a direct table delete; `database.types.ts` updated.
- pgTAP Scenario 9 (5 assertions, `plan` 26 → 31): future eviction + backfill, past preservation, non-admin blocked.

## Deploy (same discipline as #301)
The migration is additive and safe under the current live code, but **apply it to prod before merging** (the new UI calls `meetings_remove_from_pool`, which must exist first).

## Test plan
- [ ] `db-tests` CI green (pgTAP 31/31)
- [ ] typecheck / lint / build green
- [ ] After prod apply: remove a test member from the pool → gone from future weeks, still listed on past weeks; a non-admin cannot call the RPC
