### PR TITLE
fix: scroll meeting schedule to the current week on load

### DIFF
--- a/apps/portal/app/meetings/_components/schedule-tab.tsx
+++ b/apps/portal/app/meetings/_components/schedule-tab.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 import { IconPaperclip } from "@tabler/icons-react"
 import { Button } from "@workspace/ui/components/button"
@@ -22,19 +22,10 @@ import {
 } from "@/hooks/meetings/use-meetings"
 import { useQuestionersByYear } from "@/hooks/meetings/use-questioners"
 import { useMeetingsAdmin } from "@/hooks/meetings/use-meetings-admin"
+import { getCurrentMeetingId } from "@/lib/meetings/schedule"
 import type { Meeting } from "@/lib/meetings/types"
 
 import { MeetingEditDialog } from "./meeting-edit-dialog"
-
-function getCurrentWeekId(meetings: Meeting[]): string | null {
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
-  const upcoming = meetings.filter((m) => {
-    const d = new Date(m.scheduledDate)
-    return d >= today && !m.isHoliday
-  })
-  return upcoming[0]?.id ?? null
-}
 
 function FileCell({ link }: { link: string | null }) {
   if (!link) return <span className="text-xs text-muted-foreground">—</span>
@@ -60,7 +51,15 @@ export function ScheduleTab({ year }: { year: number }) {
 
   const [editTarget, setEditTarget] = useState<Meeting | null>(null)
 
-  const currentWeekId = getCurrentWeekId(meetings)
+  const currentWeekId = getCurrentMeetingId(meetings)
+  const currentRowRef = useRef<HTMLTableRowElement>(null)
+
+  // Land on the current week instead of January: bring the nearest upcoming
+  // session into view once the roster has loaded.
+  useEffect(() => {
+    if (isLoading || !currentWeekId) return
+    currentRowRef.current?.scrollIntoView({ block: "center" })
+  }, [isLoading, currentWeekId])
 
   if (isLoading) {
     return (
@@ -97,6 +96,7 @@ export function ScheduleTab({ year }: { year: number }) {
               return (
                 <TableRow
                   key={m.id}
+                  ref={isCurrent ? currentRowRef : undefined}
                   className={
                     m.isHoliday
                       ? "opacity-40"

--- a/apps/portal/lib/meetings/schedule.test.ts
+++ b/apps/portal/lib/meetings/schedule.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test"
+
+import { getCurrentMeetingId } from "./schedule"
+import type { Meeting } from "./types"
+
+function meeting(partial: Partial<Meeting> & { id: string }): Meeting {
+  return {
+    year: 2026,
+    weekLabel: null,
+    scheduledDate: "2026-01-01",
+    isHoliday: false,
+    presenter: null,
+    presenterUserId: null,
+    pptUploaded: false,
+    pptLink: null,
+    videoUploaded: false,
+    videoLink: null,
+    paperTitle: null,
+    paperLink: null,
+    notes: null,
+    location: "",
+    startTime: "",
+    createdAt: "",
+    ...partial,
+  }
+}
+
+describe("getCurrentMeetingId", () => {
+  const now = new Date("2026-07-08T12:00:00+08:00")
+
+  it("returns the nearest upcoming meeting, not the first of the year", () => {
+    const meetings = [
+      meeting({ id: "jan", scheduledDate: "2026-01-08" }),
+      meeting({ id: "jul-10", scheduledDate: "2026-07-10" }),
+      meeting({ id: "jul-17", scheduledDate: "2026-07-17" }),
+    ]
+    expect(getCurrentMeetingId(meetings, now)).toBe("jul-10")
+  })
+
+  it("counts today as the current meeting", () => {
+    const meetings = [
+      meeting({ id: "past", scheduledDate: "2026-07-01" }),
+      meeting({ id: "today", scheduledDate: "2026-07-08" }),
+      meeting({ id: "next", scheduledDate: "2026-07-15" }),
+    ]
+    expect(getCurrentMeetingId(meetings, now)).toBe("today")
+  })
+
+  it("skips holidays when picking the current meeting", () => {
+    const meetings = [
+      meeting({ id: "holiday", scheduledDate: "2026-07-10", isHoliday: true }),
+      meeting({ id: "real", scheduledDate: "2026-07-17" }),
+    ]
+    expect(getCurrentMeetingId(meetings, now)).toBe("real")
+  })
+
+  it("returns null when every meeting is in the past", () => {
+    const meetings = [
+      meeting({ id: "a", scheduledDate: "2026-01-08" }),
+      meeting({ id: "b", scheduledDate: "2026-06-30" }),
+    ]
+    expect(getCurrentMeetingId(meetings, now)).toBeNull()
+  })
+
+  it("returns null for an empty roster", () => {
+    expect(getCurrentMeetingId([], now)).toBeNull()
+  })
+})

--- a/apps/portal/lib/meetings/schedule.ts
+++ b/apps/portal/lib/meetings/schedule.ts
@@ -1,0 +1,20 @@
+import type { Meeting } from "./types"
+
+/**
+ * The "current" meeting is the nearest upcoming non-holiday session, with
+ * today counting as upcoming. `meetings` is expected sorted ascending by
+ * `scheduledDate` (as returned by `useMeetings`). Returns `null` when every
+ * session is in the past.
+ */
+export function getCurrentMeetingId(
+  meetings: Meeting[],
+  now: Date = new Date()
+): string | null {
+  const today = new Date(now)
+  today.setHours(0, 0, 0, 0)
+  for (const m of meetings) {
+    if (m.isHoliday) continue
+    if (new Date(m.scheduledDate) >= today) return m.id
+  }
+  return null
+}


### PR DESCRIPTION
## 根因
`ScheduleTab` 用 `useMeetings(year)` 撈整年排班、依 `scheduled_date` 升冪排序後直接 render，所以 meetings 頁永遠固定停在一月第一週的頂端。原本 `getCurrentWeekId` 只給「最近一場」加 `bg-muted/60` 底色，但沒有把該列捲進視野 —— 使用者落地看到的是一月，得手動往下捲才找得到當前週次(#299 截圖的現象)。

## 修法
- 把「最近一場未來、非放假的 meeting」邏輯抽到 `lib/meetings/schedule.ts` 的 `getCurrentMeetingId()`(純函式、可注入 `now`),符合 repo 慣例「pure logic 放 lib/ 才好測」,並補上 `schedule.test.ts`(5 個 case:跳過一月選最近、今天算當前、跳過放假、全過期回 null、空 roster)。
- 在 `ScheduleTab` 對「當前列」掛 `ref`,roster 載入後 `scrollIntoView({ block: "center" })`,讓使用者落地即停在當前週次而非一月。保留既有底色高亮。

## 驗證
- `bun test lib/meetings/schedule.test.ts` → 5 pass
- `bun run typecheck --filter=portal` → clean

Closes #299