### PR TITLE
docs: sync app lists with apps/mcp removal, add bulletin & games

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file briefs Claude Code (claude.ai/code) when working in this repository.
 
 ## Product
 
-**portal.winlab.tw** — WinLab's internal portal. The root domain hosts business apps (`/bento`, `/leave`, `/meetings`, `/approve`, `/trip`, `/debt`, `/reimburse`, `/receipts`, `/profile`, `/admin`), each owned by different people but sharing:
+**portal.winlab.tw** — WinLab's internal portal. The root domain hosts business apps (`/admin`, `/approve`, `/bento`, `/bulletin`, `/debt`, `/games`, `/leave`, `/meetings`, `/profile`, `/receipts`, `/reimburse`, `/trip`), each owned by different people but sharing:
 
 - **Auth** — Supabase Auth, Keycloak as the OIDC provider
 - **Profile / session** — one user state across the portal
@@ -12,7 +12,7 @@ This file briefs Claude Code (claude.ai/code) when working in this repository.
 
 A business app is `apps/portal/app/<name>/` — a route segment, **not** a separate Turborepo workspace. To add one, drop a folder under `apps/portal/app/`. Don't open a new `apps/*` Next.js project.
 
-**Exception**: when an app's design system genuinely diverges from portal (different fonts, different layout metaphor), break it out into a subdomain workspace. Today that's `apps/gallery` (`gallery.winlab.tw`, Instrument Serif, polaroid scatter) and `apps/mcp` (`mcp.winlab.tw`, MCP server). Ask the maintainer before opening a new workspace — don't open one just to dodge the shared shell. That's an owner-mindset issue.
+**Exception**: when an app's design system genuinely diverges from portal (different fonts, different layout metaphor), break it out into a subdomain workspace. Today that's `apps/gallery` (`gallery.winlab.tw`, Instrument Serif, polaroid scatter). Ask the maintainer before opening a new workspace — don't open one just to dodge the shared shell. That's an owner-mindset issue.
 
 ## Stack
 
@@ -99,9 +99,8 @@ Never open a PR without a linked issue. Exceptions: typo fixes, dependency bumps
 
 ### Monorepo topology
 
-- `apps/portal` — the main Next.js app on `portal.winlab.tw` (workspace name `portal`, runs on :3000). Most business routes (`/bento`, `/approve`, `/leave`, `/meetings`, `/trip`, `/debt`, `/reimburse`, `/receipts`, `/profile`, `/admin`) live here.
+- `apps/portal` — the main Next.js app on `portal.winlab.tw` (workspace name `portal`, runs on :3000). Most business routes (`/admin`, `/approve`, `/bento`, `/bulletin`, `/debt`, `/games`, `/leave`, `/meetings`, `/profile`, `/receipts`, `/reimburse`, `/trip`) live here.
 - `apps/gallery` — `gallery.winlab.tw`, an independent subdomain workspace (runs on :3005). Instrument Serif polaroid layout with custom `<GalleryShell>` chrome.
-- `apps/mcp` — `mcp.winlab.tw`, an MCP server exposing portal data over OAuth 2.1.
 - `packages/ui` — the single source of truth for the design system and shadcn primitives. `<PortalShell>` lives here; portal and gallery (via its own shell) import from it.
 - `packages/eslint-config` — flat-config presets: `base` / `next-js` / `react-internal`.
 - `packages/typescript-config` — `base.json` / `nextjs.json` / `react-library.json`.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Bun 1.3 · Turborepo 2 · Next.js 16 (App Router + Turbopack) · React 19 · Tai
 | `/admin`     | Super-admin role management (gated by `user_profiles.is_admin`) |
 | `/approve`   | Document signing with PDF field placement + email outbox        |
 | `/bento`     | Lunch-ordering for the lab — orders, menus, realtime            |
+| `/bulletin`  | Announcements board                                             |
 | `/debt`      | Bill-splitting + monthly settlement cron                        |
+| `/games`     | Mini-games (2048, snake, …) with global leaderboards            |
 | `/leave`     | Monday-meeting attendance sign-ups                              |
 | `/meetings`  | Lab-meeting weekly schedule + teacher papers                    |
 | `/profile`   | Personal account + bento / leave / approve / trip stats         |
@@ -26,10 +28,9 @@ Bun 1.3 · Turborepo 2 · Next.js 16 (App Router + Turbopack) · React 19 · Tai
 | `/reimburse` | Lab cash-flow bookkeeping (egress + ingress)                    |
 | `/trip`      | Travel-document uploads with admin folder export                |
 
-Two apps live on their own subdomains because their design system diverges from portal:
+One app lives on its own subdomain because its design system diverges from portal:
 
 - [`apps/gallery`](./apps/gallery) — `gallery.winlab.tw`, the lab's art wall (Instrument Serif, polaroid layout)
-- [`apps/mcp`](./apps/mcp) — `mcp.winlab.tw`, an MCP server exposing portal data over OAuth 2.1
 
 ## Get started
 


### PR DESCRIPTION
Closes #297

## Summary
Docs-only. `apps/mcp` was removed in #236 but `CLAUDE.md` / `README.md` still described it; the business-app lists also omitted `/bulletin` and `/games`.

- **CLAUDE.md** — dropped `apps/mcp` from the subdomain-workspace "Exception" and the monorepo topology; refreshed both business-app route lists (now alphabetical, incl. `/bulletin`, `/games`).
- **README.md** — added `/bulletin` and `/games` to the Apps table; changed "Two apps live on their own subdomains" → one (gallery only), removed the `apps/mcp` bullet.
- `CHANGELOG.md` intentionally untouched (historical record).

## Test plan
- [x] `grep -rni mcp --include=*.md` (excl. CHANGELOG) → no matches