### PR TITLE
feat(gallery): improve upload retry UX and manage sorting

### DIFF
--- a/apps/gallery/app/_components/gallery-card.tsx
+++ b/apps/gallery/app/_components/gallery-card.tsx
@@ -221,22 +221,32 @@ export function GalleryCard({
   const [namesByReaction, setNamesByReaction] = useState(image.reaction_names)
   const [comments, setComments] = useState<GalleryComment[]>([])
   const [commentsLoaded, setCommentsLoaded] = useState(false)
-  const [commentCountHint, setCommentCountHint] = useState(image.comment_count)
   const [pinnedAt, setPinnedAt] = useState<string | null>(image.pinned_at)
+  const viewerIdRef = useRef(viewerId)
+  const isDialogOpenRef = useRef(isDialogOpen)
+
+  // Coalesce realtime bursts into a single refresh.
+  const refreshTimerRef = useRef<number | null>(null)
+  const refreshInFlightRef = useRef(false)
+  const refreshQueuedRef = useRef(false)
 
   const canReact = isSignedIn && !isPending
   const reactionTotal = totalReactions(counts)
-  const wallCommentCount = commentsLoaded ? comments.length : commentCountHint
+  const wallCommentCount = commentsLoaded
+    ? comments.length
+    : image.comment_count
 
   useEffect(() => {
-    setCommentCountHint(image.comment_count)
+    viewerIdRef.current = viewerId
+  }, [viewerId])
+
+  useEffect(() => {
+    isDialogOpenRef.current = isDialogOpen
+  }, [isDialogOpen])
+
+  useEffect(() => {
     setPinnedAt(image.pinned_at)
-  }, [image.comment_count, image.id, image.pinned_at])
-
-  useEffect(() => {
-    if (!commentsLoaded) return
-    setCommentCountHint(comments.length)
-  }, [comments.length, commentsLoaded])
+  }, [image.pinned_at])
 
   useEffect(() => {
     if (open && highlightCommentId) {
@@ -249,14 +259,56 @@ export function GalleryCard({
   }
 
   const refreshSocial = useCallback(async () => {
+    if (!isDialogOpenRef.current) return
+    if (refreshInFlightRef.current) {
+      refreshQueuedRef.current = true
+      return
+    }
+
+    refreshInFlightRef.current = true
     const supabase = createClient()
-    const social = await loadLightboxSocial(supabase, image.id, viewerId)
-    setComments(social.comments)
-    setCommentsLoaded(true)
-    setCounts(social.reaction_counts)
-    setNamesByReaction(social.reaction_names)
-    setMyReaction(social.my_reaction)
-  }, [image.id, viewerId])
+    try {
+      const social = await loadLightboxSocial(
+        supabase,
+        image.id,
+        viewerIdRef.current
+      )
+      // Dialog might have been closed while the request was in-flight.
+      if (!isDialogOpenRef.current) return
+
+      setComments(social.comments)
+      setCommentsLoaded(true)
+      setCounts(social.reaction_counts)
+      setNamesByReaction(social.reaction_names)
+      setMyReaction(social.my_reaction)
+    } finally {
+      refreshInFlightRef.current = false
+      if (refreshQueuedRef.current) {
+        refreshQueuedRef.current = false
+        void refreshSocial()
+      }
+    }
+  }, [image.id])
+
+  const scheduleRefreshSocial = useCallback(() => {
+    if (!isDialogOpenRef.current) return
+    if (refreshTimerRef.current) {
+      window.clearTimeout(refreshTimerRef.current)
+    }
+    refreshTimerRef.current = window.setTimeout(() => {
+      refreshTimerRef.current = null
+      void refreshSocial()
+    }, 150)
+  }, [refreshSocial])
+
+  useEffect(() => {
+    if (isDialogOpen) return
+    if (refreshTimerRef.current) {
+      window.clearTimeout(refreshTimerRef.current)
+      refreshTimerRef.current = null
+    }
+    refreshQueuedRef.current = false
+  }, [isDialogOpen])
 
   useEffect(() => {
     if (!isDialogOpen) return
@@ -267,7 +319,7 @@ export function GalleryCard({
     if (isDialogOpen) return
     setComments([])
     setCommentsLoaded(false)
-  }, [isDialogOpen, image.id])
+  }, [isDialogOpen])
 
   useEffect(() => {
     if (!isDialogOpen) return
@@ -277,7 +329,7 @@ export function GalleryCard({
     const channel = supabase.channel(channelName)
 
     const onChange = () => {
-      void refreshSocial()
+      scheduleRefreshSocial()
     }
 
     channel
@@ -306,7 +358,7 @@ export function GalleryCard({
     return () => {
       void supabase.removeChannel(channel)
     }
-  }, [isDialogOpen, image.id, refreshSocial])
+  }, [isDialogOpen, image.id, refreshSocial, scheduleRefreshSocial])
 
   useEffect(() => {
     if (isDialogOpen) return

--- a/apps/gallery/app/upload/_components/upload-form.tsx
+++ b/apps/gallery/app/upload/_components/upload-form.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type { FormEvent } from "react"
-import { useRef, useState, useTransition } from "react"
+import { useEffect, useMemo, useRef, useState, useTransition } from "react"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 
@@ -35,11 +35,97 @@ type Status =
       batch?: { current: number; total: number }
     }
 
+type UploadFailure = {
+  file: File
+  detail: string
+  stage:
+    | "type"
+    | "video-processing"
+    | "storage-upload"
+    | "storage-verify"
+    | "db-insert"
+    | "unknown"
+  sequenceId: string | null
+  sequenceIndex: number | null
+}
+
 const PHASE_LABEL: Record<CompressPhase, string> = {
   init: "Loading encoder",
   probe: "Reading video",
   compress: "Compressing to 720p",
   poster: "Capturing cover frame",
+}
+
+class UploadFailureError extends Error {
+  constructor(
+    readonly stage: UploadFailure["stage"],
+    message: string
+  ) {
+    super(message)
+    this.name = "UploadFailureError"
+  }
+}
+
+function inferArtworkName(fileName: string): string {
+  const base = fileName.replace(/\.[^.]+$/, "").trim()
+  return base || "Untitled"
+}
+
+function buildArtworkName(
+  files: File[],
+  trimmedBaseName: string,
+  index: number
+): string {
+  const file = files[index]
+  if (!file) return trimmedBaseName || "Untitled"
+
+  if (files.length === 1) {
+    return trimmedBaseName || inferArtworkName(file.name)
+  }
+
+  if (!trimmedBaseName) {
+    return inferArtworkName(file.name)
+  }
+
+  return index === 0 ? trimmedBaseName : `${trimmedBaseName}${index}`
+}
+
+function describeUploadFailure(error: unknown): {
+  detail: string
+  stage: UploadFailure["stage"]
+} {
+  if (error instanceof UploadFailureError) {
+    return { detail: error.message, stage: error.stage }
+  }
+
+  const message = error instanceof Error ? error.message : String(error)
+  const lower = message.toLowerCase()
+
+  if (lower.includes("unsupported")) {
+    return { detail: message, stage: "type" }
+  }
+  if (lower.includes("verify upload") || lower.includes("file not found")) {
+    return { detail: message, stage: "storage-verify" }
+  }
+  if (lower.includes("database insert failed")) {
+    return { detail: message, stage: "db-insert" }
+  }
+  if (
+    lower.includes("compress") ||
+    lower.includes("poster") ||
+    lower.includes("video")
+  ) {
+    return { detail: message, stage: "video-processing" }
+  }
+  if (lower.includes("upload")) {
+    return { detail: message, stage: "storage-upload" }
+  }
+
+  return { detail: message, stage: "unknown" }
+}
+
+function formatFailurePreview(failure: UploadFailure): string {
+  return `${failure.file.name} [${failure.stage}] ${failure.detail}`
 }
 
 /** Client uploads bytes to Supabase Storage; server action only registers the row (no 413 on Vercel). */
@@ -48,20 +134,285 @@ export function UploadForm() {
   const formRef = useRef<HTMLFormElement>(null)
   const [pending, startTransition] = useTransition()
   const [name, setName] = useState("")
-  const [fileNames, setFileNames] = useState<string[]>([])
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([])
+  const [failedUploads, setFailedUploads] = useState<UploadFailure[]>([])
   const [status, setStatus] = useState<Status>({ kind: "idle" })
+  const fileNames = selectedFiles.map((file) => file.name)
+  const trimmedName = name.trim()
+  const sequencePreview = useMemo(() => {
+    if (selectedFiles.length === 0) return []
+    return selectedFiles
+      .slice(0, 4)
+      .map((_, index) => buildArtworkName(selectedFiles, trimmedName, index))
+  }, [selectedFiles, trimmedName])
 
-  function inferArtworkName(fileName: string): string {
-    const base = fileName.replace(/\.[^.]+$/, "").trim()
-    return base || "Untitled"
+  useEffect(() => {
+    if (status.kind !== "working") return
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault()
+      event.returnValue = ""
+    }
+
+    window.addEventListener("beforeunload", handleBeforeUnload)
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload)
+  }, [status.kind])
+
+  async function runUpload(files: File[], baseName: string) {
+    const form = formRef.current
+    const trimmed = baseName.trim()
+    const supabase = createClient()
+    const { data: claimsData } = await supabase.auth.getClaims()
+    const userId = claimsData?.claims?.sub
+    if (!userId) {
+      toast.error("Not signed in.")
+      return
+    }
+
+    let successCount = 0
+    const failures: UploadFailure[] = []
+    const sequenceId = files.length > 1 ? crypto.randomUUID() : null
+    let wallPhotoId: string | null = null
+    const batch = files.length > 1 ? { total: files.length, current: 0 } : undefined
+
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i]!
+      const batchCurrent = i + 1
+      const labelPrefix = files.length > 1 ? `(${batchCurrent}/${files.length}) ` : ""
+
+      if (batch) {
+        setStatus({
+          kind: "working",
+          label: `Uploading ${batchCurrent} of ${files.length}`,
+          ratio: (i + 0.05) / files.length,
+          batch: { current: batchCurrent, total: files.length },
+        })
+      }
+
+      const resolved = resolveMediaMimeType(file)
+      if (!resolved) {
+        failures.push({
+          file,
+          stage: "type",
+          detail: `unsupported type: ${file.type || "unknown"}`,
+          sequenceId,
+          sequenceIndex: sequenceId ? i : null,
+        })
+        continue
+      }
+
+      const artworkName = buildArtworkName(files, trimmed, i)
+
+      try {
+        let registeredId: string
+        if (resolved.kind === "image") {
+          registeredId = await uploadImage({
+            supabase,
+            userId,
+            file,
+            resolved,
+            artworkName,
+            setStatus,
+            labelPrefix,
+            sequenceId,
+            sequenceIndex: sequenceId ? i : null,
+          })
+        } else {
+          registeredId = await uploadVideo({
+            supabase,
+            userId,
+            file,
+            artworkName,
+            setStatus,
+            labelPrefix,
+            sequenceId,
+            sequenceIndex: sequenceId ? i : null,
+          })
+        }
+
+        if (!wallPhotoId && (sequenceId ? i === 0 : true)) {
+          wallPhotoId = registeredId
+        }
+        successCount += 1
+      } catch (error) {
+        failures.push({
+          file,
+          ...describeUploadFailure(error),
+          sequenceId,
+          sequenceIndex: sequenceId ? i : null,
+        })
+      }
+    }
+
+    setStatus({ kind: "idle" })
+    setFailedUploads(failures)
+
+    if (successCount > 0) {
+      const suffix = successCount > 1 ? "s" : ""
+      if (wallPhotoId) {
+        const href = buildGalleryPhotoHref({ photoId: wallPhotoId })
+        toast.success(`Uploaded ${successCount} work${suffix}.`, {
+          action: {
+            label: "View on wall",
+            onClick: () => router.push(href),
+          },
+        })
+      } else {
+        toast.success(`Uploaded ${successCount} work${suffix}.`)
+      }
+
+      if (failures.length === 0) {
+        form?.reset()
+        setName("")
+        setSelectedFiles([])
+      }
+    }
+
+    if (failures.length > 0) {
+      const preview = failures.slice(0, 3).map(formatFailurePreview).join("; ")
+      const hidden = failures.length > 3 ? ` (+${failures.length - 3} more)` : ""
+      toast.error(`Failed ${failures.length}: ${preview}${hidden}`)
+    }
+  }
+
+  async function retryFailedUploads(failures: UploadFailure[]) {
+    if (failures.length === 0) return
+
+    const trimmed = name.trim()
+    const supabase = createClient()
+    const { data: claimsData } = await supabase.auth.getClaims()
+    const userId = claimsData?.claims?.sub
+    if (!userId) {
+      toast.error("Not signed in.")
+      return
+    }
+
+    let successCount = 0
+    let wallPhotoId: string | null = null
+    const nextFailures: UploadFailure[] = []
+    const total = failures.length
+
+    for (let i = 0; i < failures.length; i++) {
+      const failure = failures[i]!
+      const file = failure.file
+      const batchCurrent = i + 1
+      const labelPrefix = total > 1 ? `(${batchCurrent}/${total}) ` : ""
+
+      setStatus({
+        kind: "working",
+        label: `Retrying ${batchCurrent} of ${total}`,
+        ratio: (i + 0.05) / total,
+        batch: { current: batchCurrent, total },
+      })
+
+      const resolved = resolveMediaMimeType(file)
+      if (!resolved) {
+        nextFailures.push({
+          file,
+          stage: "type",
+          detail: `unsupported type: ${file.type || "unknown"}`,
+          sequenceId: failure.sequenceId,
+          sequenceIndex: failure.sequenceIndex,
+        })
+        continue
+      }
+
+      const artworkName =
+        failure.sequenceId && failure.sequenceIndex != null
+          ? trimmed
+            ? failure.sequenceIndex === 0
+              ? trimmed
+              : `${trimmed}${failure.sequenceIndex}`
+            : inferArtworkName(file.name)
+          : trimmed
+            ? trimmed
+            : inferArtworkName(file.name)
+
+      try {
+        let registeredId: string
+        if (resolved.kind === "image") {
+          registeredId = await uploadImage({
+            supabase,
+            userId,
+            file,
+            resolved,
+            artworkName,
+            setStatus,
+            labelPrefix,
+            sequenceId: failure.sequenceId,
+            sequenceIndex: failure.sequenceIndex,
+          })
+        } else {
+          registeredId = await uploadVideo({
+            supabase,
+            userId,
+            file,
+            artworkName,
+            setStatus,
+            labelPrefix,
+            sequenceId: failure.sequenceId,
+            sequenceIndex: failure.sequenceIndex,
+          })
+        }
+
+        if (
+          !wallPhotoId &&
+          (failure.sequenceId ? failure.sequenceIndex === 0 : true)
+        ) {
+          wallPhotoId = registeredId
+        }
+
+        successCount += 1
+      } catch (error) {
+        nextFailures.push({
+          file,
+          ...describeUploadFailure(error),
+          sequenceId: failure.sequenceId,
+          sequenceIndex: failure.sequenceIndex,
+        })
+      }
+    }
+
+    setStatus({ kind: "idle" })
+    setFailedUploads(nextFailures)
+
+    if (successCount > 0) {
+      const suffix = successCount > 1 ? "s" : ""
+      if (wallPhotoId) {
+        const href = buildGalleryPhotoHref({ photoId: wallPhotoId })
+        toast.success(`Uploaded ${successCount} work${suffix}.`, {
+          action: {
+            label: "View on wall",
+            onClick: () => router.push(href),
+          },
+        })
+      } else {
+        toast.success(`Uploaded ${successCount} work${suffix}.`)
+      }
+    }
+
+    if (nextFailures.length === 0) {
+      formRef.current?.reset()
+      setName("")
+      setSelectedFiles([])
+      return
+    }
+
+    const preview = nextFailures
+      .slice(0, 3)
+      .map(formatFailurePreview)
+      .join("; ")
+    const hidden =
+      nextFailures.length > 3
+        ? ` (+${nextFailures.length - 3} more)`
+        : ""
+    toast.error(`Still failed ${nextFailures.length}: ${preview}${hidden}`)
   }
 
   function onSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault()
-    const form = formRef.current
-    const fileInput = form?.querySelector<HTMLInputElement>("#gallery-file")
+    const fileInput = formRef.current?.querySelector<HTMLInputElement>("#gallery-file")
     const files = Array.from(fileInput?.files ?? [])
-    const trimmed = name.trim()
 
     if (files.length === 0) {
       toast.error("Pick a file.")
@@ -73,108 +424,7 @@ export function UploadForm() {
     }
 
     startTransition(async () => {
-      const supabase = createClient()
-      const { data: claimsData } = await supabase.auth.getClaims()
-      const userId = claimsData?.claims?.sub
-      if (!userId) {
-        toast.error("Not signed in.")
-        return
-      }
-
-      let successCount = 0
-      const failed: string[] = []
-      const sequenceId = files.length > 1 ? crypto.randomUUID() : null
-      let wallPhotoId: string | null = null
-
-      const batch =
-        files.length > 1 ? { total: files.length, current: 0 } : undefined
-
-      for (let i = 0; i < files.length; i++) {
-        const file = files[i]!
-        const batchCurrent = i + 1
-        const labelPrefix =
-          files.length > 1 ? `(${batchCurrent}/${files.length}) ` : ""
-
-        if (batch) {
-          setStatus({
-            kind: "working",
-            label: `Uploading ${batchCurrent} of ${files.length}`,
-            ratio: (i + 0.05) / files.length,
-            batch: { current: batchCurrent, total: files.length },
-          })
-        }
-
-        const resolved = resolveMediaMimeType(file)
-        if (!resolved) {
-          failed.push(
-            `${file.name} (unsupported type: ${file.type || "unknown"})`
-          )
-          continue
-        }
-
-        const artworkName =
-          files.length === 1 && trimmed ? trimmed : inferArtworkName(file.name)
-
-        try {
-          let registeredId: string
-          if (resolved.kind === "image") {
-            registeredId = await uploadImage({
-              supabase,
-              userId,
-              file,
-              resolved,
-              artworkName,
-              setStatus,
-              labelPrefix,
-              sequenceId,
-              sequenceIndex: sequenceId ? i : null,
-            })
-          } else {
-            registeredId = await uploadVideo({
-              supabase,
-              userId,
-              file,
-              artworkName,
-              setStatus,
-              labelPrefix,
-              sequenceId,
-              sequenceIndex: sequenceId ? i : null,
-            })
-          }
-          if (!wallPhotoId && (sequenceId ? i === 0 : true)) {
-            wallPhotoId = registeredId
-          }
-          successCount += 1
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err)
-          failed.push(`${file.name} (${message})`)
-        }
-      }
-
-      setStatus({ kind: "idle" })
-
-      if (successCount > 0) {
-        const suffix = successCount > 1 ? "s" : ""
-        if (wallPhotoId) {
-          const href = buildGalleryPhotoHref({ photoId: wallPhotoId })
-          toast.success(`Uploaded ${successCount} work${suffix}.`, {
-            action: {
-              label: "View on wall",
-              onClick: () => router.push(href),
-            },
-          })
-        } else {
-          toast.success(`Uploaded ${successCount} work${suffix}.`)
-        }
-        form?.reset()
-        setName("")
-        setFileNames([])
-      }
-      if (failed.length > 0) {
-        const preview = failed.slice(0, 3).join("; ")
-        const hidden = failed.length > 3 ? ` (+${failed.length - 3} more)` : ""
-        toast.error(`Failed ${failed.length}: ${preview}${hidden}`)
-      }
+      await runUpload(files, name)
     })
   }
 
@@ -185,7 +435,7 @@ export function UploadForm() {
           htmlFor="gallery-name"
           className={cn(gallerySerif(), "text-base")}
         >
-          Name (single upload only)
+          Name (base name for single upload / sequence cover)
         </Label>
         <Input
           id="gallery-name"
@@ -214,9 +464,8 @@ export function UploadForm() {
           accept="image/*,video/*"
           required
           multiple
-          onChange={(e) =>
-            setFileNames(Array.from(e.target.files ?? []).map((f) => f.name))
-          }
+          onClick={() => setFailedUploads([])}
+          onChange={(e) => setSelectedFiles(Array.from(e.target.files ?? []))}
           disabled={pending}
           className={cn(
             gallerySans(),
@@ -242,6 +491,56 @@ export function UploadForm() {
         <p className={cn(gallerySans(), "text-xs text-muted-foreground")}>
           Multi-select uploads are grouped as one sequence on the wall.
         </p>
+        {selectedFiles.length > 1 && trimmedName ? (
+          <div className="rounded-xl border border-border/60 bg-muted/30 px-3 py-2">
+            <p className={cn(gallerySans(), "text-xs font-medium text-foreground")}>
+              Sequence naming preview
+            </p>
+            <p className={cn(gallerySans(), "mt-1 text-xs text-muted-foreground")}>
+              {sequencePreview.join(", ")}
+              {selectedFiles.length > sequencePreview.length
+                ? ` (+${selectedFiles.length - sequencePreview.length} more)`
+                : ""}
+            </p>
+          </div>
+        ) : null}
+        {failedUploads.length > 0 ? (
+          <div className="rounded-xl border border-destructive/25 bg-destructive/5 px-3 py-3">
+            <p className={cn(gallerySans(), "text-sm font-medium text-foreground")}>
+              Failed uploads
+            </p>
+            <ul className={cn(gallerySans(), "mt-2 space-y-1 text-xs text-muted-foreground")}>
+              {failedUploads.slice(0, 4).map((failure) => (
+                <li key={`${failure.file.name}:${failure.stage}`}>
+                  {formatFailurePreview(failure)}
+                </li>
+              ))}
+            </ul>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <Button
+                type="button"
+                size="sm"
+                disabled={pending}
+                onClick={() =>
+                  startTransition(async () => {
+                    await retryFailedUploads(failedUploads)
+                  })
+                }
+              >
+                Retry failed
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                disabled={pending}
+                onClick={() => setFailedUploads([])}
+              >
+                Dismiss
+              </Button>
+            </div>
+          </div>
+        ) : null}
       </div>
       {status.kind === "working" ? (
         <div className="flex flex-col gap-2">
@@ -304,7 +603,12 @@ async function uploadImage(
     sequenceIndex,
   } = ctx
   const ext = guessExtension(resolved.mime, file.name)
-  if (ext === "bin") throw new Error("Unsupported extension")
+  if (ext === "bin") {
+    throw new UploadFailureError(
+      "type",
+      "unsupported extension for this file"
+    )
+  }
 
   setStatus({
     kind: "working",
@@ -319,7 +623,9 @@ async function uploadImage(
       contentType: resolved.mime,
       upsert: false,
     })
-  if (uploadError) throw new Error(uploadError.message)
+  if (uploadError) {
+    throw new UploadFailureError("storage-upload", uploadError.message)
+  }
 
   setStatus({
     kind: "working",
@@ -336,7 +642,15 @@ async function uploadImage(
   })
   if (!result.ok) {
     await supabase.storage.from("gallery").remove([objectPath])
-    throw new Error(result.error)
+    throw new UploadFailureError(
+      result.error.includes("Database insert failed")
+        ? "db-insert"
+        : result.error.includes("verify upload") ||
+            result.error.includes("File not found")
+          ? "storage-verify"
+          : "unknown",
+      result.error
+    )
   }
   return result.id
 }
@@ -362,6 +676,12 @@ async function uploadVideo(ctx: UploadCtx): Promise<string> {
       })
     },
   })
+  if (!compressed.video || !compressed.poster) {
+    throw new UploadFailureError(
+      "video-processing",
+      "video compression did not return playable assets"
+    )
+  }
 
   const videoId = crypto.randomUUID()
   const posterId = crypto.randomUUID()
@@ -379,7 +699,9 @@ async function uploadVideo(ctx: UploadCtx): Promise<string> {
       contentType: compressed.videoMime,
       upsert: false,
     })
-  if (videoErr) throw new Error(videoErr.message)
+  if (videoErr) {
+    throw new UploadFailureError("storage-upload", videoErr.message)
+  }
 
   setStatus({
     kind: "working",
@@ -394,7 +716,7 @@ async function uploadVideo(ctx: UploadCtx): Promise<string> {
     })
   if (posterErr) {
     await supabase.storage.from("gallery").remove([videoPath])
-    throw new Error(posterErr.message)
+    throw new UploadFailureError("storage-upload", posterErr.message)
   }
 
   setStatus({
@@ -413,7 +735,15 @@ async function uploadVideo(ctx: UploadCtx): Promise<string> {
   })
   if (!result.ok) {
     await supabase.storage.from("gallery").remove([videoPath, posterPath])
-    throw new Error(result.error)
+    throw new UploadFailureError(
+      result.error.includes("Database insert failed")
+        ? "db-insert"
+        : result.error.includes("verify upload") ||
+            result.error.includes("File not found")
+          ? "storage-verify"
+          : "unknown",
+      result.error
+    )
   }
   return result.id
 }

--- a/apps/gallery/app/upload/_components/upload-manage-list.tsx
+++ b/apps/gallery/app/upload/_components/upload-manage-list.tsx
@@ -19,6 +19,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@workspace/ui/components/alert-dialog"
+import { Tabs, TabsList, TabsTrigger } from "@workspace/ui/components/tabs"
 import { cn } from "@workspace/ui/lib/utils"
 
 import {
@@ -287,6 +288,43 @@ export function UploadManageList({
     () => groupManageUploads(images),
     [images]
   )
+  const [sortMode, setSortMode] = useState<"date" | "name">("date")
+  const nameCollator = useMemo(
+    () => new Intl.Collator(undefined, { sensitivity: "base", numeric: true }),
+    []
+  )
+
+  const timeline = useMemo(() => {
+    const sequenceEntries = sequences.map((sequence) => {
+      const groupCreatedAt = sequence.items.reduce((max, item) => {
+        const t = new Date(item.created_at).getTime()
+        return t > max ? t : max
+      }, 0)
+      const sortName = sequence.items[0]?.name ?? ""
+
+      return {
+        kind: "sequence" as const,
+        sequence,
+        groupCreatedAt,
+        sortName,
+      }
+    })
+
+    const singleEntries = singles.map((row) => ({
+      kind: "single" as const,
+      row,
+      groupCreatedAt: new Date(row.created_at).getTime(),
+      sortName: row.name,
+    }))
+
+    return [...sequenceEntries, ...singleEntries].sort((a, b) => {
+      if (sortMode === "name") {
+        const byName = nameCollator.compare(a.sortName, b.sortName)
+        if (byName !== 0) return byName
+      }
+      return b.groupCreatedAt - a.groupCreatedAt
+    })
+  }, [nameCollator, singles, sequences, sortMode])
   const [selectionMode, setSelectionMode] = useState(false)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [confirmOpen, setConfirmOpen] = useState(false)
@@ -344,6 +382,18 @@ export function UploadManageList({
   return (
     <div className="flex flex-col gap-6">
       <div className="flex flex-wrap items-center gap-2">
+        <Tabs
+          value={sortMode}
+          onValueChange={(value) => {
+            if (value === "date" || value === "name") setSortMode(value)
+          }}
+          className="gap-0"
+        >
+          <TabsList>
+            <TabsTrigger value="date">Newest</TabsTrigger>
+            <TabsTrigger value="name">Name</TabsTrigger>
+          </TabsList>
+        </Tabs>
         <button
           type="button"
           onClick={toggleSelectionMode}
@@ -363,34 +413,39 @@ export function UploadManageList({
         ) : null}
       </div>
 
-      {sequences.map((sequence) => (
-        <UploadSequenceGroup
-          key={sequence.sequenceId}
-          sequenceId={sequence.sequenceId}
-          items={sequence.items}
-          allImages={images}
-          selectionMode={selectionMode}
-          selectedIds={selectedIds}
-          onToggleSelected={toggleSelected}
-          isAdmin={isAdmin}
-        />
-      ))}
-      {singles.length > 0 ? (
-        <ul className="flex flex-col gap-3">
-          {singles.map((image) => (
+      {timeline.map((entry) => {
+        if (entry.kind === "sequence") {
+          return (
+            <UploadSequenceGroup
+              key={entry.sequence.sequenceId}
+              sequenceId={entry.sequence.sequenceId}
+              items={entry.sequence.items}
+              allImages={images}
+              selectionMode={selectionMode}
+              selectedIds={selectedIds}
+              onToggleSelected={toggleSelected}
+              isAdmin={isAdmin}
+            />
+          )
+        }
+
+        return (
+          <ul
+            key={entry.row.id}
+            className="flex flex-col gap-3"
+          >
             <UploadListItem
-              key={image.id}
-              image={image}
+              image={entry.row}
               siblings={images}
-              selected={selectedIds.has(image.id)}
-              onToggleSelected={() => toggleSelected(image.id)}
+              selected={selectedIds.has(entry.row.id)}
+              onToggleSelected={() => toggleSelected(entry.row.id)}
               selectionMode={selectionMode}
               isAdmin={isAdmin}
               showWallPin
             />
-          ))}
-        </ul>
-      ) : null}
+          </ul>
+        )
+      })}
 
       <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <AlertDialogContent>

--- a/apps/gallery/app/upload/actions.ts
+++ b/apps/gallery/app/upload/actions.ts
@@ -71,10 +71,12 @@ export async function registerGalleryImage(
     expectedPaths.map((p) => p.slice(userId.length + 1))
   )
 
+  // Supabase Storage listing can be slightly delayed on mobile networks.
+  // Retry a bit longer to reduce intermittent "File not found" failures.
   let uploaded = false
-  for (let attempt = 0; attempt < 5 && !uploaded; attempt++) {
+  for (let attempt = 0; attempt < 9 && !uploaded; attempt++) {
     if (attempt > 0) {
-      await new Promise((r) => setTimeout(r, 120))
+      await new Promise((r) => setTimeout(r, 200))
     }
     const { data: files, error: listError } = await supabase.storage
       .from("gallery")
@@ -272,17 +274,73 @@ export async function renameGalleryImage(
   }
 
   const supabase = await createClient()
-  const { data, error } = await supabase
-    .from("gallery_images")
-    .update({ name: trimmed })
-    .eq("id", id)
-    .select("id")
+  const { data: claimsData } = await supabase.auth.getClaims()
+  const userId = claimsData?.claims?.sub
+  if (!userId) return { ok: false, error: "Not signed in." }
 
-  if (error) {
-    return { ok: false, error: `Rename failed: ${error.message}` }
+  const { data: currentRow, error: currentRowError } = await supabase
+    .from("gallery_images")
+    .select("id, sequence_id, sequence_index")
+    .eq("id", id)
+    .eq("created_by", userId)
+    .single()
+
+  if (currentRowError) {
+    return {
+      ok: false,
+      error: `Could not load this work: ${currentRowError.message}`,
+    }
   }
-  if (!data?.length) {
-    return { ok: false, error: "Could not update this work." }
+
+  // If renaming the cover shot of a burst sequence, apply the base name to
+  // the whole sequence so users see consistent names.
+  const shouldRenameSequence =
+    Boolean(currentRow?.sequence_id) && currentRow.sequence_index === 0
+
+  if (shouldRenameSequence) {
+    const sequenceId = currentRow.sequence_id as string
+
+    const { data: sequenceRows, error: seqLoadError } = await supabase
+      .from("gallery_images")
+      .select("id, sequence_index")
+      .eq("created_by", userId)
+      .eq("sequence_id", sequenceId)
+      .order("sequence_index", { ascending: true })
+
+    if (seqLoadError) {
+      return {
+        ok: false,
+        error: `Rename sequence failed: ${seqLoadError.message}`,
+      }
+    }
+
+    for (let idx = 0; idx < (sequenceRows ?? []).length; idx++) {
+      const row = sequenceRows[idx]!
+      const sequenceIndex =
+        typeof row.sequence_index === "number" ? row.sequence_index : idx
+      const nextName =
+        sequenceIndex === 0 ? trimmed : `${trimmed}${sequenceIndex}`
+
+      const { error: updateError } = await supabase
+        .from("gallery_images")
+        .update({ name: nextName })
+        .eq("id", row.id)
+        .eq("created_by", userId)
+
+      if (updateError) {
+        return { ok: false, error: `Rename failed: ${updateError.message}` }
+      }
+    }
+  } else {
+    const { error: updateError } = await supabase
+      .from("gallery_images")
+      .update({ name: trimmed })
+      .eq("id", id)
+      .eq("created_by", userId)
+
+    if (updateError) {
+      return { ok: false, error: `Rename failed: ${updateError.message}` }
+    }
   }
 
   revalidatePath("/")


### PR DESCRIPTION
Closes #307

## Summary
- Better mobile upload failure reporting (stage breakdown)
- Retry failed uploads while preserving burst sequence metadata
- Manage page: add sort toggle (Newest / Name)
- Lightbox realtime: debounce refresh to reduce UI jitter

## Test plan
- [x] un test in pps/gallery (116 pass)
- [x] un run build in pps/gallery
- [x] un run typecheck --filter=gallery

Made with [Cursor](https://cursor.com)